### PR TITLE
feat(talks): real talk executor with persisted sessions, strict alias mapping, and web-safe tool profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,10 @@
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_BOT_POOL=
+
+# --- ClawRocket web talks real executor ---
+# Enable real executor auto-selection by providing both:
+# 1) provider auth (either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN)
+# 2) a valid alias-map JSON object below
+TALK_EXECUTOR_DEFAULT_ALIAS=Mock
+TALK_EXECUTOR_ALIAS_MODEL_MAP_JSON={"Gemini":"default","Opus4.6":"default","Haiku":"default","GPT-4o":"default","Opus":"default"}
+TALK_EXECUTOR_WEB_GROUP_FOLDER=web-talks

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -22,6 +22,8 @@ import { fileURLToPath } from 'url';
 interface ContainerInput {
   prompt: string;
   sessionId?: string;
+  model?: string;
+  toolProfile?: 'default' | 'web_talk';
   groupFolder: string;
   chatJid: string;
   isMain: boolean;
@@ -414,10 +416,18 @@ async function runQuery(
     log(`Additional directories: ${extraDirs.join(', ')}`);
   }
 
+  const toolProfile = containerInput.toolProfile || 'default';
+  const useWebTalkProfile = toolProfile === 'web_talk';
+  const selectedModel =
+    containerInput.model && containerInput.model !== 'default'
+      ? containerInput.model
+      : undefined;
+
   for await (const message of query({
     prompt: stream,
     options: {
       cwd: '/workspace/group',
+      model: selectedModel,
       additionalDirectories: extraDirs.length > 0 ? extraDirs : undefined,
       resume: sessionId,
       resumeSessionAt: resumeAt,
@@ -432,23 +442,27 @@ async function runQuery(
         'TeamCreate', 'TeamDelete', 'SendMessage',
         'TodoWrite', 'ToolSearch', 'Skill',
         'NotebookEdit',
-        'mcp__nanoclaw__*'
+        ...(useWebTalkProfile ? [] : ['mcp__nanoclaw__*'])
       ],
       env: sdkEnv,
       permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: true,
       settingSources: ['project', 'user'],
-      mcpServers: {
-        nanoclaw: {
-          command: 'node',
-          args: [mcpServerPath],
-          env: {
-            NANOCLAW_CHAT_JID: containerInput.chatJid,
-            NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
-            NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
-          },
-        },
-      },
+      ...(useWebTalkProfile
+        ? {}
+        : {
+            mcpServers: {
+              nanoclaw: {
+                command: 'node',
+                args: [mcpServerPath],
+                env: {
+                  NANOCLAW_CHAT_JID: containerInput.chatJid,
+                  NANOCLAW_GROUP_FOLDER: containerInput.groupFolder,
+                  NANOCLAW_IS_MAIN: containerInput.isMain ? '1' : '0',
+                },
+              },
+            },
+          }),
       hooks: {
         PreCompact: [{ hooks: [createPreCompactHook(containerInput.assistantName)] }],
         PreToolUse: [{ matcher: 'Bash', hooks: [createSanitizeBashHook()] }],

--- a/docs/UPSTREAM-SYNC-LOG.md
+++ b/docs/UPSTREAM-SYNC-LOG.md
@@ -9,6 +9,19 @@
 
 ## Sync Entries
 
+### 2026-03-05 - Phase 1.9 Step F Real Talk Executor Rollout Notes
+
+- Added stateful real talk executor path with per-talk persisted session metadata.
+- Runtime selection is automatic in `src/clawrocket/web/index.ts`:
+  - Real executor is enabled only when:
+    - provider auth is present (`ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`)
+    - and `TALK_EXECUTOR_ALIAS_MODEL_MAP_JSON` is present and valid JSON object.
+  - Otherwise runtime falls back to `MockTalkExecutor`.
+- Added compatibility seed alias map in runtime defaults to prevent day-one failures:
+  - `Mock`, `Gemini`, `Opus4.6`, `Haiku`, `GPT-4o`, `Opus` -> `default`.
+- Rollback toggle:
+  - Remove/empty `TALK_EXECUTOR_ALIAS_MODEL_MAP_JSON` to force mock mode without code changes.
+
 ### 2026-03-04 - Cutover Mechanics Execution (Maintainer Clone)
 
 - Repository: `jokim1/clawrocket`

--- a/src/clawrocket/config.ts
+++ b/src/clawrocket/config.ts
@@ -15,6 +15,11 @@ const envConfig = readEnvFile([
   'TALK_RUN_POLL_MS',
   'TALK_RUN_MAX_CONCURRENCY',
   'TALK_MOCK_EXECUTION_MS',
+  'TALK_EXECUTOR_DEFAULT_ALIAS',
+  'TALK_EXECUTOR_ALIAS_MODEL_MAP_JSON',
+  'TALK_EXECUTOR_WEB_GROUP_FOLDER',
+  'ANTHROPIC_API_KEY',
+  'CLAUDE_CODE_OAUTH_TOKEN',
 ]);
 
 export const WEB_ENABLED =
@@ -83,3 +88,29 @@ const talkMockExecutionMs = parseInt(
 export const TALK_MOCK_EXECUTION_MS = Number.isFinite(talkMockExecutionMs)
   ? Math.max(0, talkMockExecutionMs)
   : 300;
+
+export const TALK_EXECUTOR_DEFAULT_ALIAS =
+  process.env.TALK_EXECUTOR_DEFAULT_ALIAS ||
+  envConfig.TALK_EXECUTOR_DEFAULT_ALIAS ||
+  'Mock';
+
+export const TALK_EXECUTOR_ALIAS_MODEL_MAP_JSON =
+  process.env.TALK_EXECUTOR_ALIAS_MODEL_MAP_JSON ||
+  envConfig.TALK_EXECUTOR_ALIAS_MODEL_MAP_JSON ||
+  '';
+
+export const TALK_EXECUTOR_WEB_GROUP_FOLDER =
+  process.env.TALK_EXECUTOR_WEB_GROUP_FOLDER ||
+  envConfig.TALK_EXECUTOR_WEB_GROUP_FOLDER ||
+  'web-talks';
+
+const TALK_EXECUTOR_ANTHROPIC_API_KEY =
+  process.env.ANTHROPIC_API_KEY || envConfig.ANTHROPIC_API_KEY || '';
+const TALK_EXECUTOR_CLAUDE_OAUTH_TOKEN =
+  process.env.CLAUDE_CODE_OAUTH_TOKEN ||
+  envConfig.CLAUDE_CODE_OAUTH_TOKEN ||
+  '';
+
+export const TALK_EXECUTOR_HAS_PROVIDER_AUTH =
+  TALK_EXECUTOR_ANTHROPIC_API_KEY.length > 0 ||
+  TALK_EXECUTOR_CLAUDE_OAUTH_TOKEN.length > 0;

--- a/src/clawrocket/db/accessors.ts
+++ b/src/clawrocket/db/accessors.ts
@@ -451,6 +451,14 @@ export interface TalkWithAccessRecord extends TalkRecord {
   llm_policy: string | null;
 }
 
+export interface TalkExecutorSessionRecord {
+  talk_id: string;
+  session_id: string;
+  executor_alias: string;
+  executor_model: string;
+  updated_at: string;
+}
+
 export interface TalkListPage {
   limit: number;
   offset: number;
@@ -708,6 +716,70 @@ export function deleteTalkLlmPolicy(talkId: string): void {
     .run(talkId);
 }
 
+export function getTalkLlmPolicyByTalkId(talkId: string): string | null {
+  const row = getDb()
+    .prepare(
+      `
+      SELECT llm_policy
+      FROM talk_llm_policies
+      WHERE talk_id = ?
+      LIMIT 1
+    `,
+    )
+    .get(talkId) as { llm_policy: string } | undefined;
+  return row?.llm_policy || null;
+}
+
+export function getTalkExecutorSession(
+  talkId: string,
+): TalkExecutorSessionRecord | undefined {
+  return getDb()
+    .prepare(
+      `
+      SELECT talk_id, session_id, executor_alias, executor_model, updated_at
+      FROM talk_executor_sessions
+      WHERE talk_id = ?
+      LIMIT 1
+    `,
+    )
+    .get(talkId) as TalkExecutorSessionRecord | undefined;
+}
+
+export function upsertTalkExecutorSession(input: {
+  talkId: string;
+  sessionId: string;
+  executorAlias: string;
+  executorModel: string;
+  updatedAt?: string;
+}): void {
+  getDb()
+    .prepare(
+      `
+      INSERT INTO talk_executor_sessions (
+        talk_id, session_id, executor_alias, executor_model, updated_at
+      ) VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(talk_id) DO UPDATE SET
+        session_id = excluded.session_id,
+        executor_alias = excluded.executor_alias,
+        executor_model = excluded.executor_model,
+        updated_at = excluded.updated_at
+    `,
+    )
+    .run(
+      input.talkId,
+      input.sessionId,
+      input.executorAlias,
+      input.executorModel,
+      input.updatedAt || new Date().toISOString(),
+    );
+}
+
+export function deleteTalkExecutorSession(talkId: string): void {
+  getDb()
+    .prepare('DELETE FROM talk_executor_sessions WHERE talk_id = ?')
+    .run(talkId);
+}
+
 export function canUserAccessTalk(talkId: string, userId: string): boolean {
   const owned = getDb()
     .prepare('SELECT 1 AS ok FROM talks WHERE id = ? AND owner_id = ?')
@@ -928,6 +1000,8 @@ export function enqueueTalkTurnAtomic(input: {
         status,
         trigger_message_id: txInput.messageId,
         idempotency_key: txInput.idempotencyKey || null,
+        executor_alias: null,
+        executor_model: null,
         created_at: now,
         started_at: status === 'running' ? now : null,
         ended_at: null,
@@ -1197,6 +1271,8 @@ export interface TalkRunRecord {
   status: TalkRunStatus;
   trigger_message_id: string | null;
   idempotency_key: string | null;
+  executor_alias: string | null;
+  executor_model: string | null;
   created_at: string;
   started_at: string | null;
   ended_at: string | null;
@@ -1209,9 +1285,10 @@ export function createTalkRun(input: TalkRunRecord): void {
       `
     INSERT INTO talk_runs (
       id, talk_id, requested_by, status, trigger_message_id, idempotency_key,
+      executor_alias, executor_model,
       created_at, started_at, ended_at, cancel_reason
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `,
     )
     .run(
@@ -1221,11 +1298,29 @@ export function createTalkRun(input: TalkRunRecord): void {
       input.status,
       input.trigger_message_id,
       input.idempotency_key,
+      input.executor_alias,
+      input.executor_model,
       input.created_at,
       input.started_at,
       input.ended_at,
       input.cancel_reason,
     );
+}
+
+export function setTalkRunExecutorProfile(input: {
+  runId: string;
+  executorAlias: string;
+  executorModel: string;
+}): void {
+  getDb()
+    .prepare(
+      `
+      UPDATE talk_runs
+      SET executor_alias = ?, executor_model = ?
+      WHERE id = ?
+    `,
+    )
+    .run(input.executorAlias, input.executorModel, input.runId);
 }
 
 export function getTalkRunById(runId: string): TalkRunRecord | null {

--- a/src/clawrocket/db/init.ts
+++ b/src/clawrocket/db/init.ts
@@ -140,6 +140,8 @@ function createClawrocketSchema(database: Database.Database): void {
         CHECK(status IN ('queued', 'running', 'cancelled', 'completed', 'failed')),
       trigger_message_id TEXT REFERENCES talk_messages(id) ON DELETE SET NULL,
       idempotency_key TEXT,
+      executor_alias TEXT,
+      executor_model TEXT,
       created_at TEXT NOT NULL,
       started_at TEXT,
       ended_at TEXT,
@@ -167,6 +169,14 @@ function createClawrocketSchema(database: Database.Database): void {
     CREATE TABLE IF NOT EXISTS talk_llm_policies (
       talk_id TEXT PRIMARY KEY REFERENCES talks(id) ON DELETE CASCADE,
       llm_policy TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS talk_executor_sessions (
+      talk_id TEXT PRIMARY KEY REFERENCES talks(id) ON DELETE CASCADE,
+      session_id TEXT NOT NULL,
+      executor_alias TEXT NOT NULL,
+      executor_model TEXT NOT NULL,
       updated_at TEXT NOT NULL
     );
   `);
@@ -208,6 +218,20 @@ function createClawrocketSchema(database: Database.Database): void {
   // Add trigger_message_id column if it doesn't exist (migration for existing DBs)
   try {
     database.exec(`ALTER TABLE talk_runs ADD COLUMN trigger_message_id TEXT`);
+  } catch {
+    /* column already exists */
+  }
+
+  // Add executor_alias column if it doesn't exist (migration for existing DBs)
+  try {
+    database.exec(`ALTER TABLE talk_runs ADD COLUMN executor_alias TEXT`);
+  } catch {
+    /* column already exists */
+  }
+
+  // Add executor_model column if it doesn't exist (migration for existing DBs)
+  try {
+    database.exec(`ALTER TABLE talk_runs ADD COLUMN executor_model TEXT`);
   } catch {
     /* column already exists */
   }

--- a/src/clawrocket/talks/executor.ts
+++ b/src/clawrocket/talks/executor.ts
@@ -10,6 +10,22 @@ export interface TalkExecutorOutput {
   content: string;
 }
 
+export class TalkExecutorError extends Error {
+  readonly code: string;
+  readonly sourceMessage: string;
+
+  constructor(
+    code: string,
+    message: string,
+    options?: { sourceMessage?: string },
+  ) {
+    super(message);
+    this.code = code;
+    this.sourceMessage = options?.sourceMessage || message;
+    this.name = 'TalkExecutorError';
+  }
+}
+
 export interface TalkExecutor {
   execute(
     input: TalkExecutorInput,

--- a/src/clawrocket/talks/policy.ts
+++ b/src/clawrocket/talks/policy.ts
@@ -1,0 +1,54 @@
+export const TALK_POLICY_MAX_AGENTS = 12;
+
+function parsePolicyAgentCandidates(
+  rawPolicy: string,
+  maxItems: number,
+): string[] {
+  let candidates: unknown[] = [];
+  try {
+    const parsed = JSON.parse(rawPolicy) as unknown;
+    if (Array.isArray(parsed)) {
+      candidates = parsed;
+    } else if (parsed && typeof parsed === 'object') {
+      const asRecord = parsed as Record<string, unknown>;
+      if (Array.isArray(asRecord.agents)) {
+        candidates = asRecord.agents;
+      } else if (Array.isArray(asRecord.models)) {
+        candidates = asRecord.models;
+      } else {
+        candidates = [asRecord.agent, asRecord.model];
+      }
+    } else if (typeof parsed === 'string') {
+      candidates = [parsed];
+    }
+  } catch {
+    candidates = rawPolicy.split(/[|,]/);
+  }
+
+  return [
+    ...new Set(
+      candidates
+        .map((candidate) =>
+          typeof candidate === 'string' ? candidate.trim() : '',
+        )
+        .filter(Boolean),
+    ),
+  ].slice(0, maxItems);
+}
+
+export function parsePolicyAgentsForExecution(
+  llmPolicy: string | null,
+): string[] {
+  const raw = llmPolicy?.trim();
+  if (!raw) return [];
+  return parsePolicyAgentCandidates(raw, TALK_POLICY_MAX_AGENTS);
+}
+
+export function parsePolicyAgentsForUiBadges(
+  llmPolicy: string | null,
+  maxBadges: number,
+): string[] {
+  const raw = llmPolicy?.trim();
+  if (!raw) return [];
+  return parsePolicyAgentCandidates(raw, maxBadges);
+}

--- a/src/clawrocket/talks/real-executor.test.ts
+++ b/src/clawrocket/talks/real-executor.test.ts
@@ -1,0 +1,360 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  _initTestDatabase,
+  createTalk,
+  createTalkRun,
+  getTalkExecutorSession,
+  getTalkRunById,
+  upsertTalkExecutorSession,
+  upsertTalkLlmPolicy,
+  upsertUser,
+} from '../db/index.js';
+
+import { TalkExecutorError } from './executor.js';
+import {
+  getTalkExecutorAliasModelMap,
+  RealTalkExecutor,
+  type RealTalkExecutorOptions,
+} from './real-executor.js';
+
+function createRunningRun(runId: string, talkId = 'talk-1'): void {
+  createTalkRun({
+    id: runId,
+    talk_id: talkId,
+    requested_by: 'owner-1',
+    status: 'running',
+    trigger_message_id: null,
+    idempotency_key: null,
+    executor_alias: null,
+    executor_model: null,
+    created_at: '2024-01-01T00:00:00.000Z',
+    started_at: '2024-01-01T00:00:00.000Z',
+    ended_at: null,
+    cancel_reason: null,
+  });
+}
+
+describe('RealTalkExecutor', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    upsertUser({
+      id: 'owner-1',
+      email: 'owner@example.com',
+      displayName: 'Owner',
+      role: 'owner',
+    });
+    createTalk({
+      id: 'talk-1',
+      ownerId: 'owner-1',
+      topicTitle: 'Executor Test Talk',
+    });
+  });
+
+  it('uses default alias when no policy exists and persists session metadata', async () => {
+    createRunningRun('run-1');
+
+    const runContainer: NonNullable<
+      RealTalkExecutorOptions['runContainer']
+    > = async (_group, input, onProcess, onOutput) => {
+      onProcess?.({ killed: false, kill: () => true } as any, 'container-1');
+      await onOutput?.({
+        status: 'success',
+        result: 'chunk one',
+        newSessionId: 'session-1',
+      });
+      await onOutput?.({
+        status: 'success',
+        result: 'chunk two',
+        newSessionId: 'session-1',
+      });
+      return { status: 'success', result: null, newSessionId: 'session-1' };
+    };
+
+    const executor = new RealTalkExecutor({
+      aliasModelMap: { Mock: 'default' },
+      defaultAlias: 'Mock',
+      runContainer,
+    });
+
+    const output = await executor.execute(
+      {
+        runId: 'run-1',
+        talkId: 'talk-1',
+        requestedBy: 'owner-1',
+        triggerMessageId: 'msg-trigger-1',
+        triggerContent: 'hello world',
+      },
+      new AbortController().signal,
+    );
+
+    expect(output.content).toBe('chunk onechunk two');
+    const run = getTalkRunById('run-1');
+    expect(run?.executor_alias).toBe('Mock');
+    expect(run?.executor_model).toBe('default');
+    const session = getTalkExecutorSession('talk-1');
+    expect(session?.session_id).toBe('session-1');
+    expect(session?.executor_alias).toBe('Mock');
+    expect(session?.executor_model).toBe('default');
+  });
+
+  it('uses first policy alias only and maps compatibility aliases', async () => {
+    createRunningRun('run-2');
+    upsertTalkLlmPolicy({
+      talkId: 'talk-1',
+      llmPolicy: '{"agents":["Gemini","Opus4.6"]}',
+    });
+
+    const captured: Array<{ model?: string; toolProfile?: string }> = [];
+    const runContainer: NonNullable<
+      RealTalkExecutorOptions['runContainer']
+    > = async (_group, input, onProcess) => {
+      captured.push({ model: input.model, toolProfile: input.toolProfile });
+      onProcess?.({ killed: false, kill: () => true } as any, 'container-2');
+      return { status: 'success', result: null, newSessionId: 'session-2' };
+    };
+
+    const executor = new RealTalkExecutor({
+      aliasModelMap: {
+        Mock: 'default',
+        Gemini: 'default',
+        'Opus4.6': 'default',
+      },
+      defaultAlias: 'Mock',
+      runContainer,
+    });
+
+    await executor.execute(
+      {
+        runId: 'run-2',
+        talkId: 'talk-1',
+        requestedBy: 'owner-1',
+        triggerMessageId: 'msg-trigger-1',
+        triggerContent: 'hello again',
+      },
+      new AbortController().signal,
+    );
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].model).toBe('default');
+    expect(captured[0].toolProfile).toBe('web_talk');
+    const run = getTalkRunById('run-2');
+    expect(run?.executor_alias).toBe('Gemini');
+  });
+
+  it('exposes compatibility seed aliases in default map', () => {
+    const aliasMap = getTalkExecutorAliasModelMap();
+    expect(aliasMap.Mock).toBe('default');
+    expect(aliasMap.Gemini).toBe('default');
+    expect(aliasMap['Opus4.6']).toBe('default');
+    expect(aliasMap.Haiku).toBe('default');
+    expect(aliasMap['GPT-4o']).toBe('default');
+    expect(aliasMap.Opus).toBe('default');
+  });
+
+  it('fails with explicit code when alias is unmapped', async () => {
+    createRunningRun('run-3');
+    upsertTalkLlmPolicy({
+      talkId: 'talk-1',
+      llmPolicy: '{"agents":["CustomAlias"]}',
+    });
+
+    const executor = new RealTalkExecutor({
+      aliasModelMap: { Mock: 'default' },
+      defaultAlias: 'Mock',
+      runContainer: async () => {
+        throw new Error('should not be called');
+      },
+    });
+
+    await expect(
+      executor.execute(
+        {
+          runId: 'run-3',
+          talkId: 'talk-1',
+          requestedBy: 'owner-1',
+          triggerMessageId: 'msg-trigger-1',
+          triggerContent: 'fail me',
+        },
+        new AbortController().signal,
+      ),
+    ).rejects.toMatchObject({ code: 'executor_alias_unmapped' });
+  });
+
+  it('keeps existing session authoritative even if talk policy changes', async () => {
+    createRunningRun('run-4');
+    upsertTalkLlmPolicy({
+      talkId: 'talk-1',
+      llmPolicy: '{"agents":["Gemini"]}',
+    });
+    upsertTalkExecutorSession({
+      talkId: 'talk-1',
+      sessionId: 'session-existing',
+      executorAlias: 'Opus4.6',
+      executorModel: 'model-opus',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+
+    const captured: Array<{ model?: string; sessionId?: string }> = [];
+    const runContainer: NonNullable<
+      RealTalkExecutorOptions['runContainer']
+    > = async (_group, input) => {
+      captured.push({ model: input.model, sessionId: input.sessionId });
+      return {
+        status: 'success',
+        result: null,
+        newSessionId: 'session-existing',
+      };
+    };
+
+    const executor = new RealTalkExecutor({
+      aliasModelMap: {
+        Mock: 'default',
+        Gemini: 'model-gemini',
+        'Opus4.6': 'model-opus',
+      },
+      defaultAlias: 'Mock',
+      runContainer,
+    });
+
+    await executor.execute(
+      {
+        runId: 'run-4',
+        talkId: 'talk-1',
+        requestedBy: 'owner-1',
+        triggerMessageId: 'msg-trigger-1',
+        triggerContent: 'session path',
+      },
+      new AbortController().signal,
+    );
+
+    expect(captured).toEqual([
+      {
+        model: 'model-opus',
+        sessionId: 'session-existing',
+      },
+    ]);
+    const run = getTalkRunById('run-4');
+    expect(run?.executor_alias).toBe('Opus4.6');
+    expect(run?.executor_model).toBe('model-opus');
+  });
+
+  it('retries once after invalid session and then succeeds with re-resolved alias', async () => {
+    createRunningRun('run-5');
+    upsertTalkLlmPolicy({
+      talkId: 'talk-1',
+      llmPolicy: '{"agents":["Gemini"]}',
+    });
+    upsertTalkExecutorSession({
+      talkId: 'talk-1',
+      sessionId: 'session-stale',
+      executorAlias: 'Opus4.6',
+      executorModel: 'model-opus',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+
+    const calls: Array<{ model?: string; sessionId?: string }> = [];
+    const runContainer: NonNullable<
+      RealTalkExecutorOptions['runContainer']
+    > = async (_group, input) => {
+      calls.push({ model: input.model, sessionId: input.sessionId });
+      if (calls.length === 1) {
+        return {
+          status: 'error',
+          result: null,
+          error: 'resume session not found',
+        };
+      }
+      return { status: 'success', result: 'ok', newSessionId: 'session-new' };
+    };
+
+    const executor = new RealTalkExecutor({
+      aliasModelMap: {
+        Mock: 'default',
+        Gemini: 'model-gemini',
+        'Opus4.6': 'model-opus',
+      },
+      defaultAlias: 'Mock',
+      runContainer,
+    });
+
+    const output = await executor.execute(
+      {
+        runId: 'run-5',
+        talkId: 'talk-1',
+        requestedBy: 'owner-1',
+        triggerMessageId: 'msg-trigger-1',
+        triggerContent: 'retry path',
+      },
+      new AbortController().signal,
+    );
+
+    expect(output.content).toBe('ok');
+    expect(calls).toEqual([
+      { model: 'model-opus', sessionId: 'session-stale' },
+      { model: 'model-gemini', sessionId: undefined },
+    ]);
+    const session = getTalkExecutorSession('talk-1');
+    expect(session?.session_id).toBe('session-new');
+    expect(session?.executor_alias).toBe('Gemini');
+    expect(session?.executor_model).toBe('model-gemini');
+  });
+
+  it('fails when retry after session reset still errors', async () => {
+    createRunningRun('run-6');
+    upsertTalkLlmPolicy({
+      talkId: 'talk-1',
+      llmPolicy: '{"agents":["Gemini"]}',
+    });
+    upsertTalkExecutorSession({
+      talkId: 'talk-1',
+      sessionId: 'session-stale',
+      executorAlias: 'Opus4.6',
+      executorModel: 'model-opus',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+
+    let calls = 0;
+    const runContainer: NonNullable<
+      RealTalkExecutorOptions['runContainer']
+    > = async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          status: 'error',
+          result: null,
+          error: 'invalid session',
+        };
+      }
+      return {
+        status: 'error',
+        result: null,
+        error: 'backend unavailable',
+      };
+    };
+
+    const executor = new RealTalkExecutor({
+      aliasModelMap: {
+        Mock: 'default',
+        Gemini: 'model-gemini',
+        'Opus4.6': 'model-opus',
+      },
+      defaultAlias: 'Mock',
+      runContainer,
+    });
+
+    await expect(
+      executor.execute(
+        {
+          runId: 'run-6',
+          talkId: 'talk-1',
+          requestedBy: 'owner-1',
+          triggerMessageId: 'msg-trigger-1',
+          triggerContent: 'retry fail',
+        },
+        new AbortController().signal,
+      ),
+    ).rejects.toBeInstanceOf(TalkExecutorError);
+    expect(calls).toBe(2);
+  });
+});

--- a/src/clawrocket/talks/real-executor.ts
+++ b/src/clawrocket/talks/real-executor.ts
@@ -1,0 +1,343 @@
+import type { ChildProcess } from 'child_process';
+
+import {
+  runContainerAgent,
+  type ContainerOutput,
+} from '../../container-runner.js';
+import { logger } from '../../logger.js';
+import type { RegisteredGroup } from '../../types.js';
+import {
+  deleteTalkExecutorSession,
+  getTalkExecutorSession,
+  getTalkLlmPolicyByTalkId,
+  setTalkRunExecutorProfile,
+  upsertTalkExecutorSession,
+} from '../db/index.js';
+import {
+  TALK_EXECUTOR_ALIAS_MODEL_MAP_JSON,
+  TALK_EXECUTOR_DEFAULT_ALIAS,
+  TALK_EXECUTOR_WEB_GROUP_FOLDER,
+} from '../config.js';
+
+import {
+  TalkExecutor,
+  TalkExecutorError,
+  TalkExecutorInput,
+  TalkExecutorOutput,
+} from './executor.js';
+import { parsePolicyAgentsForExecution } from './policy.js';
+
+const COMPATIBILITY_ALIAS_MODEL_SEEDS: Record<string, string> = {
+  Mock: 'default',
+  Gemini: 'default',
+  'Opus4.6': 'default',
+  Haiku: 'default',
+  'GPT-4o': 'default',
+  Opus: 'default',
+};
+
+const INVALID_SESSION_ERROR_HINTS = [
+  'invalid session',
+  'session not found',
+  'resume session not found',
+  'unknown session',
+  'session expired',
+  'invalid resume',
+];
+
+function abortError(reason?: unknown): Error {
+  const err = new Error(
+    typeof reason === 'string' ? reason : 'Talk execution aborted',
+  );
+  err.name = 'AbortError';
+  return err;
+}
+
+function isSessionInvalidError(errorMessage: string): boolean {
+  const normalized = errorMessage.toLowerCase();
+  if (!normalized.includes('session') && !normalized.includes('resume')) {
+    return false;
+  }
+  return INVALID_SESSION_ERROR_HINTS.some((hint) => normalized.includes(hint));
+}
+
+function normalizeEnvAliasModelMap(rawJson: string): Record<string, string> {
+  if (!rawJson.trim()) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch (error) {
+    logger.warn(
+      { err: error },
+      'TALK_EXECUTOR_ALIAS_MODEL_MAP_JSON is invalid JSON; ignoring override',
+    );
+    return {};
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    logger.warn(
+      'TALK_EXECUTOR_ALIAS_MODEL_MAP_JSON must be a JSON object; ignoring override',
+    );
+    return {};
+  }
+
+  const normalized: Record<string, string> = {};
+  for (const [rawAlias, rawModel] of Object.entries(parsed)) {
+    const alias = rawAlias.trim();
+    const model = typeof rawModel === 'string' ? rawModel.trim() : '';
+    if (!alias || !model) {
+      logger.warn(
+        { alias: rawAlias },
+        'Skipping invalid talk executor alias map entry',
+      );
+      continue;
+    }
+    normalized[alias] = model;
+  }
+
+  return normalized;
+}
+
+export function hasValidAliasModelMapConfig(rawJson: string): boolean {
+  if (!rawJson.trim()) return false;
+  try {
+    const parsed = JSON.parse(rawJson);
+    return (
+      Boolean(parsed) && typeof parsed === 'object' && !Array.isArray(parsed)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function getTalkExecutorAliasModelMap(): Record<string, string> {
+  return {
+    ...COMPATIBILITY_ALIAS_MODEL_SEEDS,
+    ...normalizeEnvAliasModelMap(TALK_EXECUTOR_ALIAS_MODEL_MAP_JSON),
+  };
+}
+
+interface ExecutionProfile {
+  alias: string;
+  model: string;
+  sessionId?: string;
+}
+
+export interface RealTalkExecutorOptions {
+  aliasModelMap?: Record<string, string>;
+  defaultAlias?: string;
+  groupFolder?: string;
+  runContainer?: typeof runContainerAgent;
+}
+
+export class RealTalkExecutor implements TalkExecutor {
+  private readonly aliasModelMap: Record<string, string>;
+  private readonly defaultAlias: string;
+  private readonly groupFolder: string;
+  private readonly runContainer: typeof runContainerAgent;
+
+  constructor(options: RealTalkExecutorOptions = {}) {
+    this.aliasModelMap =
+      options.aliasModelMap || getTalkExecutorAliasModelMap();
+    this.defaultAlias = options.defaultAlias || TALK_EXECUTOR_DEFAULT_ALIAS;
+    this.groupFolder = options.groupFolder || TALK_EXECUTOR_WEB_GROUP_FOLDER;
+    this.runContainer = options.runContainer || runContainerAgent;
+  }
+
+  async execute(
+    input: TalkExecutorInput,
+    signal: AbortSignal,
+  ): Promise<TalkExecutorOutput> {
+    const session = getTalkExecutorSession(input.talkId);
+    const fromSession = this.resolveExecutionProfile(input.talkId, session);
+    return this.executeWithRetry(
+      input,
+      signal,
+      fromSession,
+      session !== undefined,
+    );
+  }
+
+  private resolveExecutionProfile(
+    talkId: string,
+    session:
+      | {
+          session_id: string;
+          executor_alias: string;
+          executor_model: string;
+        }
+      | undefined,
+  ): ExecutionProfile {
+    if (session) {
+      return {
+        alias: session.executor_alias,
+        model: session.executor_model,
+        sessionId: session.session_id,
+      };
+    }
+
+    const llmPolicy = getTalkLlmPolicyByTalkId(talkId);
+    const parsedAliases = parsePolicyAgentsForExecution(llmPolicy);
+    const alias = parsedAliases[0] || this.defaultAlias;
+    const model = this.aliasModelMap[alias];
+    if (!model) {
+      throw new TalkExecutorError(
+        'executor_alias_unmapped',
+        `No model mapping found for talk alias "${alias}"`,
+      );
+    }
+
+    return { alias, model };
+  }
+
+  private async executeWithRetry(
+    input: TalkExecutorInput,
+    signal: AbortSignal,
+    profile: ExecutionProfile,
+    sessionExists: boolean,
+  ): Promise<TalkExecutorOutput> {
+    try {
+      return await this.executeOnce(input, signal, profile);
+    } catch (error) {
+      if (!sessionExists) throw error;
+      if (
+        !(error instanceof TalkExecutorError) ||
+        error.code !== 'executor_container_error' ||
+        !isSessionInvalidError(error.sourceMessage)
+      ) {
+        throw error;
+      }
+
+      logger.warn(
+        {
+          talkId: input.talkId,
+          runId: input.runId,
+          alias: profile.alias,
+          model: profile.model,
+        },
+        'Clearing invalid talk executor session and retrying once',
+      );
+
+      deleteTalkExecutorSession(input.talkId);
+      const retryProfile = this.resolveExecutionProfile(
+        input.talkId,
+        undefined,
+      );
+      return this.executeOnce(input, signal, retryProfile);
+    }
+  }
+
+  private async executeOnce(
+    input: TalkExecutorInput,
+    signal: AbortSignal,
+    profile: ExecutionProfile,
+  ): Promise<TalkExecutorOutput> {
+    setTalkRunExecutorProfile({
+      runId: input.runId,
+      executorAlias: profile.alias,
+      executorModel: profile.model,
+    });
+
+    const output = await this.executeContainer(input, signal, profile);
+
+    if (output.sessionId) {
+      upsertTalkExecutorSession({
+        talkId: input.talkId,
+        sessionId: output.sessionId,
+        executorAlias: profile.alias,
+        executorModel: profile.model,
+      });
+    }
+
+    return {
+      content: output.content.trim() || 'No response generated.',
+    };
+  }
+
+  private async executeContainer(
+    input: TalkExecutorInput,
+    signal: AbortSignal,
+    profile: ExecutionProfile,
+  ): Promise<{ content: string; sessionId?: string }> {
+    if (signal.aborted) {
+      throw abortError(signal.reason);
+    }
+
+    const group: RegisteredGroup = {
+      name: 'Web Talk Executor',
+      folder: this.groupFolder,
+      trigger: '@web',
+      added_at: '1970-01-01T00:00:00.000Z',
+      requiresTrigger: false,
+      isMain: false,
+    };
+
+    const chunks: string[] = [];
+    let lastSessionId = profile.sessionId;
+    let processRef: ChildProcess | null = null;
+    const onAbort = () => {
+      if (processRef && !processRef.killed) {
+        processRef.kill('SIGTERM');
+      }
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+    try {
+      const result = await this.runContainer(
+        group,
+        {
+          prompt: input.triggerContent,
+          sessionId: profile.sessionId,
+          model: profile.model,
+          toolProfile: 'web_talk',
+          groupFolder: this.groupFolder,
+          chatJid: `talk:${input.talkId}`,
+          isMain: false,
+          assistantName: 'ClawRocket',
+        },
+        (proc) => {
+          processRef = proc;
+          if (signal.aborted && !proc.killed) {
+            proc.kill('SIGTERM');
+          }
+        },
+        async (streamOutput: ContainerOutput) => {
+          if (streamOutput.newSessionId) {
+            lastSessionId = streamOutput.newSessionId;
+          }
+          if (streamOutput.result) {
+            chunks.push(streamOutput.result);
+          }
+        },
+      );
+
+      if (signal.aborted) {
+        throw abortError(signal.reason);
+      }
+
+      if (result.newSessionId) {
+        lastSessionId = result.newSessionId;
+      }
+
+      if (result.status === 'error') {
+        const sourceMessage =
+          result.error || 'Unknown container execution error';
+        throw new TalkExecutorError(
+          'executor_container_error',
+          'Container execution failed',
+          { sourceMessage },
+        );
+      }
+
+      const aggregatedContent = chunks.join('').trim();
+
+      return {
+        content: aggregatedContent || result.result || '',
+        sessionId: lastSessionId,
+      };
+    } finally {
+      signal.removeEventListener('abort', onAbort);
+    }
+  }
+}

--- a/src/clawrocket/talks/run-queue.ts
+++ b/src/clawrocket/talks/run-queue.ts
@@ -29,6 +29,8 @@ export class TalkRunQueue {
       status,
       trigger_message_id: null,
       idempotency_key: input.idempotencyKey || null,
+      executor_alias: null,
+      executor_model: null,
       created_at: now,
       started_at: status === 'running' ? now : null,
       ended_at: null,

--- a/src/clawrocket/talks/run-worker.test.ts
+++ b/src/clawrocket/talks/run-worker.test.ts
@@ -16,6 +16,7 @@ import type {
   TalkExecutorInput,
   TalkExecutorOutput,
 } from './executor.js';
+import { TalkExecutorError } from './executor.js';
 import { MockTalkExecutor } from './mock-executor.js';
 import { TalkRunWorker } from './run-worker.js';
 
@@ -47,6 +48,15 @@ class BlockingExecutor implements TalkExecutor {
       };
       signal.addEventListener('abort', onAbort, { once: true });
     });
+  }
+}
+
+class AliasUnmappedExecutor implements TalkExecutor {
+  async execute(): Promise<TalkExecutorOutput> {
+    throw new TalkExecutorError(
+      'executor_alias_unmapped',
+      'No model mapping configured for alias',
+    );
   }
 }
 
@@ -256,6 +266,42 @@ describe('TalkRunWorker', () => {
 
     const staleRun = getTalkRunById('run-5');
     expect(staleRun?.cancel_reason).toBe('interrupted_by_restart');
+
+    await worker.stop();
+  });
+
+  it('propagates typed executor error codes to failed run events', async () => {
+    const worker = new TalkRunWorker({
+      executor: new AliasUnmappedExecutor(),
+      pollMs: 10_000,
+      maxConcurrency: 1,
+    });
+    await worker.start();
+
+    enqueueTalkTurnAtomic({
+      talkId: 'talk-1',
+      userId: 'owner-1',
+      content: 'this should fail',
+      messageId: 'msg-7',
+      runId: 'run-7',
+    });
+
+    worker.wake();
+    await waitFor(() => getTalkRunById('run-7')?.status === 'failed');
+
+    const run = getTalkRunById('run-7');
+    expect(run?.cancel_reason).toContain('executor_alias_unmapped');
+
+    const events = getOutboxEventsForTopics(['talk:talk-1'], 0, 100);
+    const failedEvent = events.find(
+      (event) =>
+        event.event_type === 'talk_run_failed' &&
+        event.payload.includes('"runId":"run-7"'),
+    );
+    expect(failedEvent).toBeDefined();
+    expect(failedEvent?.payload).toContain(
+      '"errorCode":"executor_alias_unmapped"',
+    );
 
     await worker.stop();
   });

--- a/src/clawrocket/talks/run-worker.ts
+++ b/src/clawrocket/talks/run-worker.ts
@@ -12,7 +12,7 @@ import {
 } from '../db/index.js';
 import { logger } from '../../logger.js';
 
-import type { TalkExecutor } from './executor.js';
+import { TalkExecutorError, type TalkExecutor } from './executor.js';
 import { MockTalkExecutor } from './mock-executor.js';
 
 export interface TalkRunWorkerOptions {
@@ -240,7 +240,11 @@ export class TalkRunWorker implements TalkRunWorkerControl {
         return;
       }
 
-      this.failRun(run, 'execution_failed', errorMessage(error));
+      this.failRun(
+        run,
+        error instanceof TalkExecutorError ? error.code : 'execution_failed',
+        errorMessage(error),
+      );
     }
   }
 

--- a/src/clawrocket/web/index.ts
+++ b/src/clawrocket/web/index.ts
@@ -1,18 +1,42 @@
 import { logger } from '../../logger.js';
 import {
+  TALK_EXECUTOR_ALIAS_MODEL_MAP_JSON,
+  TALK_EXECUTOR_HAS_PROVIDER_AUTH,
   TALK_RUN_MAX_CONCURRENCY,
   TALK_RUN_POLL_MS,
   WEB_HOST,
   WEB_PORT,
 } from '../config.js';
+import type { TalkExecutor } from '../talks/executor.js';
 import { MockTalkExecutor } from '../talks/mock-executor.js';
+import {
+  hasValidAliasModelMapConfig,
+  RealTalkExecutor,
+} from '../talks/real-executor.js';
 import { TalkRunWorker } from '../talks/run-worker.js';
 
 import { createWebServer, WebServerHandle } from './server.js';
 
 export async function startWebServer(): Promise<WebServerHandle> {
+  const hasValidAliasMap = hasValidAliasModelMapConfig(
+    TALK_EXECUTOR_ALIAS_MODEL_MAP_JSON,
+  );
+  const useRealExecutor = TALK_EXECUTOR_HAS_PROVIDER_AUTH && hasValidAliasMap;
+  const executor: TalkExecutor = useRealExecutor
+    ? new RealTalkExecutor()
+    : new MockTalkExecutor();
+
+  logger.info(
+    {
+      mode: useRealExecutor ? 'real' : 'mock',
+      hasProviderAuth: TALK_EXECUTOR_HAS_PROVIDER_AUTH,
+      hasValidAliasMap,
+    },
+    'Talk executor mode selected',
+  );
+
   const runWorker = new TalkRunWorker({
-    executor: new MockTalkExecutor(),
+    executor,
     pollMs: TALK_RUN_POLL_MS,
     maxConcurrency: TALK_RUN_MAX_CONCURRENCY,
   });

--- a/src/clawrocket/web/routes/talks.ts
+++ b/src/clawrocket/web/routes/talks.ts
@@ -15,6 +15,11 @@ import {
   type TalkMessageRecord,
   type TalkWithAccessRecord,
 } from '../../db/index.js';
+import {
+  parsePolicyAgentsForExecution,
+  parsePolicyAgentsForUiBadges,
+  TALK_POLICY_MAX_AGENTS,
+} from '../../talks/policy.js';
 import { canEditTalk } from '../middleware/acl.js';
 import { AuthContext, ApiEnvelope } from '../types.js';
 
@@ -41,10 +46,9 @@ interface TalkMessageApiRecord {
 
 const DEFAULT_TALK_AGENTS = ['Mock'];
 const MAX_TALK_AGENT_BADGES = 6;
-const MAX_POLICY_AGENTS = 12;
 const MAX_POLICY_AGENT_LABEL_CHARS = 80;
 const TALK_POLICY_LIMITS = {
-  maxAgents: MAX_POLICY_AGENTS,
+  maxAgents: TALK_POLICY_MAX_AGENTS,
   maxAgentChars: MAX_POLICY_AGENT_LABEL_CHARS,
 } as const;
 
@@ -74,7 +78,9 @@ function parseTalkAgents(talkId: string, llmPolicy: string | null): string[] {
   const raw = llmPolicy?.trim();
   if (!raw) return DEFAULT_TALK_AGENTS;
 
-  const normalized = parsePolicyAgentCandidates(raw, MAX_TALK_AGENT_BADGES);
+  // Intentionally separate from execution parser:
+  // list badges are capped for density and default to Mock on parse failures.
+  const normalized = parsePolicyAgentsForUiBadges(raw, MAX_TALK_AGENT_BADGES);
 
   if (normalized.length > 0) {
     return normalized;
@@ -90,45 +96,7 @@ function parseTalkAgents(talkId: string, llmPolicy: string | null): string[] {
 }
 
 function parseTalkPolicyAgents(llmPolicy: string | null): string[] {
-  const raw = llmPolicy?.trim();
-  if (!raw) return [];
-  return parsePolicyAgentCandidates(raw, MAX_POLICY_AGENTS);
-}
-
-function parsePolicyAgentCandidates(
-  rawPolicy: string,
-  maxItems: number,
-): string[] {
-  let candidates: unknown[] = [];
-  try {
-    const parsed = JSON.parse(rawPolicy) as unknown;
-    if (Array.isArray(parsed)) {
-      candidates = parsed;
-    } else if (parsed && typeof parsed === 'object') {
-      const asRecord = parsed as Record<string, unknown>;
-      if (Array.isArray(asRecord.agents)) {
-        candidates = asRecord.agents;
-      } else if (Array.isArray(asRecord.models)) {
-        candidates = asRecord.models;
-      } else {
-        candidates = [asRecord.agent, asRecord.model];
-      }
-    } else if (typeof parsed === 'string') {
-      candidates = [parsed];
-    }
-  } catch {
-    candidates = rawPolicy.split(/[|,]/);
-  }
-
-  return [
-    ...new Set(
-      candidates
-        .map((candidate) =>
-          typeof candidate === 'string' ? candidate.trim() : '',
-        )
-        .filter(Boolean),
-    ),
-  ].slice(0, maxItems);
+  return parsePolicyAgentsForExecution(llmPolicy);
 }
 
 function normalizePolicyAgents(input: unknown): {
@@ -152,8 +120,8 @@ function normalizePolicyAgents(input: unknown): {
       error: `each agent label must be ${MAX_POLICY_AGENT_LABEL_CHARS} characters or less`,
     };
   }
-  if (normalized.length > MAX_POLICY_AGENTS) {
-    return { error: `at most ${MAX_POLICY_AGENTS} agents are allowed` };
+  if (normalized.length > TALK_POLICY_MAX_AGENTS) {
+    return { error: `at most ${TALK_POLICY_MAX_AGENTS} agents are allowed` };
   }
 
   return { agents: normalized };

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -33,6 +33,8 @@ const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
 export interface ContainerInput {
   prompt: string;
   sessionId?: string;
+  model?: string;
+  toolProfile?: 'default' | 'web_talk';
   groupFolder: string;
   chatJid: string;
   isMain: boolean;

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -29,12 +29,15 @@ import {
   enqueueTalkTurnAtomic,
   failInterruptedRunsOnStartup,
   failRunAndPromoteNextAtomic,
+  deleteTalkExecutorSession,
   getIdempotencyCache,
   getOutboxEventsForTopics,
   getQueuedTalkRuns,
   getRunningTalkRun,
   getTalkById,
+  getTalkExecutorSession,
   getTalkForUser,
+  getTalkLlmPolicyByTalkId,
   getTalkRunById,
   getUserById,
   listTalkMessages,
@@ -44,7 +47,10 @@ import {
   pruneEventOutbox,
   pruneIdempotencyCache,
   saveIdempotencyCache,
+  setTalkRunExecutorProfile,
   upsertTalk,
+  upsertTalkExecutorSession,
+  upsertTalkLlmPolicy,
   upsertTalkMember,
   upsertUser,
   upsertWebSession,
@@ -535,6 +541,49 @@ describe('phase 0 schema and reliability tables', () => {
     expect(second).toBeUndefined();
   });
 
+  it('stores and reads talk policy by talk id', () => {
+    expect(getTalkLlmPolicyByTalkId('talk-1')).toBeNull();
+
+    upsertTalkLlmPolicy({
+      talkId: 'talk-1',
+      llmPolicy: '{"agents":["Gemini","Opus4.6"]}',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+
+    expect(getTalkLlmPolicyByTalkId('talk-1')).toBe(
+      '{"agents":["Gemini","Opus4.6"]}',
+    );
+  });
+
+  it('upserts and deletes talk executor sessions', () => {
+    expect(getTalkExecutorSession('talk-1')).toBeUndefined();
+
+    upsertTalkExecutorSession({
+      talkId: 'talk-1',
+      sessionId: 'session-1',
+      executorAlias: 'Gemini',
+      executorModel: 'default',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+    upsertTalkExecutorSession({
+      talkId: 'talk-1',
+      sessionId: 'session-2',
+      executorAlias: 'Opus4.6',
+      executorModel: 'default',
+      updatedAt: '2024-01-01T00:00:01.000Z',
+    });
+
+    const session = getTalkExecutorSession('talk-1');
+    expect(session).toBeDefined();
+    expect(session?.session_id).toBe('session-2');
+    expect(session?.executor_alias).toBe('Opus4.6');
+    expect(session?.executor_model).toBe('default');
+    expect(session?.updated_at).toBe('2024-01-01T00:00:01.000Z');
+
+    deleteTalkExecutorSession('talk-1');
+    expect(getTalkExecutorSession('talk-1')).toBeUndefined();
+  });
+
   it('does not change talk owner when upserting existing talk id', () => {
     upsertUser({
       id: 'owner-2',
@@ -872,6 +921,8 @@ describe('phase 0 schema and reliability tables', () => {
       status: 'running',
       trigger_message_id: null,
       idempotency_key: null,
+      executor_alias: null,
+      executor_model: null,
       created_at: new Date().toISOString(),
       started_at: new Date().toISOString(),
       ended_at: null,
@@ -884,6 +935,8 @@ describe('phase 0 schema and reliability tables', () => {
       status: 'queued',
       trigger_message_id: null,
       idempotency_key: null,
+      executor_alias: null,
+      executor_model: null,
       created_at: new Date().toISOString(),
       started_at: null,
       ended_at: null,
@@ -901,6 +954,27 @@ describe('phase 0 schema and reliability tables', () => {
       new Date().toISOString(),
     );
     expect(getTalkRunById('run-1')?.status).toBe('completed');
+  });
+
+  it('persists executor alias/model metadata on talk runs', () => {
+    enqueueTalkTurnAtomic({
+      talkId: 'talk-1',
+      userId: 'owner-1',
+      content: 'metadata check',
+      messageId: 'msg-meta-1',
+      runId: 'run-meta-1',
+      now: '2024-01-01T00:00:55.000Z',
+    });
+
+    setTalkRunExecutorProfile({
+      runId: 'run-meta-1',
+      executorAlias: 'Gemini',
+      executorModel: 'default',
+    });
+
+    const run = getTalkRunById('run-meta-1');
+    expect(run?.executor_alias).toBe('Gemini');
+    expect(run?.executor_model).toBe('default');
   });
 
   it('preserves hot events while pruning old outbox rows', () => {


### PR DESCRIPTION
Summary
Implements Phase 1.9 Step F end-to-end by introducing a real talk executor path for web talks, with persisted per-talk session continuity, strict alias->model resolution, and automatic fallback to mock mode when runtime prerequisites are missing.

This PR also includes follow-up hardening from review:

Retry-on-invalid-session now keys off a dedicated raw source error field (TalkExecutorError.sourceMessage) rather than formatted Error.message.
Streamed chunk aggregation now uses raw concatenation (join('')) to avoid injecting spurious newlines.
What changed
1) DB schema + accessors
Added talk_executor_sessions table:
talk_id (PK, FK talks, cascade delete)
session_id
executor_alias
executor_model
updated_at
Added talk_runs.executor_alias and talk_runs.executor_model migrations.
Added accessors:
getTalkExecutorSession
upsertTalkExecutorSession
deleteTalkExecutorSession
setTalkRunExecutorProfile
getTalkLlmPolicyByTalkId
Extended TalkRunRecord with executor_alias / executor_model.
2) Policy parser split (execution vs badge UI)
Added shared parser module: src/clawrocket/talks/policy.ts.
Execution parser (max 12, no Mock fallback) is shared and reused.
Badge parser remains intentionally separate (max 6, Mock fallback + warning) and is explicitly documented in routes.
3) Real executor + strict mapping
Added RealTalkExecutor (src/clawrocket/talks/real-executor.ts):
Uses persisted session profile when present (session-authoritative).
Otherwise resolves first policy alias, falls back to default alias.
Strict alias->model mapping; unmapped alias throws typed executor_alias_unmapped.
Persists per-run alias/model metadata before execution.
Aggregates streamed output into a single assistant response.
On session-invalid container errors: clears session and retries once.
4) Compatibility alias seeds + env override
Added compatibility seed map (prevents day-one failures):
Mock, Gemini, Opus4.6, Haiku, GPT-4o, Opus -> default
Env map (TALK_EXECUTOR_ALIAS_MODEL_MAP_JSON) merges over seeds.
Invalid map entries are skipped with warnings.
5) Container protocol updates
Extended ContainerInput with:
model?: string
toolProfile?: 'default' | 'web_talk'
In agent-runner:
web_talk disables MCP server wiring and excludes mcp__nanoclaw__*.
Default profile remains unchanged.
6) Worker wiring + rollout mode
Web startup now selects executor mode automatically:
real when provider auth is present + alias map JSON is valid object.
mock otherwise.
Logs selected mode and gating signals.
7) Typed executor error hardening
TalkExecutorError now includes sourceMessage.
Retry detection uses sourceMessage + code === executor_container_error.
Tests
Added/updated:

src/clawrocket/talks/real-executor.test.ts (new)
default alias path
first-policy-alias behavior
compatibility seeds
unmapped alias failure
session-authoritative execution
invalid-session reset+retry once
retry failure path
src/db.test.ts
talk policy lookup
talk executor session upsert/delete
run executor metadata persistence
src/clawrocket/talks/run-worker.test.ts
typed executor error code propagation into failure events
Validation
npm run typecheck ✅
npm test ✅
npm run build ✅
npm run format:check ✅
npm --prefix container/agent-runner run build ✅
Notes
No external HTTP API changes.
SSE/event contract unchanged.
Per-run cancellation-event split remains deferred (unchanged in this PR).