### PR TITLE
fix(runtime): make SIGINT/SIGTERM shutdown idempotent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -475,17 +475,33 @@ async function main(): Promise<void> {
   }
 
   // Graceful shutdown handlers
+  let shutdownInFlight = false;
   const shutdown = async (signal: string) => {
-    logger.info({ signal }, 'Shutdown signal received');
-    await queue.shutdown(10000);
-    if (webServer) {
-      await webServer.stop();
+    if (shutdownInFlight) {
+      logger.warn({ signal }, 'Shutdown already in progress, ignoring signal');
+      return;
     }
-    for (const ch of channels) await ch.disconnect();
-    process.exit(0);
+    shutdownInFlight = true;
+    logger.info({ signal }, 'Shutdown signal received');
+
+    try {
+      await queue.shutdown(10000);
+      if (webServer) {
+        await webServer.stop();
+      }
+      for (const ch of channels) await ch.disconnect();
+      process.exit(0);
+    } catch (err) {
+      logger.error({ err, signal }, 'Shutdown failed');
+      process.exit(1);
+    }
   };
-  process.on('SIGTERM', () => shutdown('SIGTERM'));
-  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.once('SIGTERM', () => {
+    void shutdown('SIGTERM');
+  });
+  process.once('SIGINT', () => {
+    void shutdown('SIGINT');
+  });
 
   // Channel callbacks (shared by all channels)
   const channelOpts = {


### PR DESCRIPTION
Summary
Fixes shutdown behavior where repeated Ctrl+C caused repeated shutdown logs and could leave the process hanging.

Problem
SIGINT/SIGTERM handlers were registered with process.on(...).
Multiple signals re-entered the async shutdown path.
Result: repeated "Shutdown signal received" logs and unstable exit behavior.
Changes
Switched signal handlers to one-shot registration:
process.once('SIGINT', ...)
process.once('SIGTERM', ...)
Added shutdownInFlight guard to prevent re-entrant shutdown execution.
Wrapped shutdown sequence in try/catch:
process.exit(0) on successful shutdown
process.exit(1) on shutdown failure with error logging
File changed
src/index.ts
Validation
npm run typecheck passed
Expected behavior after merge
A single Ctrl+C triggers one clean shutdown sequence.
Additional signals during shutdown are ignored with a clear warning log.