### PR TITLE
feat(web): add clawtalk sidebar navigation

### DIFF
--- a/webapp/src/App.test.tsx
+++ b/webapp/src/App.test.tsx
@@ -11,20 +11,29 @@ describe('App', () => {
   });
 
   it('shows sign-in and hides dev quick login when dev mode is disabled', async () => {
-    mockFetch([
-      jsonResponse(401, {
-        ok: false,
-        error: { code: 'unauthorized', message: 'Authentication is required' },
-      }),
-      jsonResponse(401, {
-        ok: false,
-        error: { code: 'invalid_refresh_token', message: 'Refresh failed' },
-      }),
-      jsonResponse(200, {
-        ok: true,
-        data: { devMode: false },
-      }),
-    ]);
+    mockFetchByPath({
+      '/api/v1/session/me': [
+        jsonResponse(401, {
+          ok: false,
+          error: {
+            code: 'unauthorized',
+            message: 'Authentication is required',
+          },
+        }),
+      ],
+      '/api/v1/auth/refresh': [
+        jsonResponse(401, {
+          ok: false,
+          error: { code: 'invalid_refresh_token', message: 'Refresh failed' },
+        }),
+      ],
+      '/api/v1/auth/config': [
+        jsonResponse(200, {
+          ok: true,
+          data: { devMode: false },
+        }),
+      ],
+    });
 
     renderWithRouter('/app/talks');
     await screen.findByRole('heading', { name: 'ClawRocket' });
@@ -36,20 +45,29 @@ describe('App', () => {
   });
 
   it('shows dev quick login when dev mode is enabled', async () => {
-    mockFetch([
-      jsonResponse(401, {
-        ok: false,
-        error: { code: 'unauthorized', message: 'Authentication is required' },
-      }),
-      jsonResponse(401, {
-        ok: false,
-        error: { code: 'invalid_refresh_token', message: 'Refresh failed' },
-      }),
-      jsonResponse(200, {
-        ok: true,
-        data: { devMode: true },
-      }),
-    ]);
+    mockFetchByPath({
+      '/api/v1/session/me': [
+        jsonResponse(401, {
+          ok: false,
+          error: {
+            code: 'unauthorized',
+            message: 'Authentication is required',
+          },
+        }),
+      ],
+      '/api/v1/auth/refresh': [
+        jsonResponse(401, {
+          ok: false,
+          error: { code: 'invalid_refresh_token', message: 'Refresh failed' },
+        }),
+      ],
+      '/api/v1/auth/config': [
+        jsonResponse(200, {
+          ok: true,
+          data: { devMode: true },
+        }),
+      ],
+    });
 
     renderWithRouter('/app/talks');
     await screen.findByRole('heading', { name: 'ClawRocket' });
@@ -57,70 +75,90 @@ describe('App', () => {
   });
 
   it('renders talks list when session is authenticated', async () => {
-    mockFetch([
-      jsonResponse(200, {
-        ok: true,
-        data: {
-          user: {
-            id: 'u1',
-            email: 'owner@example.com',
-            displayName: 'Owner',
-            role: 'owner',
-          },
-        },
-      }),
-      jsonResponse(200, {
-        ok: true,
-        data: {
-          talks: [
-            {
-              id: 'talk-1',
-              ownerId: 'u1',
-              title: 'Family Planning',
-              agents: ['Gemini', 'Opus4.6'],
-              status: 'active',
-              version: 1,
-              createdAt: '2026-03-04T00:00:00.000Z',
-              updatedAt: '2026-03-04T00:00:00.000Z',
-              accessRole: 'owner',
+    mockFetchByPath({
+      '/api/v1/session/me': [
+        jsonResponse(200, {
+          ok: true,
+          data: {
+            user: {
+              id: 'u1',
+              email: 'owner@example.com',
+              displayName: 'Owner',
+              role: 'owner',
             },
-          ],
-          page: { limit: 50, offset: 0, count: 1 },
-        },
-      }),
-    ]);
+          },
+        }),
+      ],
+      '/api/v1/talks': [
+        jsonResponse(200, {
+          ok: true,
+          data: {
+            talks: [
+              {
+                id: 'talk-1',
+                ownerId: 'u1',
+                title: 'Family Planning',
+                agents: ['Gemini', 'Opus4.6'],
+                status: 'active',
+                version: 1,
+                createdAt: '2026-03-04T00:00:00.000Z',
+                updatedAt: '2026-03-04T00:00:00.000Z',
+                accessRole: 'owner',
+              },
+            ],
+            page: { limit: 50, offset: 0, count: 1 },
+          },
+        }),
+      ],
+    });
 
     renderWithRouter('/app/talks');
     await screen.findByRole('heading', { name: 'Talks' });
-    expect(screen.getByRole('link', { name: /Family Planning/i })).toBeTruthy();
+    expect(screen.getByText('ClawTalk')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Home' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Settings' })).toBeTruthy();
+    expect(screen.getAllByRole('link', { name: /Family Planning/i })).toHaveLength(
+      2,
+    );
   });
 
   it('returns to sign-in when a later API call returns 401', async () => {
-    mockFetch([
-      jsonResponse(200, {
-        ok: true,
-        data: {
-          user: {
-            id: 'u1',
-            email: 'owner@example.com',
-            displayName: 'Owner',
-            role: 'owner',
+    mockFetchByPath({
+      '/api/v1/session/me': [
+        jsonResponse(200, {
+          ok: true,
+          data: {
+            user: {
+              id: 'u1',
+              email: 'owner@example.com',
+              displayName: 'Owner',
+              role: 'owner',
+            },
           },
-        },
-      }),
-      jsonResponse(401, {
-        ok: false,
-        error: { code: 'unauthorized', message: 'Authentication is required' },
-      }),
-      jsonResponse(401, {
-        ok: false,
-        error: { code: 'invalid_refresh_token', message: 'Refresh failed' },
-      }),
-      jsonResponse(200, {
-        ok: true,
-        data: { devMode: false },
-      }),
-    ]);
+        }),
+      ],
+      '/api/v1/talks': [
+        jsonResponse(401, {
+          ok: false,
+          error: {
+            code: 'unauthorized',
+            message: 'Authentication is required',
+          },
+        }),
+      ],
+      '/api/v1/auth/refresh': [
+        jsonResponse(401, {
+          ok: false,
+          error: { code: 'invalid_refresh_token', message: 'Refresh failed' },
+        }),
+      ],
+      '/api/v1/auth/config': [
+        jsonResponse(200, {
+          ok: true,
+          data: { devMode: false },
+        }),
+      ],
+    });
 
     renderWithRouter('/app/talks');
     await waitFor(() =>
@@ -129,34 +167,42 @@ describe('App', () => {
   });
 
   it('shows sign-in after clicking sign out from authenticated shell', async () => {
-    mockFetch([
-      jsonResponse(200, {
-        ok: true,
-        data: {
-          user: {
-            id: 'u1',
-            email: 'owner@example.com',
-            displayName: 'Owner',
-            role: 'owner',
+    mockFetchByPath({
+      '/api/v1/session/me': [
+        jsonResponse(200, {
+          ok: true,
+          data: {
+            user: {
+              id: 'u1',
+              email: 'owner@example.com',
+              displayName: 'Owner',
+              role: 'owner',
+            },
           },
-        },
-      }),
-      jsonResponse(200, {
-        ok: true,
-        data: {
-          talks: [],
-          page: { limit: 50, offset: 0, count: 0 },
-        },
-      }),
-      jsonResponse(200, {
-        ok: true,
-        data: { loggedOut: true },
-      }),
-      jsonResponse(200, {
-        ok: true,
-        data: { devMode: false },
-      }),
-    ]);
+        }),
+      ],
+      '/api/v1/talks': [
+        jsonResponse(200, {
+          ok: true,
+          data: {
+            talks: [],
+            page: { limit: 50, offset: 0, count: 0 },
+          },
+        }),
+      ],
+      '/api/v1/auth/logout': [
+        jsonResponse(200, {
+          ok: true,
+          data: { loggedOut: true },
+        }),
+      ],
+      '/api/v1/auth/config': [
+        jsonResponse(200, {
+          ok: true,
+          data: { devMode: false },
+        }),
+      ],
+    });
 
     renderWithRouter('/app/talks');
     const signOutButton = await screen.findByRole('button', {
@@ -168,38 +214,55 @@ describe('App', () => {
   });
 
   it('shows unavailable talk state for 404 detail fetch', async () => {
-    mockFetch([
-      jsonResponse(200, {
-        ok: true,
-        data: {
-          user: {
-            id: 'u1',
-            email: 'owner@example.com',
-            displayName: 'Owner',
-            role: 'owner',
+    mockFetchByPath({
+      '/api/v1/session/me': [
+        jsonResponse(200, {
+          ok: true,
+          data: {
+            user: {
+              id: 'u1',
+              email: 'owner@example.com',
+              displayName: 'Owner',
+              role: 'owner',
+            },
           },
-        },
-      }),
-      jsonResponse(404, {
-        ok: false,
-        error: { code: 'talk_not_found', message: 'Talk not found' },
-      }),
-      jsonResponse(200, {
-        ok: true,
-        data: {
-          talkId: 'talk-missing',
-          messages: [],
-          page: { limit: 100, count: 0, beforeCreatedAt: null },
-        },
-      }),
-      jsonResponse(200, {
-        ok: true,
-        data: {
-          talkId: 'talk-missing',
-          agents: [],
-        },
-      }),
-    ]);
+        }),
+      ],
+      '/api/v1/talks': [
+        jsonResponse(200, {
+          ok: true,
+          data: {
+            talks: [],
+            page: { limit: 50, offset: 0, count: 0 },
+          },
+        }),
+      ],
+      '/api/v1/talks/talk-missing': [
+        jsonResponse(404, {
+          ok: false,
+          error: { code: 'talk_not_found', message: 'Talk not found' },
+        }),
+      ],
+      '/api/v1/talks/talk-missing/messages': [
+        jsonResponse(200, {
+          ok: true,
+          data: {
+            talkId: 'talk-missing',
+            messages: [],
+            page: { limit: 100, count: 0, beforeCreatedAt: null },
+          },
+        }),
+      ],
+      '/api/v1/talks/talk-missing/agents': [
+        jsonResponse(200, {
+          ok: true,
+          data: {
+            talkId: 'talk-missing',
+            agents: [],
+          },
+        }),
+      ],
+    });
 
     renderWithRouter('/app/talks/talk-missing');
     await screen.findByRole('heading', { name: 'Talk Unavailable' });
@@ -214,14 +277,29 @@ function renderWithRouter(initialEntry: string): void {
   );
 }
 
-function mockFetch(responses: Response[]): void {
-  const queue = [...responses];
-  vi.stubGlobal('fetch', async () => {
-    const next = queue.shift();
-    if (!next) {
-      throw new Error('No mocked response left for fetch()');
+function mockFetchByPath(
+  responsesByPath: Record<string, Response | Response[]>,
+): void {
+  const queues = new Map(
+    Object.entries(responsesByPath).map(([path, responses]) => [
+      path,
+      Array.isArray(responses) ? [...responses] : [responses],
+    ]),
+  );
+
+  vi.stubGlobal('fetch', async (input: RequestInfo | URL) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    const path = new URL(url, 'http://localhost').pathname;
+    const queue = queues.get(path);
+    if (!queue || queue.length === 0) {
+      throw new Error(`No mocked response left for fetch(${path})`);
     }
-    return next;
+    return queue.shift()!;
   });
 }
 

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,11 +1,14 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Link, Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 
+import { ClawTalkSidebar } from './components/ClawTalkSidebar';
 import { SignInView } from './components/SignInView';
 import {
   getSessionMe,
+  listTalks,
   logout as logoutSession,
   SessionUser,
+  Talk,
   UnauthorizedError,
 } from './lib/api';
 import { TalkDetailPage } from './pages/TalkDetailPage';
@@ -20,6 +23,9 @@ type AuthState =
 export function App() {
   const [auth, setAuth] = useState<AuthState>({ status: 'loading' });
   const [signOutBusy, setSignOutBusy] = useState(false);
+  const [talks, setTalks] = useState<Talk[]>([]);
+  const [talksLoading, setTalksLoading] = useState(true);
+  const [talksError, setTalksError] = useState<string | null>(null);
 
   const refreshSession = useCallback(async () => {
     try {
@@ -53,6 +59,40 @@ export function App() {
     void refreshSession();
   }, [refreshSession]);
 
+  const refreshTalks = useCallback(async () => {
+    try {
+      const rows = await listTalks();
+      setTalks(rows);
+      setTalksError(null);
+    } catch (err) {
+      if (err instanceof UnauthorizedError) {
+        handleUnauthorized();
+        return;
+      }
+      setTalksError(err instanceof Error ? err.message : 'Failed to load talks');
+    } finally {
+      setTalksLoading(false);
+    }
+  }, [handleUnauthorized]);
+
+  useEffect(() => {
+    if (auth.status !== 'authenticated') {
+      setTalks([]);
+      setTalksLoading(true);
+      setTalksError(null);
+      return;
+    }
+    void refreshTalks();
+  }, [auth.status, refreshTalks]);
+
+  const handleTalkCreated = useCallback((talk: Talk) => {
+    setTalks((current) => {
+      const next = current.filter((item) => item.id !== talk.id);
+      return [talk, ...next];
+    });
+    setTalksError(null);
+  }, []);
+
   if (auth.status === 'loading') {
     return <main className="page-state">Checking session…</main>;
   }
@@ -61,53 +101,70 @@ export function App() {
     return <SignInView onSignedIn={refreshSession} />;
   }
 
+  const canManageSettings =
+    auth.user.role === 'owner' || auth.user.role === 'admin';
+
   return (
     <main className="app-shell">
-      <header className="app-topbar">
-        <nav className="app-nav">
-          <Link to="/app/talks">Talks</Link>
-          {auth.user.role === 'owner' || auth.user.role === 'admin' ? (
-            <Link to="/app/settings">Settings</Link>
-          ) : null}
-        </nav>
-        <div className="app-user-meta">
-          <strong>{auth.user.displayName}</strong>
-          <span>{auth.user.email}</span>
+      <ClawTalkSidebar
+        talks={talks}
+        loading={talksLoading}
+        error={talksError}
+        canManageSettings={canManageSettings}
+      />
+      <div className="app-main">
+        <header className="app-main-topbar">
+          <div className="app-user-meta">
+            <strong>{auth.user.displayName}</strong>
+            <span>{auth.user.email}</span>
+          </div>
+          <button
+            type="button"
+            className="secondary-btn"
+            onClick={handleSignOut}
+            disabled={signOutBusy}
+          >
+            Sign out
+          </button>
+        </header>
+        <div className="app-main-content">
+          <Routes>
+            <Route path="/" element={<Navigate to="/app/talks" replace />} />
+            <Route
+              path="/app/talks"
+              element={
+                <TalkListPage
+                  onUnauthorized={handleUnauthorized}
+                  externalData={{
+                    talks,
+                    loading: talksLoading,
+                    error: talksError,
+                  }}
+                  onTalkCreated={handleTalkCreated}
+                />
+              }
+            />
+            <Route
+              path="/app/talks/:talkId"
+              element={<TalkDetailPage onUnauthorized={handleUnauthorized} />}
+            />
+            <Route
+              path="/app/settings"
+              element={
+                canManageSettings ? (
+                  <SettingsPage
+                    onUnauthorized={handleUnauthorized}
+                    userRole={auth.user.role}
+                  />
+                ) : (
+                  <Navigate to="/app/talks" replace />
+                )
+              }
+            />
+            <Route path="*" element={<Navigate to="/app/talks" replace />} />
+          </Routes>
         </div>
-        <button
-          type="button"
-          className="secondary-btn"
-          onClick={handleSignOut}
-          disabled={signOutBusy}
-        >
-          Sign out
-        </button>
-      </header>
-      <Routes>
-        <Route path="/" element={<Navigate to="/app/talks" replace />} />
-        <Route
-          path="/app/talks"
-          element={<TalkListPage onUnauthorized={handleUnauthorized} />}
-        />
-        <Route
-          path="/app/talks/:talkId"
-          element={<TalkDetailPage onUnauthorized={handleUnauthorized} />}
-        />
-        <Route
-          path="/app/settings"
-          element={
-            auth.user.role === 'owner' || auth.user.role === 'admin' ? (
-              <SettingsPage
-                onUnauthorized={handleUnauthorized}
-                userRole={auth.user.role}
-              />
-            ) : (
-              <Navigate to="/app/talks" replace />
-            )
-          }
-        />
-        <Route path="*" element={<Navigate to="/app/talks" replace />} />
-      </Routes>
+      </div>
     </main>
   );
 }

--- a/webapp/src/components/ClawTalkSidebar.tsx
+++ b/webapp/src/components/ClawTalkSidebar.tsx
@@ -1,0 +1,86 @@
+import { NavLink } from 'react-router-dom';
+
+import type { Talk } from '../lib/api';
+
+type Props = {
+  talks: Talk[];
+  loading: boolean;
+  error: string | null;
+  canManageSettings: boolean;
+};
+
+function ClawTalkMark(): JSX.Element {
+  return (
+    <span className="clawtalk-sidebar-brand-mark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false">
+        <path d="M6.5 4.5c1.4 0 2.5 1.2 2.5 2.6V10l1.8-2.4c.7-.9 2-1.1 2.9-.4.9.7 1.1 2 .4 2.9l-.9 1.2h3.3c2.5 0 4.5 2 4.5 4.5v.8c0 1.4-1.1 2.5-2.5 2.5H9.6c-2.8 0-5.1-2.3-5.1-5.1V7.1c0-1.4.9-2.6 2-2.6Z" />
+      </svg>
+    </span>
+  );
+}
+
+export function ClawTalkSidebar({
+  talks,
+  loading,
+  error,
+  canManageSettings,
+}: Props): JSX.Element {
+  return (
+    <aside className="clawtalk-sidebar" aria-label="Primary navigation">
+      <div className="clawtalk-sidebar-brand">
+        <ClawTalkMark />
+        <div>
+          <strong>ClawTalk</strong>
+          <span>Talk workspace</span>
+        </div>
+      </div>
+
+      <nav className="clawtalk-sidebar-nav" aria-label="App sections">
+        <NavLink
+          to="/app/talks"
+          end
+          className={({ isActive }) =>
+            `clawtalk-sidebar-link${isActive ? ' active' : ''}`
+          }
+        >
+          Home
+        </NavLink>
+        {canManageSettings ? (
+          <NavLink
+            to="/app/settings"
+            className={({ isActive }) =>
+              `clawtalk-sidebar-link${isActive ? ' active' : ''}`
+            }
+          >
+            Settings
+          </NavLink>
+        ) : null}
+      </nav>
+
+      <div className="clawtalk-sidebar-section">
+        <div className="clawtalk-sidebar-section-label">Talks</div>
+        <div className="clawtalk-sidebar-talks" aria-label="Talk list">
+          {loading ? (
+            <p className="clawtalk-sidebar-empty">Loading talks…</p>
+          ) : error ? (
+            <p className="clawtalk-sidebar-empty">{error}</p>
+          ) : talks.length === 0 ? (
+            <p className="clawtalk-sidebar-empty">No talks yet.</p>
+          ) : (
+            talks.map((talk) => (
+              <NavLink
+                key={talk.id}
+                to={`/app/talks/${talk.id}`}
+                className={({ isActive }) =>
+                  `clawtalk-talk-link${isActive ? ' active' : ''}`
+                }
+              >
+                <span className="clawtalk-talk-link-title">{talk.title}</span>
+              </NavLink>
+            ))
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/webapp/src/pages/TalkListPage.tsx
+++ b/webapp/src/pages/TalkListPage.tsx
@@ -3,10 +3,20 @@ import { Link, useNavigate } from 'react-router-dom';
 
 import { createTalk, listTalks, Talk, UnauthorizedError } from '../lib/api';
 
+type ExternalTalkData = {
+  talks: Talk[];
+  loading: boolean;
+  error: string | null;
+};
+
 export function TalkListPage({
   onUnauthorized,
+  externalData,
+  onTalkCreated,
 }: {
   onUnauthorized: () => void;
+  externalData?: ExternalTalkData;
+  onTalkCreated?: (talk: Talk) => void;
 }): JSX.Element {
   const navigate = useNavigate();
   const [talks, setTalks] = useState<Talk[]>([]);
@@ -17,6 +27,10 @@ export function TalkListPage({
   const [createError, setCreateError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (externalData) {
+      return;
+    }
+
     let cancelled = false;
 
     const load = async () => {
@@ -43,7 +57,7 @@ export function TalkListPage({
     return () => {
       cancelled = true;
     };
-  }, [onUnauthorized]);
+  }, [externalData, onUnauthorized]);
 
   const handleCreateTalk = async (event: FormEvent) => {
     event.preventDefault();
@@ -57,6 +71,7 @@ export function TalkListPage({
     setCreateError(null);
     try {
       const talk = await createTalk(title);
+      onTalkCreated?.(talk);
       navigate(`/app/talks/${talk.id}`);
     } catch (err) {
       if (err instanceof UnauthorizedError) {
@@ -69,15 +84,19 @@ export function TalkListPage({
     }
   };
 
-  if (loading) {
+  const effectiveTalks = externalData ? externalData.talks : talks;
+  const effectiveLoading = externalData ? externalData.loading : loading;
+  const effectiveError = externalData ? externalData.error : error;
+
+  if (effectiveLoading) {
     return <p className="page-state">Loading talks…</p>;
   }
 
-  if (error) {
+  if (effectiveError) {
     return (
       <section className="page-state">
         <h2>Talks Unavailable</h2>
-        <p>{error}</p>
+        <p>{effectiveError}</p>
       </section>
     );
   }
@@ -111,11 +130,11 @@ export function TalkListPage({
         </div>
       ) : null}
 
-      {talks.length === 0 ? (
+      {effectiveTalks.length === 0 ? (
         <p className="page-state">No talks yet.</p>
       ) : (
         <ul className="talk-list">
-          {talks.map((talk) => (
+          {effectiveTalks.map((talk) => (
             <li key={talk.id}>
               <Link to={`/app/talks/${talk.id}`}>
                 <div className="talk-list-main">

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -23,31 +23,161 @@ a {
 
 .app-shell {
   min-height: 100vh;
+  display: flex;
+  align-items: stretch;
+  gap: 1rem;
   padding: 1rem;
 }
 
-.app-topbar {
+.clawtalk-sidebar {
+  width: 285px;
+  flex: 0 0 285px;
+  align-self: flex-start;
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem 0.9rem;
+  position: sticky;
+  top: 1rem;
+  max-height: calc(100vh - 2rem);
+  overflow: hidden;
+  border: 1px solid #d6dfed;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #fbfdff 0%, #f3f6fb 100%);
+  box-shadow: 0 12px 32px rgba(31, 52, 88, 0.08);
+}
+
+.clawtalk-sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.2rem 0.2rem 0.75rem;
+  border-bottom: 1px solid #e3eaf5;
+}
+
+.clawtalk-sidebar-brand strong {
+  display: block;
+  font-size: 1.2rem;
+  color: #18263d;
+}
+
+.clawtalk-sidebar-brand span {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 0.82rem;
+  color: #69758e;
+}
+
+.clawtalk-sidebar-brand-mark {
+  width: 2.35rem;
+  height: 2.35rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #2759d6 0%, #5d8bff 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.24);
+}
+
+.clawtalk-sidebar-brand-mark svg {
+  width: 1.35rem;
+  height: 1.35rem;
+  fill: #fefeff;
+}
+
+.clawtalk-sidebar-nav {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.clawtalk-sidebar-link,
+.clawtalk-talk-link {
+  display: flex;
+  align-items: center;
+  min-height: 2.7rem;
+  padding: 0.72rem 0.85rem;
+  border-radius: 12px;
+  text-decoration: none;
+  color: #31415f;
+  font-weight: 600;
+  transition:
+    background 140ms ease,
+    color 140ms ease,
+    transform 140ms ease;
+}
+
+.clawtalk-sidebar-link:hover,
+.clawtalk-talk-link:hover {
+  background: rgba(67, 104, 184, 0.08);
+  color: #173a79;
+}
+
+.clawtalk-sidebar-link.active,
+.clawtalk-talk-link.active {
+  background: linear-gradient(180deg, #edf3ff 0%, #e3ecff 100%);
+  color: #153c86;
+  box-shadow: inset 0 0 0 1px #cbd9fb;
+}
+
+.clawtalk-sidebar-section {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  overflow: hidden;
+}
+
+.clawtalk-sidebar-section-label {
+  padding: 0 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #7a86a0;
+}
+
+.clawtalk-sidebar-talks {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  gap: 0.28rem;
+  overflow-y: auto;
+  padding-right: 0.15rem;
+}
+
+.clawtalk-talk-link-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.clawtalk-sidebar-empty {
+  margin: 0;
+  padding: 0.3rem 0.85rem;
+  color: #66728d;
+  font-size: 0.9rem;
+}
+
+.app-main {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.app-main-topbar {
+  display: flex;
+  justify-content: flex-end;
   align-items: center;
   gap: 1rem;
-  margin-bottom: 1rem;
 }
 
-.app-nav {
-  display: flex;
-  gap: 0.75rem;
-  align-items: center;
-}
-
-.app-nav a {
-  text-decoration: none;
-  font-weight: 600;
-  color: #163c78;
-}
-
-.app-nav a:hover {
-  text-decoration: underline;
+.app-main-content {
+  min-width: 0;
+  display: grid;
+  align-content: start;
 }
 
 .app-user-meta {
@@ -195,6 +325,26 @@ a {
   gap: 0.75rem;
   align-items: center;
   flex-wrap: wrap;
+}
+
+.settings-status-grid {
+  margin-top: 1rem;
+}
+
+.settings-standby-list {
+  margin: 1rem 0;
+}
+
+.settings-standby-list ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.2rem;
+}
+
+.settings-button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
 }
 
 .talk-llm-editor {
@@ -377,12 +527,14 @@ a {
 }
 
 .page-shell {
-  max-width: 980px;
-  margin: 0 auto;
+  width: 100%;
+  max-width: none;
+  margin: 0;
   background: #fff;
   border: 1px solid #d8dfec;
   border-radius: 14px;
   padding: 1rem;
+  box-shadow: 0 12px 30px rgba(31, 52, 88, 0.06);
 }
 
 .talk-detail-shell {
@@ -803,10 +955,32 @@ a {
   color: #1f6e3e;
 }
 
-@media (max-width: 720px) {
-  .app-topbar {
+@media (max-width: 960px) {
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .clawtalk-sidebar {
+    width: 100%;
+    flex-basis: auto;
+    position: static;
+    max-height: none;
+  }
+
+  .clawtalk-sidebar-talks {
+    max-height: 240px;
+  }
+
+  .app-main-topbar {
+    justify-content: space-between;
     align-items: flex-start;
     flex-direction: column;
+  }
+}
+
+@media (max-width: 720px) {
+  .clawtalk-sidebar-brand {
+    padding-bottom: 0.6rem;
   }
 
   .page-header {


### PR DESCRIPTION
## Summary
- add a persistent ClawTalk sidebar modeled on the Rocketboard navigation pattern
- move Home and Settings into the sidebar and surface the full talk list there for fast navigation
- keep the main talk list and sidebar in sync from shared app-level talk state
- fix sidebar scroll containment and remove unnecessary talk-list refetches on every route change
- harden App tests to use URL-aware fetch mocks instead of queue-order assumptions

## What Changed
- add a new sidebar component:
  - `webapp/src/components/ClawTalkSidebar.tsx`
- rework the app shell to use a sidebar + main-content layout:
  - `webapp/src/App.tsx`
- pass shared talk data into the talks page so the sidebar and main list stay aligned:
  - `webapp/src/pages/TalkListPage.tsx`
- add sidebar styling, sticky desktop behavior, and internal talk-list scrolling:
  - `webapp/src/styles.css`
- update app-shell tests for the new navigation and fetch behavior:
  - `webapp/src/App.test.tsx`

## UX Changes
- top-left brand now shows `ClawTalk`
- top navigation includes:
  - `Home`
  - `Settings`
- sidebar section label is `Talks`
- each talk title in the sidebar links directly to that talk
- long talk lists scroll inside the sidebar instead of stretching the page

## Validation
- `npm --prefix webapp run typecheck`
- `npm --prefix webapp run test`
