### PR TITLE
feat(webapp): show effective agent badges in talk detail header

### DIFF
--- a/webapp/src/pages/TalkDetailPage.test.tsx
+++ b/webapp/src/pages/TalkDetailPage.test.tsx
@@ -4,6 +4,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -65,6 +66,7 @@ describe('TalkDetailPage', () => {
         data: {
           talkId: 'talk-1',
           agents: ['Gemini'],
+          limits: { maxAgents: 12, maxAgentChars: 80 },
         },
       }),
     ]);
@@ -98,6 +100,7 @@ describe('TalkDetailPage', () => {
         data: {
           talkId: 'talk-1',
           agents: ['Gemini'],
+          limits: { maxAgents: 12, maxAgentChars: 80 },
         },
       }),
     ]);
@@ -106,6 +109,46 @@ describe('TalkDetailPage', () => {
     await screen.findByRole('heading', { name: /Smoke Talk/i });
     expect(screen.getByRole('button', { name: 'Cancel Runs' })).toBeTruthy();
     expect(screen.getByLabelText('Comma-separated agents')).toBeTruthy();
+  });
+
+  it('renders effective agent badges from talk payload', async () => {
+    mockFetch([
+      jsonResponse(200, {
+        ok: true,
+        data: {
+          talk: buildTalk({
+            accessRole: 'owner',
+            agents: ['Gemini', 'Opus4.6', 'Haiku'],
+          }),
+        },
+      }),
+      jsonResponse(200, {
+        ok: true,
+        data: {
+          talkId: 'talk-1',
+          messages: [],
+          page: { limit: 100, count: 0, beforeCreatedAt: null },
+        },
+      }),
+      jsonResponse(200, {
+        ok: true,
+        data: {
+          talkId: 'talk-1',
+          agents: ['Gemini'],
+          limits: { maxAgents: 12, maxAgentChars: 80 },
+        },
+      }),
+    ]);
+
+    renderDetailPage();
+    await screen.findByRole('heading', { name: /Smoke Talk/i });
+
+    const effectiveAgents = screen.getByRole('list', {
+      name: 'Effective agents',
+    });
+    expect(within(effectiveAgents).getByText('Gemini')).toBeTruthy();
+    expect(within(effectiveAgents).getByText('Opus4.6')).toBeTruthy();
+    expect(within(effectiveAgents).getByText('Haiku')).toBeTruthy();
   });
 
   it('updates talk policy from detail editor', async () => {
@@ -129,6 +172,7 @@ describe('TalkDetailPage', () => {
         data: {
           talkId: 'talk-1',
           agents: ['Gemini', 'Opus4.6'],
+          limits: { maxAgents: 12, maxAgentChars: 80 },
         },
       }),
       jsonResponse(200, {
@@ -136,6 +180,7 @@ describe('TalkDetailPage', () => {
         data: {
           talkId: 'talk-1',
           agents: ['Gemini', 'Opus4.6'],
+          limits: { maxAgents: 12, maxAgentChars: 80 },
         },
       }),
     ]);
@@ -149,8 +194,9 @@ describe('TalkDetailPage', () => {
     await user.click(screen.getByRole('button', { name: 'Save Agents' }));
 
     await screen.findByText('Talk policy updated.');
-    expect(screen.getByText('Gemini')).toBeTruthy();
-    expect(screen.getByText('Opus4.6')).toBeTruthy();
+    const policyPanel = screen.getByLabelText('Talk policy');
+    expect(within(policyPanel).getByText('Gemini')).toBeTruthy();
+    expect(within(policyPanel).getByText('Opus4.6')).toBeTruthy();
   });
 
   it('shows send and cancel inline error states and clears send error on typing', async () => {
@@ -174,6 +220,7 @@ describe('TalkDetailPage', () => {
         data: {
           talkId: 'talk-1',
           agents: ['Gemini'],
+          limits: { maxAgents: 12, maxAgentChars: 80 },
         },
       }),
       jsonResponse(500, {
@@ -234,6 +281,7 @@ describe('TalkDetailPage', () => {
         data: {
           talkId: 'talk-1',
           agents: ['Gemini'],
+          limits: { maxAgents: 12, maxAgentChars: 80 },
         },
       }),
       jsonResponse(200, {
@@ -332,6 +380,7 @@ describe('TalkDetailPage', () => {
         data: {
           talkId: 'talk-1',
           agents: ['Gemini'],
+          limits: { maxAgents: 12, maxAgentChars: 80 },
         },
       }),
     ]);

--- a/webapp/src/pages/TalkDetailPage.tsx
+++ b/webapp/src/pages/TalkDetailPage.tsx
@@ -838,6 +838,19 @@ export function TalkDetailPage({
             </span>
           </h1>
           <p>Event-authoritative live timeline.</p>
+          {talk.agents.length > 0 ? (
+            <div
+              className="talk-agent-row talk-agent-row-detail"
+              role="list"
+              aria-label="Effective agents"
+            >
+              {talk.agents.map((agent) => (
+                <span key={agent} className="talk-agent-chip" role="listitem">
+                  {agent}
+                </span>
+              ))}
+            </div>
+          ) : null}
         </div>
         <Link to="/app/talks">Back</Link>
       </header>

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -246,6 +246,10 @@ a {
   gap: 0.35rem;
 }
 
+.talk-agent-row-detail {
+  margin-top: 0.45rem;
+}
+
 .talk-agent-chip {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Summary
Adds the same agent visibility to Talk Detail that already exists in Talk List, so users can immediately see which agents are associated with the active talk.

Changes
Render effective agent badges in the Talk Detail header using talk.agents.
Keep existing policy editor behavior unchanged (this is display-only for effective agents).
Add dedicated test coverage for header badge rendering.
Update a policy editor assertion to scope queries to the policy panel (avoids ambiguity now that badges appear in two places).
Add small spacing style for the new detail-header badge row.
Files
[webapp/src/pages/TalkDetailPage.tsx](app://-/index.html?hostId=local#)
[webapp/src/pages/TalkDetailPage.test.tsx](app://-/index.html?hostId=local#)
[webapp/src/styles.css](app://-/index.html?hostId=local#)
Validation
npm run test:web ✅
npm --prefix webapp run typecheck ✅
npm run build:web ✅
npm run typecheck ✅
npm run format:check ✅