### PR TITLE
fix(policy): harden talk policy updates with shared limits contract + idempotent PUT

### DIFF
--- a/src/clawrocket/web/routes/talks.test.ts
+++ b/src/clawrocket/web/routes/talks.test.ts
@@ -327,6 +327,10 @@ describe('talk routes', () => {
     const viewerBody = (await viewerRes.json()) as any;
     expect(viewerBody.ok).toBe(true);
     expect(viewerBody.data.agents).toEqual(['Gemini', 'Opus4.6']);
+    expect(viewerBody.data.limits).toEqual({
+      maxAgents: 12,
+      maxAgentChars: 80,
+    });
 
     const outsiderRes = await server.request(
       '/api/v1/talks/talk-owner/policy',
@@ -362,6 +366,8 @@ describe('talk routes', () => {
     const editorBody = (await editorRes.json()) as any;
     expect(editorBody.ok).toBe(true);
     expect(editorBody.data.agents).toEqual(['Gemini', 'Opus4.6']);
+    expect(editorBody.data.limits.maxAgents).toBe(12);
+    expect(editorBody.data.limits.maxAgentChars).toBe(80);
 
     const readBackRes = await server.request(
       '/api/v1/talks/talk-owner/policy',
@@ -413,6 +419,36 @@ describe('talk routes', () => {
       (row: any) => row.id === 'talk-owner',
     );
     expect(talk.agents).toEqual(['Mock']);
+  });
+
+  it('replays idempotent policy updates', async () => {
+    const first = await server.request('/api/v1/talks/talk-owner/policy', {
+      method: 'PUT',
+      headers: {
+        Authorization: 'Bearer owner-token',
+        'Content-Type': 'application/json',
+        'Idempotency-Key': 'idem-policy-1',
+      },
+      body: JSON.stringify({ agents: ['Gemini', 'Opus4.6'] }),
+    });
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as any;
+    expect(firstBody.ok).toBe(true);
+    expect(firstBody.data.agents).toEqual(['Gemini', 'Opus4.6']);
+
+    const replay = await server.request('/api/v1/talks/talk-owner/policy', {
+      method: 'PUT',
+      headers: {
+        Authorization: 'Bearer owner-token',
+        'Content-Type': 'application/json',
+        'Idempotency-Key': 'idem-policy-1',
+      },
+      body: JSON.stringify({ agents: ['Gemini', 'Opus4.6'] }),
+    });
+    expect(replay.status).toBe(200);
+    expect(replay.headers.get('x-idempotent-replay')).toBe('true');
+    const replayBody = (await replay.json()) as any;
+    expect(replayBody.data.agents).toEqual(['Gemini', 'Opus4.6']);
   });
 
   it('enqueues chat runs and persists user messages', async () => {

--- a/src/clawrocket/web/routes/talks.ts
+++ b/src/clawrocket/web/routes/talks.ts
@@ -43,6 +43,10 @@ const DEFAULT_TALK_AGENTS = ['Mock'];
 const MAX_TALK_AGENT_BADGES = 6;
 const MAX_POLICY_AGENTS = 12;
 const MAX_POLICY_AGENT_LABEL_CHARS = 80;
+const TALK_POLICY_LIMITS = {
+  maxAgents: MAX_POLICY_AGENTS,
+  maxAgentChars: MAX_POLICY_AGENT_LABEL_CHARS,
+} as const;
 
 function toTalkApiRecord(talk: TalkWithAccessRecord): TalkApiRecord {
   return {
@@ -302,7 +306,11 @@ export function getTalkPolicyRoute(input: {
   auth: AuthContext;
 }): {
   statusCode: number;
-  body: ApiEnvelope<{ talkId: string; agents: string[] }>;
+  body: ApiEnvelope<{
+    talkId: string;
+    agents: string[];
+    limits: { maxAgents: number; maxAgentChars: number };
+  }>;
 } {
   const talk = getTalkForUser(input.talkId, input.auth.userId);
   if (!talk) {
@@ -325,6 +333,7 @@ export function getTalkPolicyRoute(input: {
       data: {
         talkId: input.talkId,
         agents: parseTalkPolicyAgents(talk.llm_policy),
+        limits: TALK_POLICY_LIMITS,
       },
     },
   };
@@ -336,7 +345,11 @@ export function updateTalkPolicyRoute(input: {
   agents: unknown;
 }): {
   statusCode: number;
-  body: ApiEnvelope<{ talkId: string; agents: string[] }>;
+  body: ApiEnvelope<{
+    talkId: string;
+    agents: string[];
+    limits: { maxAgents: number; maxAgentChars: number };
+  }>;
 } {
   const talk = getTalkForUser(input.talkId, input.auth.userId);
   if (!talk) {
@@ -395,6 +408,7 @@ export function updateTalkPolicyRoute(input: {
       data: {
         talkId: input.talkId,
         agents: normalized.agents,
+        limits: TALK_POLICY_LIMITS,
       },
     },
   };

--- a/src/clawrocket/web/server.ts
+++ b/src/clawrocket/web/server.ts
@@ -726,6 +726,38 @@ function buildApp(opts: WebServerOptions): Hono {
       );
     }
 
+    const bodyText = await c.req.text();
+    const idempotencyKey = c.req.header('idempotency-key') || null;
+    const precheck = idempotencyPrecheck({
+      userId: auth.userId,
+      idempotencyKey,
+      method: c.req.method,
+      path: c.req.path,
+      bodyText,
+    });
+    if (precheck.error) {
+      return c.json(
+        {
+          ok: false,
+          error: {
+            code: 'idempotency_error',
+            message: precheck.error,
+          },
+        },
+        400,
+      );
+    }
+
+    if (precheck.replay && precheck.response) {
+      return new Response(precheck.response.responseBody, {
+        status: precheck.response.statusCode,
+        headers: {
+          'content-type': 'application/json; charset=utf-8',
+          'x-idempotent-replay': 'true',
+        },
+      });
+    }
+
     const encodedTalkId = c.req.param('talkId');
     const talkId = safeDecodePathSegment(encodedTalkId);
     if (!talkId) {
@@ -741,7 +773,6 @@ function buildApp(opts: WebServerOptions): Hono {
       );
     }
 
-    const bodyText = await c.req.text();
     const payload = parseJsonPayload<{ agents?: unknown }>(bodyText);
     if (!payload.ok) {
       return c.json(
@@ -761,7 +792,18 @@ function buildApp(opts: WebServerOptions): Hono {
       auth,
       agents: payload.data.agents,
     });
-    return new Response(JSON.stringify(result.body), {
+    const serialized = JSON.stringify(result.body);
+    saveIdempotencyResult({
+      userId: auth.userId,
+      idempotencyKey,
+      method: c.req.method,
+      path: c.req.path,
+      requestHash: precheck.requestHash,
+      statusCode: result.statusCode,
+      responseBody: serialized,
+    });
+
+    return new Response(serialized, {
       status: result.statusCode,
       headers: { 'content-type': 'application/json; charset=utf-8' },
     });

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -55,6 +55,10 @@ export type TalkRun = {
 export type TalkPolicy = {
   talkId: string;
   agents: string[];
+  limits: {
+    maxAgents: number;
+    maxAgentChars: number;
+  };
 };
 
 type ApiEnvelope<T> =

--- a/webapp/src/pages/TalkDetailPage.tsx
+++ b/webapp/src/pages/TalkDetailPage.tsx
@@ -335,11 +335,9 @@ function detailReducer(state: DetailState, action: DetailAction): DetailState {
 
 const SCROLL_STICK_THRESHOLD_PX = 120;
 const TALK_MESSAGE_MAX_CHARS = 20_000;
-const TALK_POLICY_MAX_AGENTS = 12;
-const TALK_POLICY_MAX_AGENT_CHARS = 80;
-
 function normalizePolicyDraft(
   draft: string,
+  limits: { maxAgents: number; maxAgentChars: number } | null,
 ): { agents?: string[]; error?: string } {
   const normalized = [
     ...new Set(
@@ -350,14 +348,18 @@ function normalizePolicyDraft(
     ),
   ];
 
-  if (normalized.some((agent) => agent.length > TALK_POLICY_MAX_AGENT_CHARS)) {
+  if (!limits) {
+    return { agents: normalized };
+  }
+
+  if (normalized.some((agent) => agent.length > limits.maxAgentChars)) {
     return {
-      error: `Each agent label must be ${TALK_POLICY_MAX_AGENT_CHARS} characters or less.`,
+      error: `Each agent label must be ${limits.maxAgentChars} characters or less.`,
     };
   }
-  if (normalized.length > TALK_POLICY_MAX_AGENTS) {
+  if (normalized.length > limits.maxAgents) {
     return {
-      error: `At most ${TALK_POLICY_MAX_AGENTS} agents are allowed.`,
+      error: `At most ${limits.maxAgents} agents are allowed.`,
     };
   }
 
@@ -374,6 +376,10 @@ export function TalkDetailPage({
   const [draft, setDraft] = useState('');
   const [policyDraft, setPolicyDraft] = useState('');
   const [policyAgents, setPolicyAgents] = useState<string[]>([]);
+  const [policyLimits, setPolicyLimits] = useState<{
+    maxAgents: number;
+    maxAgentChars: number;
+  } | null>(null);
   const [policyState, setPolicyState] = useState<{
     status: 'idle' | 'saving' | 'error' | 'success';
     message?: string;
@@ -534,6 +540,7 @@ export function TalkDetailPage({
     dispatch({ type: 'BOOTSTRAP_LOADING' });
     setPolicyAgents([]);
     setPolicyDraft('');
+    setPolicyLimits(null);
     setPolicyState({ status: 'idle' });
 
     const load = async () => {
@@ -546,6 +553,7 @@ export function TalkDetailPage({
         if (!cancelled) {
           setPolicyAgents(policy.agents);
           setPolicyDraft(policy.agents.join(', '));
+          setPolicyLimits(policy.limits);
           setPolicyState({ status: 'idle' });
           dispatch({ type: 'BOOTSTRAP_READY', talk, messages });
         }
@@ -742,7 +750,7 @@ export function TalkDetailPage({
     if (state.kind !== 'ready') return;
     if (!canEditPolicy) return;
 
-    const normalized = normalizePolicyDraft(policyDraft);
+    const normalized = normalizePolicyDraft(policyDraft, policyLimits);
     if (!normalized.agents) {
       setPolicyState({ status: 'error', message: normalized.error });
       return;


### PR DESCRIPTION
Summary
This PR addresses the follow-up hardening items from policy editor review:

Uses a single backend-authored limits contract for talk policy validation.
Adds idempotency support to PUT /api/v1/talks/:talkId/policy.
Keeps existing product behavior/scope unchanged.
Changes
Backend policy routes now return limits metadata with policy payloads:
GET /api/v1/talks/:talkId/policy
PUT /api/v1/talks/:talkId/policy
Added limits: { maxAgents, maxAgentChars }
Added idempotency handling to PUT /api/v1/talks/:talkId/policy:
precheck on Idempotency-Key
replay returns stored response + x-idempotent-replay: true
mismatch returns 400 idempotency_error
Frontend now consumes backend policy limits (instead of duplicated local constants) in the policy editor validation path.
Why
Prevent drift between backend and frontend policy constraints.
Align policy writes with idempotency guarantees used in other mutation routes.
Keep behavior predictable under retries/repeated requests.