### PR TITLE
fix(skills-engine): restore run-migrations test reliability by avoiding nested tsx cli

### DIFF
--- a/scripts/run-migrations.ts
+++ b/scripts/run-migrations.ts
@@ -1,24 +1,10 @@
 #!/usr/bin/env tsx
-import { execFileSync, execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 import { compareSemver } from '../skills-engine/state.js';
-
-// Resolve tsx binary once to avoid npx race conditions across migrations
-function resolveTsx(): string {
-  // Check local node_modules first
-  const local = path.resolve('node_modules/.bin/tsx');
-  if (fs.existsSync(local)) return local;
-  // Fall back to whichever tsx is in PATH
-  try {
-    return execSync('which tsx', { encoding: 'utf-8' }).trim();
-  } catch {
-    return 'npx'; // last resort
-  }
-}
-
-const tsxBin = resolveTsx();
 
 const fromVersion = process.argv[2];
 const toVersion = process.argv[3];
@@ -35,6 +21,21 @@ interface MigrationResult {
   version: string;
   success: boolean;
   error?: string;
+}
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..');
+const tsxLoaderPath = path.join(
+  repoRoot,
+  'node_modules',
+  'tsx',
+  'dist',
+  'loader.mjs',
+);
+
+if (!fs.existsSync(tsxLoaderPath)) {
+  console.error(`tsx loader not found at ${tsxLoaderPath}. Run npm install.`);
+  process.exit(1);
 }
 
 const results: MigrationResult[] = [];
@@ -72,14 +73,15 @@ for (const version of migrationVersions) {
   }
 
   try {
-    const tsxArgs = tsxBin.endsWith('npx')
-      ? ['tsx', migrationIndex, projectRoot]
-      : [migrationIndex, projectRoot];
-    execFileSync(tsxBin, tsxArgs, {
-      stdio: 'pipe',
-      cwd: projectRoot,
-      timeout: 120_000,
-    });
+    execFileSync(
+      process.execPath,
+      ['--import', tsxLoaderPath, migrationIndex, projectRoot],
+      {
+        stdio: 'pipe',
+        cwd: projectRoot,
+        timeout: 120_000,
+      },
+    );
     results.push({ version, success: true });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/skills-engine/__tests__/run-migrations.test.ts
+++ b/skills-engine/__tests__/run-migrations.test.ts
@@ -9,7 +9,7 @@ describe('run-migrations', () => {
   let tmpDir: string;
   let newCoreDir: string;
   const scriptPath = path.resolve('scripts/run-migrations.ts');
-  const tsxBin = path.resolve('node_modules/.bin/tsx');
+  const tsxLoaderPath = path.resolve('node_modules/tsx/dist/loader.mjs');
 
   beforeEach(() => {
     tmpDir = createTempDir();
@@ -32,12 +32,16 @@ describe('run-migrations', () => {
     to: string,
   ): { stdout: string; exitCode: number } {
     try {
-      const stdout = execFileSync(tsxBin, [scriptPath, from, to, newCoreDir], {
-        cwd: tmpDir,
-        encoding: 'utf-8',
-        stdio: 'pipe',
-        timeout: 30_000,
-      });
+      const stdout = execFileSync(
+        process.execPath,
+        ['--import', tsxLoaderPath, scriptPath, from, to, newCoreDir],
+        {
+          cwd: tmpDir,
+          encoding: 'utf-8',
+          stdio: 'pipe',
+          timeout: 30_000,
+        },
+      );
       return { stdout, exitCode: 0 };
     } catch (err: any) {
       return { stdout: err.stdout ?? '', exitCode: err.status ?? 1 };


### PR DESCRIPTION
Summary
Fixes the previously failing skills-engine/run-migrations test suite by removing nested tsx CLI execution from the migration runner path.

Root Cause
run-migrations was spawning tsx from a process already running under tsx. In this environment that nested invocation failed with an IPC socket permission error (EPERM), producing empty stdout and causing JSON parse failures in tests.

Changes
Updated migration execution in:
[scripts/run-migrations.ts](app://-/index.html?hostId=local#)
Replaced nested tsx CLI execution with:
node --import node_modules/tsx/dist/loader.mjs <migration> <projectRoot>
Added loader-path preflight check with explicit error message if missing.
Updated test harness in:
[skills-engine/tests/run-migrations.test.ts](app://-/index.html?hostId=local#)
Test runner now invokes run-migrations.ts via node --import <tsx loader> for parity with runtime behavior.
Result
run-migrations tests now emit valid JSON output consistently.
Full test suite is green again.
Validation
npm test -- skills-engine/__tests__/run-migrations.test.ts ✅
npm test ✅
npm run typecheck ✅
npm run build ✅
npm run format:check ✅