### PR TITLE
feat(settings): add subscription host import flow

### DIFF
--- a/src/clawrocket/talks/executor-credentials-verifier.test.ts
+++ b/src/clawrocket/talks/executor-credentials-verifier.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { _initTestDatabase, upsertUser } from '../db/index.js';
+
+import { ExecutorCredentialVerifier } from './executor-credentials-verifier.js';
+import { ExecutorSettingsService } from './executor-settings.js';
+
+function createService(): ExecutorSettingsService {
+  return new ExecutorSettingsService();
+}
+
+describe('ExecutorCredentialVerifier', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    vi.restoreAllMocks();
+    upsertUser({
+      id: 'owner-1',
+      email: 'owner@example.com',
+      displayName: 'Owner',
+      role: 'owner',
+    });
+  });
+
+  it('passes only the selected subscription credential and chosen model into verification', async () => {
+    const service = createService();
+    service.saveExecutorConfig(
+      {
+        executorAuthMode: 'subscription',
+        claudeOauthToken: 'oauth-subscription',
+        anthropicApiKey: 'sk-standby',
+        aliasModelMap: { Gemini: 'claude-subscription-model' },
+        defaultAlias: 'Gemini',
+      },
+      'owner-1',
+    );
+
+    const runContainer = vi.fn(
+      async (
+        _group: unknown,
+        _input: { model?: string; secrets?: Record<string, string> },
+      ) => ({
+        status: 'success' as const,
+        result: 'OK',
+      }),
+    );
+
+    const verifier = new ExecutorCredentialVerifier({
+      executorSettings: service,
+      runContainer,
+    });
+
+    const scheduled = verifier.scheduleVerification('subscription');
+    expect(scheduled.scheduled).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(runContainer).toHaveBeenCalledTimes(1);
+    });
+    await vi.waitFor(() => {
+      expect(service.getSettingsView().verificationStatus).toBe('verified');
+    });
+
+    const containerInput = runContainer.mock.calls[0]?.[1];
+    expect(containerInput).toBeDefined();
+    if (!containerInput) {
+      throw new Error(
+        'Expected subscription verification to call runContainer',
+      );
+    }
+    expect(containerInput.model).toBe('claude-subscription-model');
+    expect(containerInput.secrets).toEqual({
+      CLAUDE_CODE_OAUTH_TOKEN: 'oauth-subscription',
+    });
+  });
+
+  it('classifies token-budget failures as unavailable instead of invalid auth', async () => {
+    const service = createService();
+    service.saveExecutorConfig(
+      {
+        executorAuthMode: 'subscription',
+        claudeOauthToken: 'oauth-subscription',
+      },
+      'owner-1',
+    );
+
+    const verifier = new ExecutorCredentialVerifier({
+      executorSettings: service,
+      runContainer: vi.fn(async () => ({
+        status: 'error' as const,
+        result: null,
+        error: 'Context token limit exceeded during verification.',
+      })),
+    });
+
+    verifier.scheduleVerification('subscription');
+
+    await vi.waitFor(() => {
+      expect(service.getSettingsView().verificationStatus).toBe('unavailable');
+    });
+
+    expect(service.getSettingsView().lastVerificationError).toBe(
+      'Context token limit exceeded during verification.',
+    );
+  });
+});

--- a/src/clawrocket/talks/executor-credentials-verifier.ts
+++ b/src/clawrocket/talks/executor-credentials-verifier.ts
@@ -1,0 +1,412 @@
+import type { ChildProcess } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+
+import { DATA_DIR } from '../../config.js';
+import {
+  runContainerAgent,
+  type ContainerOutput,
+} from '../../container-runner.js';
+import {
+  resolveGroupFolderPath,
+  resolveGroupIpcPath,
+} from '../../group-folder.js';
+import { logger } from '../../logger.js';
+import type { RegisteredGroup } from '../../types.js';
+
+import type {
+  ExecutorAuthMode,
+  ExecutorSettingsService,
+  ExecutorVerificationTarget,
+  VerifiableExecutorAuthMode,
+} from './executor-settings.js';
+
+const HTTP_VERIFY_TIMEOUT_MS = 5_000;
+const SUBSCRIPTION_VERIFY_TIMEOUT_MS = 60_000;
+const DEFAULT_ANTHROPIC_BASE_URL = 'https://api.anthropic.com';
+
+type VerificationResult = {
+  status: 'verified' | 'invalid' | 'unavailable';
+  error?: string | null;
+};
+
+export interface ExecutorCredentialVerificationSchedule {
+  scheduled: boolean;
+  mode: ExecutorAuthMode;
+  code:
+    | 'scheduled'
+    | 'already_verifying'
+    | 'selection_required'
+    | 'missing_credential'
+    | 'mode_none';
+  message: string;
+}
+
+interface InFlightVerification {
+  fingerprint: string;
+  promise: Promise<void>;
+}
+
+export class ExecutorCredentialVerifier {
+  private readonly executorSettings: ExecutorSettingsService;
+  private readonly fetchImpl: typeof fetch;
+  private readonly runContainer: typeof runContainerAgent;
+  private readonly inFlight = new Map<
+    VerifiableExecutorAuthMode,
+    InFlightVerification
+  >();
+
+  constructor(input: {
+    executorSettings: ExecutorSettingsService;
+    fetchImpl?: typeof fetch;
+    runContainer?: typeof runContainerAgent;
+  }) {
+    this.executorSettings = input.executorSettings;
+    this.fetchImpl = input.fetchImpl || fetch;
+    this.runContainer = input.runContainer || runContainerAgent;
+  }
+
+  scheduleVerification(
+    requestedMode?: ExecutorAuthMode,
+  ): ExecutorCredentialVerificationSchedule {
+    const selectedMode =
+      requestedMode || this.executorSettings.getSettingsView().executorAuthMode;
+    const target = this.executorSettings.getVerificationTarget(requestedMode);
+
+    if (!target) {
+      const blockedReason = this.executorSettings.getExecutionBlockedReason();
+      if (selectedMode === 'none') {
+        return {
+          scheduled: false,
+          mode: selectedMode,
+          code: 'mode_none',
+          message:
+            blockedReason ||
+            'Select an Anthropic auth mode before requesting verification.',
+        };
+      }
+      return {
+        scheduled: false,
+        mode: selectedMode,
+        code: blockedReason?.includes('Multiple Anthropic credential types')
+          ? 'selection_required'
+          : 'missing_credential',
+        message:
+          blockedReason ||
+          'The selected Anthropic auth mode has no configured credential to verify.',
+      };
+    }
+
+    const existing = this.inFlight.get(target.mode);
+    if (existing && existing.fingerprint === target.fingerprint) {
+      return {
+        scheduled: false,
+        mode: target.mode,
+        code: 'already_verifying',
+        message: 'A verification attempt is already in progress for this mode.',
+      };
+    }
+
+    this.executorSettings.markVerificationStarted(
+      target.mode,
+      target.fingerprint,
+    );
+
+    const promise = this.performVerification(target)
+      .then((result) => {
+        this.executorSettings.completeVerification(
+          target.mode,
+          target.fingerprint,
+          result,
+        );
+      })
+      .catch((error) => {
+        logger.warn(
+          { err: error, mode: target.mode },
+          'Unexpected executor credential verification failure',
+        );
+        this.executorSettings.completeVerification(
+          target.mode,
+          target.fingerprint,
+          {
+            status: 'unavailable',
+            error:
+              error instanceof Error
+                ? error.message
+                : 'Verification failed unexpectedly.',
+          },
+        );
+      })
+      .finally(() => {
+        const current = this.inFlight.get(target.mode);
+        if (current?.fingerprint === target.fingerprint) {
+          this.inFlight.delete(target.mode);
+        }
+      });
+
+    this.inFlight.set(target.mode, {
+      fingerprint: target.fingerprint,
+      promise,
+    });
+
+    return {
+      scheduled: true,
+      mode: target.mode,
+      code: 'scheduled',
+      message: 'Verification started.',
+    };
+  }
+
+  private async performVerification(
+    target: ExecutorVerificationTarget,
+  ): Promise<VerificationResult> {
+    switch (target.mode) {
+      case 'subscription':
+        return this.verifySubscription(target);
+      case 'api_key':
+      case 'advanced_bearer':
+        return this.verifyHttpCredential(target);
+    }
+  }
+
+  private async verifyHttpCredential(
+    target: ExecutorVerificationTarget,
+  ): Promise<VerificationResult> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+      controller.abort('verification_timeout');
+    }, HTTP_VERIFY_TIMEOUT_MS);
+
+    try {
+      const endpoint = resolveAnthropicEndpoint(
+        target.anthropicBaseUrl,
+        '/v1/models',
+      );
+      const headers: Record<string, string> = {
+        accept: 'application/json',
+        'anthropic-version': '2023-06-01',
+      };
+      if (target.mode === 'api_key') {
+        headers['x-api-key'] = target.credential;
+      }
+      if (target.mode === 'advanced_bearer') {
+        headers.authorization = `Bearer ${target.credential}`;
+      }
+
+      const response = await this.fetchImpl(endpoint, {
+        method: 'GET',
+        headers,
+        signal: controller.signal,
+      });
+      const failureMessage = await readFailureMessage(response);
+
+      if (response.ok) {
+        return { status: 'verified' };
+      }
+      if (
+        response.status === 400 ||
+        response.status === 401 ||
+        response.status === 403
+      ) {
+        return {
+          status: 'invalid',
+          error:
+            failureMessage || 'The provider rejected the selected credential.',
+        };
+      }
+      return {
+        status: 'unavailable',
+        error:
+          failureMessage ||
+          `Verification endpoint returned HTTP ${response.status}.`,
+      };
+    } catch (error) {
+      return {
+        status: 'unavailable',
+        error:
+          error instanceof Error && error.name === 'AbortError'
+            ? 'Verification timed out before the provider responded.'
+            : error instanceof Error
+              ? error.message
+              : 'Verification failed before the provider could be reached.',
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private async verifySubscription(
+    target: ExecutorVerificationTarget,
+  ): Promise<VerificationResult> {
+    const folder = buildVerificationFolder();
+    const group: RegisteredGroup = {
+      name: 'Executor Subscription Verification',
+      folder,
+      trigger: '@verify',
+      added_at: new Date().toISOString(),
+      requiresTrigger: false,
+      isMain: false,
+    };
+
+    const chunks: string[] = [];
+    let processRef: ChildProcess | null = null;
+    let timeout: NodeJS.Timeout | null = null;
+
+    try {
+      const verificationPromise = this.runContainer(
+        group,
+        {
+          prompt: 'Reply with OK and nothing else.',
+          model: target.model,
+          toolProfile: 'web_talk',
+          groupFolder: folder,
+          chatJid: `verify:${folder}`,
+          isMain: false,
+          assistantName: 'ClawRocket Verify',
+          secrets: buildVerificationSecrets(target),
+        },
+        (proc) => {
+          processRef = proc;
+        },
+        async (output: ContainerOutput) => {
+          if (output.result) {
+            chunks.push(output.result);
+          }
+        },
+      );
+
+      const timeoutPromise = new Promise<ContainerOutput>((resolve) => {
+        timeout = setTimeout(() => {
+          if (processRef && !processRef.killed) {
+            processRef.kill('SIGTERM');
+          }
+          resolve({
+            status: 'error',
+            result: null,
+            error: 'Subscription verification timed out.',
+          });
+        }, SUBSCRIPTION_VERIFY_TIMEOUT_MS);
+      });
+
+      const result = await Promise.race([verificationPromise, timeoutPromise]);
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+
+      if (result.status === 'success') {
+        return { status: 'verified' };
+      }
+
+      const message =
+        result.error?.trim() ||
+        chunks.join('\n').trim() ||
+        'Subscription verification failed.';
+      if (looksLikeAuthFailure(message)) {
+        return { status: 'invalid', error: message };
+      }
+      return {
+        status: 'unavailable',
+        error: message,
+      };
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Subscription verification could not be completed.';
+      return {
+        status: looksLikeAuthFailure(message) ? 'invalid' : 'unavailable',
+        error: message,
+      };
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      await cleanupVerificationArtifacts(folder);
+    }
+  }
+}
+
+function buildVerificationFolder(): string {
+  return `executorverify${randomUUID().replace(/-/g, '').slice(0, 12)}`;
+}
+
+function resolveAnthropicEndpoint(baseUrl: string, pathname: string): string {
+  const url = new URL(baseUrl || DEFAULT_ANTHROPIC_BASE_URL);
+  const basePath = url.pathname.endsWith('/')
+    ? url.pathname.slice(0, -1)
+    : url.pathname;
+  url.pathname = `${basePath}${pathname.startsWith('/') ? pathname : `/${pathname}`}`;
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}
+
+async function readFailureMessage(response: Response): Promise<string | null> {
+  const text = await response.text();
+  if (!text.trim()) return null;
+  try {
+    const parsed = JSON.parse(text) as {
+      error?: { message?: string };
+      message?: string;
+    };
+    return parsed.error?.message || parsed.message || text;
+  } catch {
+    return text;
+  }
+}
+
+function looksLikeAuthFailure(message: string): boolean {
+  return [
+    /invalid (api key|authentication|auth|oauth|token)/i,
+    /authentication (failed|required)/i,
+    /auth(entication)? failed/i,
+    /unauthori[sz]ed/i,
+    /forbidden/i,
+    /login (failed|required)/i,
+    /credential(s)? (invalid|missing|rejected)/i,
+    /subscription (expired|invalid|required)/i,
+    /\b401\b/,
+    /\b403\b/,
+  ].some((pattern) => pattern.test(message));
+}
+
+function buildVerificationSecrets(
+  target: ExecutorVerificationTarget,
+): Record<string, string> {
+  if (target.mode === 'subscription') {
+    return {
+      CLAUDE_CODE_OAUTH_TOKEN: target.credential,
+    };
+  }
+  if (target.mode === 'api_key') {
+    return {
+      ANTHROPIC_API_KEY: target.credential,
+      ANTHROPIC_BASE_URL: target.anthropicBaseUrl,
+    };
+  }
+  return {
+    ANTHROPIC_AUTH_TOKEN: target.credential,
+    ANTHROPIC_BASE_URL: target.anthropicBaseUrl,
+  };
+}
+
+async function cleanupVerificationArtifacts(folder: string): Promise<void> {
+  const paths = [
+    resolveGroupFolderPath(folder),
+    path.join(DATA_DIR, 'sessions', folder),
+    resolveGroupIpcPath(folder),
+  ];
+
+  for (const target of paths) {
+    try {
+      await fs.promises.rm(target, { recursive: true, force: true });
+    } catch (error) {
+      logger.debug(
+        { err: error, path: target, folder },
+        'Failed to clean temporary verification artifacts',
+      );
+    }
+  }
+}

--- a/src/clawrocket/talks/executor-settings.test.ts
+++ b/src/clawrocket/talks/executor-settings.test.ts
@@ -51,6 +51,9 @@ describe('ExecutorSettingsService', () => {
     expect(saved.hasApiKey).toBe(true);
     expect(saved.hasOauthToken).toBe(false);
     expect(saved.hasAuthToken).toBe(false);
+    expect(saved.executorAuthMode).toBe('api_key');
+    expect(saved.activeCredentialConfigured).toBe(true);
+    expect(saved.verificationStatus).toBe('not_verified');
     expect(saved.anthropicBaseUrl).toBe('https://api.example.test');
     expect(saved.defaultAlias).toBe('Gemini');
     expect(saved.configVersion).toBe(1);
@@ -59,7 +62,6 @@ describe('ExecutorSettingsService', () => {
       displayName: 'Owner',
     });
     expect(saved.lastUpdatedAt).not.toBeNull();
-    expect(service.resolveDetectedAuthMethod()).toBe('api_key');
 
     expect(service.getExecutorSecrets()).toEqual({
       ANTHROPIC_API_KEY: 'sk-test',
@@ -117,6 +119,7 @@ describe('ExecutorSettingsService', () => {
     expect(view.effectiveAliasMap.Gemini).toBe('gemini-pro');
     expect(view.anthropicBaseUrl).toBe('https://bootstrap.example.test');
     expect(view.hasApiKey).toBe(true);
+    expect(view.executorAuthMode).toBe('api_key');
     expect(view.configVersion).toBe(1);
     expect(view.lastUpdatedBy).toBeNull();
   });
@@ -284,6 +287,136 @@ describe('ExecutorSettingsService', () => {
         'owner-1',
       ),
     ).toThrowError(ExecutorSettingsValidationError);
+  });
+
+  it('exports only the selected Anthropic auth mode when standby credentials are stored', () => {
+    const service = createService();
+
+    service.saveExecutorConfig(
+      {
+        claudeOauthToken: 'oauth-test',
+        anthropicApiKey: 'sk-test',
+        executorAuthMode: 'subscription',
+        aliasModelMap: { Gemini: 'gemini-pro' },
+        defaultAlias: 'Gemini',
+      },
+      'owner-1',
+    );
+
+    expect(service.getExecutorSecrets()).toEqual({
+      CLAUDE_CODE_OAUTH_TOKEN: 'oauth-test',
+    });
+
+    service.saveExecutorConfig(
+      {
+        executorAuthMode: 'api_key',
+      },
+      'owner-1',
+    );
+
+    expect(service.getExecutorSecrets()).toEqual({
+      ANTHROPIC_API_KEY: 'sk-test',
+    });
+  });
+
+  it('makes imported subscription credentials immediately available to verification', () => {
+    const service = createService();
+
+    const imported = service.importSubscriptionCredential(
+      'oauth-imported',
+      'owner-1',
+    );
+
+    expect(imported.status).toBe('imported');
+    expect(imported.settings.executorAuthMode).toBe('subscription');
+    expect(service.getExecutorSecrets()).toEqual({
+      CLAUDE_CODE_OAUTH_TOKEN: 'oauth-imported',
+    });
+
+    const target = service.getVerificationTarget('subscription');
+    expect(target?.mode).toBe('subscription');
+    expect(target?.credential).toBe('oauth-imported');
+  });
+
+  it('requires explicit selection when auth token is mixed with another credential', () => {
+    const now = new Date().toISOString();
+    getDb()
+      .prepare(
+        `
+        INSERT INTO settings_kv (key, value, updated_at, updated_by)
+        VALUES (?, ?, ?, ?)
+      `,
+      )
+      .run('executor.anthropicApiKey', 'sk-test', now, null);
+    getDb()
+      .prepare(
+        `
+        INSERT INTO settings_kv (key, value, updated_at, updated_by)
+        VALUES (?, ?, ?, ?)
+      `,
+      )
+      .run('executor.anthropicAuthToken', 'bearer-test', now, null);
+    getDb()
+      .prepare(
+        `
+        INSERT INTO settings_kv (key, value, updated_at, updated_by)
+        VALUES (?, ?, ?, ?)
+      `,
+      )
+      .run('executor.configOwned', 'true', now, null);
+
+    const service = createService();
+    const view = service.getSettingsView();
+
+    expect(view.executorAuthMode).toBe('none');
+    expect(view.activeCredentialConfigured).toBe(false);
+    expect(view.configErrors).toContain(
+      'Multiple Anthropic credential types are stored. Select an active auth mode before running the core executor.',
+    );
+  });
+
+  it('resets stale verifying state on read', () => {
+    const service = createService();
+    service.saveExecutorConfig(
+      {
+        anthropicApiKey: 'sk-test',
+        executorAuthMode: 'api_key',
+        aliasModelMap: { Gemini: 'gemini-pro' },
+        defaultAlias: 'Gemini',
+      },
+      'owner-1',
+    );
+    const target = service.getVerificationTarget('api_key');
+    expect(target).not.toBeNull();
+
+    const staleStartedAt = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    getDb()
+      .prepare(
+        `
+        UPDATE settings_kv
+        SET value = ?, updated_at = ?
+        WHERE key = 'executor.authVerification'
+      `,
+      )
+      .run(
+        JSON.stringify({
+          api_key: {
+            status: 'verifying',
+            fingerprint: target!.fingerprint,
+            verificationStartedAt: staleStartedAt,
+            lastVerifiedAt: null,
+            lastVerificationError: null,
+          },
+        }),
+        staleStartedAt,
+      );
+
+    const view = service.getSettingsView();
+
+    expect(view.verificationStatus).toBe('not_verified');
+    expect(view.lastVerificationError).toBe(
+      'Previous verification attempt expired before completion.',
+    );
   });
 
   it('surfaces config errors for corrupted owned config and metadata without user FK', () => {

--- a/src/clawrocket/talks/executor-settings.ts
+++ b/src/clawrocket/talks/executor-settings.ts
@@ -11,6 +11,7 @@ import {
   TALK_EXECUTOR_DEFAULT_ALIAS,
 } from '../config.js';
 import { countRunningTalkRuns } from '../db/index.js';
+import { fingerprintStableJson, stableJson } from './json-fingerprint.js';
 
 export const EXECUTOR_COMPATIBILITY_ALIAS_MODEL_SEEDS: Record<string, string> =
   {
@@ -23,12 +24,26 @@ export const EXECUTOR_COMPATIBILITY_ALIAS_MODEL_SEEDS: Record<string, string> =
   };
 
 type SettingSource = 'db' | 'bootstrap' | 'none';
-export type DetectedAuthMethod = 'oauth' | 'api_key' | 'auth_token' | 'none';
+export type ExecutorAuthMode =
+  | 'subscription'
+  | 'api_key'
+  | 'advanced_bearer'
+  | 'none';
+export type ExecutorVerificationStatus =
+  | 'missing'
+  | 'not_verified'
+  | 'verifying'
+  | 'verified'
+  | 'invalid'
+  | 'unavailable';
+export type VerifiableExecutorAuthMode = Exclude<ExecutorAuthMode, 'none'>;
 
 const EXECUTOR_SETTINGS_PREFIX = 'executor.';
 const EXECUTOR_KEY_API_KEY = 'executor.anthropicApiKey';
 const EXECUTOR_KEY_OAUTH_TOKEN = 'executor.claudeOauthToken';
 const EXECUTOR_KEY_AUTH_TOKEN = 'executor.anthropicAuthToken';
+const EXECUTOR_KEY_AUTH_MODE = 'executor.authMode';
+const EXECUTOR_KEY_AUTH_VERIFICATION = 'executor.authVerification';
 const EXECUTOR_KEY_BASE_URL = 'executor.anthropicBaseUrl';
 const EXECUTOR_KEY_ALIAS_MODEL_MAP = 'executor.aliasModelMap';
 const EXECUTOR_KEY_DEFAULT_ALIAS = 'executor.defaultAlias';
@@ -36,7 +51,14 @@ const EXECUTOR_KEY_CONFIG_VERSION = 'executor.configVersion';
 const EXECUTOR_KEY_CONFIG_OWNED = 'executor.configOwned';
 
 const DEFAULT_EXECUTOR_ALIAS = 'Mock';
+const DEFAULT_ANTHROPIC_BASE_URL = 'https://api.anthropic.com';
 const SELF_RESTART_ENV = 'CLAWROCKET_SELF_RESTART';
+const VERIFICATION_STALE_MS = 2 * 60 * 1000;
+const VERIFIABLE_EXECUTOR_AUTH_MODES: VerifiableExecutorAuthMode[] = [
+  'subscription',
+  'api_key',
+  'advanced_bearer',
+];
 
 const PROCESS_BOOT_ID = randomUUID();
 
@@ -62,10 +84,30 @@ interface StoredRows {
   apiKey: string | null;
   oauthToken: string | null;
   authToken: string | null;
+  authMode: ExecutorAuthMode | null;
+  authVerificationJson: string | null;
   baseUrl: string | null;
   aliasModelMapJson: string | null;
   defaultAlias: string | null;
 }
+
+interface AuthModeResolution {
+  mode: ExecutorAuthMode;
+  needsExplicitSelection: boolean;
+  inferred: boolean;
+}
+
+interface VerificationStateRecord {
+  status: 'not_verified' | 'verifying' | 'verified' | 'invalid' | 'unavailable';
+  fingerprint: string | null;
+  verificationStartedAt: string | null;
+  lastVerifiedAt: string | null;
+  lastVerificationError: string | null;
+}
+
+type VerificationStateMap = Partial<
+  Record<VerifiableExecutorAuthMode, VerificationStateRecord>
+>;
 
 interface ParsedAliasMapResult {
   aliasMap: Record<string, string>;
@@ -85,11 +127,16 @@ export interface ResolvedExecutorConfig {
   configuredAliasMap: Record<string, string>;
   effectiveAliasMap: Record<string, string>;
   defaultAlias: string;
+  executorAuthMode: ExecutorAuthMode;
   anthropicBaseUrl: string;
   configOwned: boolean;
   configVersion: number;
+  activeCredentialConfigured: boolean;
   hasProviderAuth: boolean;
   hasValidAliasMap: boolean;
+  verificationStatus: ExecutorVerificationStatus;
+  lastVerifiedAt: string | null;
+  lastVerificationError: string | null;
   configErrors: string[];
   sources: SettingSources;
 }
@@ -114,9 +161,14 @@ export interface ExecutorSettingsView {
   configuredAliasMap: Record<string, string>;
   effectiveAliasMap: Record<string, string>;
   defaultAlias: string;
+  executorAuthMode: ExecutorAuthMode;
   hasApiKey: boolean;
   hasOauthToken: boolean;
   hasAuthToken: boolean;
+  activeCredentialConfigured: boolean;
+  verificationStatus: ExecutorVerificationStatus;
+  lastVerifiedAt: string | null;
+  lastVerificationError: string | null;
   anthropicBaseUrl: string;
   isConfigured: boolean;
   configVersion: number;
@@ -130,9 +182,13 @@ export interface ExecutorStatusView {
   restartSupported: boolean;
   pendingRestartReasons: string[];
   activeRunCount: number;
+  executorAuthMode: ExecutorAuthMode;
+  activeCredentialConfigured: boolean;
+  verificationStatus: ExecutorVerificationStatus;
+  lastVerifiedAt: string | null;
+  lastVerificationError: string | null;
   hasProviderAuth: boolean;
   hasValidAliasMap: boolean;
-  detectedAuthMethod: DetectedAuthMethod;
   configVersion: number;
   isConfigured: boolean;
   bootId: string;
@@ -140,12 +196,26 @@ export interface ExecutorStatusView {
 }
 
 export interface ExecutorConfigUpdate {
+  executorAuthMode?: ExecutorAuthMode;
   anthropicApiKey?: string | null;
   claudeOauthToken?: string | null;
   anthropicAuthToken?: string | null;
   anthropicBaseUrl?: string | null;
   aliasModelMap?: Record<string, string>;
   defaultAlias?: string;
+}
+
+export interface ExecutorVerificationTarget {
+  mode: VerifiableExecutorAuthMode;
+  fingerprint: string;
+  anthropicBaseUrl: string;
+  credential: string;
+  model: string;
+}
+
+export interface ExecutorSubscriptionImportResult {
+  status: 'imported' | 'no_change';
+  settings: ExecutorSettingsView;
 }
 
 export class ExecutorSettingsValidationError extends Error {
@@ -200,22 +270,236 @@ function parseAliasModelMapJson(rawJson: string | null): ParsedAliasMapResult {
   }
 }
 
-function stableJson(value: unknown): string {
-  if (!value || typeof value !== 'object') {
-    return JSON.stringify(value);
-  }
-  return JSON.stringify(value, Object.keys(value as object).sort());
-}
-
 function normalizeUrl(value: string | null | undefined): string {
   return (value || '').trim();
 }
 
-function detectAuthMethod(rows: StoredRows): DetectedAuthMethod {
-  if (rows.oauthToken) return 'oauth';
-  if (rows.apiKey) return 'api_key';
-  if (rows.authToken) return 'auth_token';
-  return 'none';
+function isExecutorAuthMode(value: string | null): value is ExecutorAuthMode {
+  return (
+    value === 'subscription' ||
+    value === 'api_key' ||
+    value === 'advanced_bearer' ||
+    value === 'none'
+  );
+}
+
+function usesCustomBaseUrl(mode: ExecutorAuthMode): boolean {
+  return mode === 'api_key' || mode === 'advanced_bearer';
+}
+
+function getModeCredential(
+  mode: ExecutorAuthMode,
+  rows: Pick<StoredRows, 'apiKey' | 'oauthToken' | 'authToken'>,
+): string | null {
+  switch (mode) {
+    case 'subscription':
+      return rows.oauthToken;
+    case 'api_key':
+      return rows.apiKey;
+    case 'advanced_bearer':
+      return rows.authToken;
+    default:
+      return null;
+  }
+}
+
+function resolveAuthMode(rows: StoredRows): AuthModeResolution {
+  if (rows.authMode && isExecutorAuthMode(rows.authMode)) {
+    return {
+      mode: rows.authMode,
+      needsExplicitSelection: false,
+      inferred: false,
+    };
+  }
+
+  const hasApiKey = Boolean(rows.apiKey);
+  const hasOauthToken = Boolean(rows.oauthToken);
+  const hasAuthToken = Boolean(rows.authToken);
+
+  if (hasAuthToken && (hasApiKey || hasOauthToken)) {
+    return {
+      mode: 'none',
+      needsExplicitSelection: true,
+      inferred: false,
+    };
+  }
+
+  // Deliberately prefer API-key mode when both API key and OAuth are stored.
+  // This matches Claude Code behavior where API-key auth takes precedence over
+  // subscription auth when both credential types are configured.
+  if (hasApiKey) {
+    return {
+      mode: 'api_key',
+      needsExplicitSelection: false,
+      inferred: true,
+    };
+  }
+
+  if (hasOauthToken) {
+    return {
+      mode: 'subscription',
+      needsExplicitSelection: false,
+      inferred: true,
+    };
+  }
+
+  if (hasAuthToken) {
+    return {
+      mode: 'advanced_bearer',
+      needsExplicitSelection: false,
+      inferred: true,
+    };
+  }
+
+  return {
+    mode: 'none',
+    needsExplicitSelection: false,
+    inferred: false,
+  };
+}
+
+function fingerprint(input: unknown): string {
+  return fingerprintStableJson(input);
+}
+
+function computeModeFingerprint(
+  mode: VerifiableExecutorAuthMode,
+  rows: Pick<StoredRows, 'apiKey' | 'oauthToken' | 'authToken' | 'baseUrl'>,
+): string | null {
+  const credential = getModeCredential(mode, rows);
+  if (!credential) return null;
+  return fingerprint({
+    mode,
+    credential,
+    baseUrl: usesCustomBaseUrl(mode) ? normalizeUrl(rows.baseUrl) : '',
+  });
+}
+
+function createNotVerifiedState(
+  fingerprintValue: string,
+  previous?: VerificationStateRecord,
+): VerificationStateRecord {
+  return {
+    status: 'not_verified',
+    fingerprint: fingerprintValue,
+    verificationStartedAt: null,
+    lastVerifiedAt: previous?.lastVerifiedAt ?? null,
+    lastVerificationError: null,
+  };
+}
+
+function normalizeVerificationRecord(
+  raw: unknown,
+): VerificationStateRecord | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+
+  const candidate = raw as Record<string, unknown>;
+  const status = candidate.status;
+  if (
+    status !== 'not_verified' &&
+    status !== 'verifying' &&
+    status !== 'verified' &&
+    status !== 'invalid' &&
+    status !== 'unavailable'
+  ) {
+    return null;
+  }
+
+  return {
+    status,
+    fingerprint:
+      typeof candidate.fingerprint === 'string' ? candidate.fingerprint : null,
+    verificationStartedAt:
+      typeof candidate.verificationStartedAt === 'string'
+        ? candidate.verificationStartedAt
+        : null,
+    lastVerifiedAt:
+      typeof candidate.lastVerifiedAt === 'string'
+        ? candidate.lastVerifiedAt
+        : null,
+    lastVerificationError:
+      typeof candidate.lastVerificationError === 'string'
+        ? candidate.lastVerificationError
+        : null,
+  };
+}
+
+function parseVerificationStateJson(
+  rawJson: string | null,
+): VerificationStateMap {
+  if (!rawJson || !rawJson.trim()) return {};
+
+  try {
+    const parsed = JSON.parse(rawJson) as Record<string, unknown>;
+    const next: VerificationStateMap = {};
+    for (const mode of VERIFIABLE_EXECUTOR_AUTH_MODES) {
+      const record = normalizeVerificationRecord(parsed[mode]);
+      if (record) {
+        next[mode] = record;
+      }
+    }
+    return next;
+  } catch {
+    return {};
+  }
+}
+
+function stringifyVerificationState(
+  state: VerificationStateMap,
+): string | null {
+  const normalized = Object.fromEntries(
+    VERIFIABLE_EXECUTOR_AUTH_MODES.flatMap((mode) =>
+      state[mode] ? [[mode, state[mode]]] : [],
+    ),
+  );
+  return Object.keys(normalized).length > 0 ? JSON.stringify(normalized) : null;
+}
+
+function deriveVerificationStatus(
+  mode: ExecutorAuthMode,
+  rows: StoredRows,
+  state: VerificationStateMap,
+): {
+  activeCredentialConfigured: boolean;
+  verificationStatus: ExecutorVerificationStatus;
+  lastVerifiedAt: string | null;
+  lastVerificationError: string | null;
+} {
+  if (mode === 'none') {
+    return {
+      activeCredentialConfigured: false,
+      verificationStatus: 'missing',
+      lastVerifiedAt: null,
+      lastVerificationError: null,
+    };
+  }
+
+  const credential = getModeCredential(mode, rows);
+  if (!credential) {
+    return {
+      activeCredentialConfigured: false,
+      verificationStatus: 'missing',
+      lastVerifiedAt: null,
+      lastVerificationError: null,
+    };
+  }
+
+  const record = state[mode];
+  if (!record) {
+    return {
+      activeCredentialConfigured: true,
+      verificationStatus: 'not_verified',
+      lastVerifiedAt: null,
+      lastVerificationError: null,
+    };
+  }
+
+  return {
+    activeCredentialConfigured: true,
+    verificationStatus: record.status,
+    lastVerifiedAt: record.lastVerifiedAt,
+    lastVerificationError: record.lastVerificationError,
+  };
 }
 
 function snapshotMode(config: ResolvedExecutorConfig): 'real' | 'mock' {
@@ -250,6 +534,11 @@ export class ExecutorSettingsService {
   private runningSnapshot: RunningConfigSnapshot | null = null;
   private readonly bootstrapConfig: BootstrapExecutorConfig;
   private readonly startupAnchorMs: number;
+  private rowsCache: {
+    fingerprint: string;
+    rows: StoredRows;
+    nextReconcileAt: number | null;
+  } | null = null;
 
   constructor(input?: {
     bootstrapConfig?: Partial<BootstrapExecutorConfig>;
@@ -282,6 +571,10 @@ export class ExecutorSettingsService {
       this.bootstrapConfig.aliasModelMapJson,
     );
     const storedAliasResult = parseAliasModelMapJson(rows.aliasModelMapJson);
+    const authModeResolution = resolveAuthMode(rows);
+    const verificationState = parseVerificationStateJson(
+      rows.authVerificationJson,
+    );
 
     const configuredAliasMap =
       rows.aliasModelMapJson !== null
@@ -345,7 +638,11 @@ export class ExecutorSettingsService {
           ? ''
           : this.bootstrapConfig.baseUrl;
 
-    if (rows.configOwned && anthropicBaseUrl) {
+    if (
+      rows.configOwned &&
+      anthropicBaseUrl &&
+      usesCustomBaseUrl(authModeResolution.mode)
+    ) {
       try {
         new URL(anthropicBaseUrl);
       } catch {
@@ -353,18 +650,32 @@ export class ExecutorSettingsService {
       }
     }
 
+    if (authModeResolution.needsExplicitSelection) {
+      configErrors.push(
+        'Multiple Anthropic credential types are stored. Select an active auth mode before running the core executor.',
+      );
+    }
+
+    const verification = deriveVerificationStatus(
+      authModeResolution.mode,
+      rows,
+      verificationState,
+    );
+
     return {
       configuredAliasMap,
       effectiveAliasMap,
       defaultAlias,
+      executorAuthMode: authModeResolution.mode,
       anthropicBaseUrl,
       configOwned: rows.configOwned,
       configVersion: rows.configVersion,
-      hasProviderAuth:
-        Boolean(rows.apiKey) ||
-        Boolean(rows.oauthToken) ||
-        Boolean(rows.authToken),
+      activeCredentialConfigured: verification.activeCredentialConfigured,
+      hasProviderAuth: verification.activeCredentialConfigured,
       hasValidAliasMap,
+      verificationStatus: verification.verificationStatus,
+      lastVerifiedAt: verification.lastVerifiedAt,
+      lastVerificationError: verification.lastVerificationError,
       configErrors,
       sources: {
         configuredAliasMap: configuredAliasSource,
@@ -427,6 +738,14 @@ export class ExecutorSettingsService {
         updatedAt,
         null,
       );
+      if (config.executorAuthMode !== 'none') {
+        this.upsertSettingRow(
+          EXECUTOR_KEY_AUTH_MODE,
+          config.executorAuthMode,
+          updatedAt,
+          null,
+        );
+      }
       this.upsertSettingRow(
         EXECUTOR_KEY_CONFIG_VERSION,
         String(nextVersion),
@@ -502,6 +821,32 @@ export class ExecutorSettingsService {
         ? this.validateSecretInput(update.anthropicAuthToken, 'Auth token')
         : rows.authToken;
 
+    const nextRowsPreview: StoredRows = {
+      ...rows,
+      apiKey,
+      oauthToken,
+      authToken,
+      baseUrl,
+    };
+    const authModeResolution = resolveAuthMode(nextRowsPreview);
+    const candidateAuthMode =
+      update.executorAuthMode !== undefined
+        ? this.validateAuthMode(update.executorAuthMode)
+        : authModeResolution.mode;
+    const shouldPersistAuthMode =
+      update.executorAuthMode !== undefined ||
+      !authModeResolution.needsExplicitSelection;
+    const nextVerification = this.reconcileVerificationStateForConfigChange(
+      rows,
+      {
+        apiKey,
+        oauthToken,
+        authToken,
+        baseUrl,
+      },
+      parseVerificationStateJson(rows.authVerificationJson),
+    );
+
     const updatedAt = new Date().toISOString();
     const nextVersion = rows.configVersion + 1;
     const tx = getDb().transaction(() => {
@@ -541,6 +886,20 @@ export class ExecutorSettingsService {
         updatedAt,
         userId,
       );
+      if (shouldPersistAuthMode) {
+        this.upsertSettingRow(
+          EXECUTOR_KEY_AUTH_MODE,
+          candidateAuthMode,
+          updatedAt,
+          userId,
+        );
+      }
+      this.writeOptionalSettingRow(
+        EXECUTOR_KEY_AUTH_VERIFICATION,
+        stringifyVerificationState(nextVerification),
+        updatedAt,
+        userId,
+      );
       this.upsertSettingRow(
         EXECUTOR_KEY_CONFIG_VERSION,
         String(nextVersion),
@@ -557,6 +916,41 @@ export class ExecutorSettingsService {
 
     tx();
     return this.getSettingsView();
+  }
+
+  importSubscriptionCredential(
+    credential: string,
+    userId: string,
+  ): ExecutorSubscriptionImportResult {
+    const normalized = this.validateSecretInput(
+      credential,
+      'OAuth token',
+    );
+    const rows = this.readStoredRows();
+    const authModeResolution = resolveAuthMode(rows);
+    if (
+      rows.oauthToken === normalized &&
+      authModeResolution.mode === 'subscription' &&
+      !authModeResolution.needsExplicitSelection
+    ) {
+      return {
+        status: 'no_change',
+        settings: this.getSettingsView(),
+      };
+    }
+
+    const settings = this.saveExecutorConfig(
+      {
+        executorAuthMode: 'subscription',
+        claudeOauthToken: normalized,
+      },
+      userId,
+    );
+
+    return {
+      status: 'imported',
+      settings,
+    };
   }
 
   captureRunningSnapshot(
@@ -622,18 +1016,157 @@ export class ExecutorSettingsService {
       );
       return {};
     }
+
+    const authModeResolution = resolveAuthMode(rows);
     const output: Record<string, string> = {};
 
-    if (rows.oauthToken) output.CLAUDE_CODE_OAUTH_TOKEN = rows.oauthToken;
-    if (rows.apiKey) output.ANTHROPIC_API_KEY = rows.apiKey;
-    if (rows.authToken) output.ANTHROPIC_AUTH_TOKEN = rows.authToken;
-    if (rows.baseUrl) output.ANTHROPIC_BASE_URL = rows.baseUrl;
+    switch (authModeResolution.mode) {
+      case 'subscription':
+        if (rows.oauthToken) {
+          output.CLAUDE_CODE_OAUTH_TOKEN = rows.oauthToken;
+        }
+        break;
+      case 'api_key':
+        if (rows.apiKey) {
+          output.ANTHROPIC_API_KEY = rows.apiKey;
+        }
+        break;
+      case 'advanced_bearer':
+        if (rows.authToken) {
+          output.ANTHROPIC_AUTH_TOKEN = rows.authToken;
+        }
+        break;
+      default:
+        break;
+    }
+
+    if (rows.baseUrl && usesCustomBaseUrl(authModeResolution.mode)) {
+      output.ANTHROPIC_BASE_URL = rows.baseUrl;
+    }
 
     return output;
   }
 
-  resolveDetectedAuthMethod(): DetectedAuthMethod {
-    return detectAuthMethod(this.readStoredRows());
+  getExecutionBlockedReason(): string | null {
+    const rows = this.readStoredRows();
+    const authModeResolution = resolveAuthMode(rows);
+
+    if (authModeResolution.needsExplicitSelection) {
+      return 'Multiple Anthropic credential types are stored. Choose an active auth mode in Settings before running the core executor.';
+    }
+
+    if (authModeResolution.mode === 'none') {
+      return 'Anthropic credentials are not configured for the selected core executor mode.';
+    }
+
+    if (!getModeCredential(authModeResolution.mode, rows)) {
+      return `Selected Anthropic auth mode "${authModeResolution.mode}" has no configured credential.`;
+    }
+
+    if (usesCustomBaseUrl(authModeResolution.mode) && rows.baseUrl) {
+      try {
+        new URL(rows.baseUrl);
+      } catch {
+        return 'Anthropic/Gateway Base URL must be a valid absolute URL.';
+      }
+    }
+
+    return null;
+  }
+
+  getVerificationTarget(
+    requestedMode?: ExecutorAuthMode,
+  ): ExecutorVerificationTarget | null {
+    const rows = this.readStoredRows();
+    const config = this.resolveEffectiveConfig();
+    const authModeResolution = resolveAuthMode(rows);
+    const mode =
+      requestedMode && requestedMode !== 'none'
+        ? requestedMode
+        : authModeResolution.mode;
+
+    if (
+      mode === 'none' ||
+      authModeResolution.needsExplicitSelection ||
+      !VERIFIABLE_EXECUTOR_AUTH_MODES.includes(mode)
+    ) {
+      return null;
+    }
+
+    const targetFingerprint = computeModeFingerprint(mode, rows);
+    if (!targetFingerprint) return null;
+    const credential = getModeCredential(mode, rows);
+    if (!credential) return null;
+
+    return {
+      mode,
+      fingerprint: targetFingerprint,
+      anthropicBaseUrl:
+        normalizeUrl(rows.baseUrl) || DEFAULT_ANTHROPIC_BASE_URL,
+      credential,
+      model:
+        config.effectiveAliasMap[config.defaultAlias] || DEFAULT_EXECUTOR_ALIAS,
+    };
+  }
+
+  markVerificationStarted(
+    mode: VerifiableExecutorAuthMode,
+    fingerprintValue: string,
+  ): void {
+    const rows = this.readStoredRows();
+    const updatedAt = new Date().toISOString();
+    const next = parseVerificationStateJson(rows.authVerificationJson);
+    const current = next[mode];
+
+    next[mode] = {
+      status: 'verifying',
+      fingerprint: fingerprintValue,
+      verificationStartedAt: updatedAt,
+      lastVerifiedAt: current?.lastVerifiedAt ?? null,
+      lastVerificationError: null,
+    };
+
+    this.writeOptionalSettingRow(
+      EXECUTOR_KEY_AUTH_VERIFICATION,
+      stringifyVerificationState(next),
+      updatedAt,
+      null,
+    );
+  }
+
+  completeVerification(
+    mode: VerifiableExecutorAuthMode,
+    fingerprintValue: string,
+    result: {
+      status: Extract<
+        ExecutorVerificationStatus,
+        'verified' | 'invalid' | 'unavailable'
+      >;
+      error?: string | null;
+    },
+  ): void {
+    const rows = this.readStoredRows();
+    const next = parseVerificationStateJson(rows.authVerificationJson);
+    const current = next[mode];
+    if (!current || current.fingerprint !== fingerprintValue) {
+      return;
+    }
+
+    const updatedAt = new Date().toISOString();
+    next[mode] = {
+      status: result.status,
+      fingerprint: fingerprintValue,
+      verificationStartedAt: null,
+      lastVerifiedAt: updatedAt,
+      lastVerificationError: result.error?.trim() || null,
+    };
+
+    this.writeOptionalSettingRow(
+      EXECUTOR_KEY_AUTH_VERIFICATION,
+      stringifyVerificationState(next),
+      updatedAt,
+      null,
+    );
   }
 
   getBootId(): string {
@@ -657,9 +1190,14 @@ export class ExecutorSettingsService {
       configuredAliasMap: config.configuredAliasMap,
       effectiveAliasMap: config.effectiveAliasMap,
       defaultAlias: config.defaultAlias,
+      executorAuthMode: config.executorAuthMode,
       hasApiKey: Boolean(rows.apiKey),
       hasOauthToken: Boolean(rows.oauthToken),
       hasAuthToken: Boolean(rows.authToken),
+      activeCredentialConfigured: config.activeCredentialConfigured,
+      verificationStatus: config.verificationStatus,
+      lastVerifiedAt: config.lastVerifiedAt,
+      lastVerificationError: config.lastVerificationError,
       anthropicBaseUrl: config.anthropicBaseUrl,
       isConfigured: config.configOwned,
       configVersion: rows.configVersion,
@@ -676,9 +1214,13 @@ export class ExecutorSettingsService {
       restartSupported: this.isRestartSupported(),
       pendingRestartReasons: this.computeRestartReasons(),
       activeRunCount: countRunningTalkRuns(),
+      executorAuthMode: config.executorAuthMode,
+      activeCredentialConfigured: config.activeCredentialConfigured,
+      verificationStatus: config.verificationStatus,
+      lastVerifiedAt: config.lastVerifiedAt,
+      lastVerificationError: config.lastVerificationError,
       hasProviderAuth: config.hasProviderAuth,
       hasValidAliasMap: config.hasValidAliasMap,
-      detectedAuthMethod: this.resolveDetectedAuthMethod(),
       configVersion: config.configVersion,
       isConfigured: config.configOwned,
       bootId: this.getBootId(),
@@ -687,6 +1229,32 @@ export class ExecutorSettingsService {
   }
 
   private readStoredRows(): StoredRows {
+    const raw = this.readStoredRowsRaw();
+    const rawFingerprint = fingerprint(raw);
+    const now = Date.now();
+
+    if (
+      this.rowsCache &&
+      this.rowsCache.fingerprint === rawFingerprint &&
+      (this.rowsCache.nextReconcileAt === null ||
+        now < this.rowsCache.nextReconcileAt)
+    ) {
+      return this.rowsCache.rows;
+    }
+
+    const reconciled = this.reconcileStoredRows(raw);
+    this.rowsCache = {
+      fingerprint: fingerprint(reconciled),
+      rows: reconciled,
+      nextReconcileAt: this.computeNextReconcileAt(
+        reconciled.authVerificationJson,
+      ),
+    };
+
+    return reconciled;
+  }
+
+  private readStoredRowsRaw(): StoredRows {
     const rows = getDb()
       .prepare(
         `
@@ -698,6 +1266,13 @@ export class ExecutorSettingsService {
       .all() as SettingRow[];
 
     const byKey = new Map(rows.map((row) => [row.key, row]));
+    const authModeValue = byKey.get(EXECUTOR_KEY_AUTH_MODE)?.value ?? null;
+    if (authModeValue !== null && !isExecutorAuthMode(authModeValue)) {
+      logger.warn(
+        { authModeValue },
+        'Ignoring invalid stored executor auth mode value',
+      );
+    }
 
     return {
       configOwned: byKey.get(EXECUTOR_KEY_CONFIG_OWNED)?.value === 'true',
@@ -709,10 +1284,165 @@ export class ExecutorSettingsService {
       apiKey: byKey.get(EXECUTOR_KEY_API_KEY)?.value ?? null,
       oauthToken: byKey.get(EXECUTOR_KEY_OAUTH_TOKEN)?.value ?? null,
       authToken: byKey.get(EXECUTOR_KEY_AUTH_TOKEN)?.value ?? null,
+      authMode: isExecutorAuthMode(authModeValue) ? authModeValue : null,
+      authVerificationJson:
+        byKey.get(EXECUTOR_KEY_AUTH_VERIFICATION)?.value ?? null,
       baseUrl: byKey.get(EXECUTOR_KEY_BASE_URL)?.value ?? null,
       aliasModelMapJson: byKey.get(EXECUTOR_KEY_ALIAS_MODEL_MAP)?.value ?? null,
       defaultAlias: byKey.get(EXECUTOR_KEY_DEFAULT_ALIAS)?.value ?? null,
     };
+  }
+
+  private reconcileStoredRows(rows: StoredRows): StoredRows {
+    const authModeResolution = resolveAuthMode(rows);
+    const nextVerification = parseVerificationStateJson(
+      rows.authVerificationJson,
+    );
+    let nextRows = rows;
+    let authModeChanged = false;
+    let verificationChanged = false;
+
+    if (
+      rows.authMode === null &&
+      authModeResolution.inferred &&
+      (rows.apiKey || rows.oauthToken || rows.authToken)
+    ) {
+      nextRows = {
+        ...nextRows,
+        authMode: authModeResolution.mode,
+      };
+      authModeChanged = true;
+    }
+
+    for (const mode of VERIFIABLE_EXECUTOR_AUTH_MODES) {
+      const current = nextVerification[mode];
+      const nextFingerprint = computeModeFingerprint(mode, nextRows);
+
+      if (!nextFingerprint) {
+        if (current) {
+          delete nextVerification[mode];
+          verificationChanged = true;
+        }
+        continue;
+      }
+
+      if (!current) continue;
+
+      if (current.fingerprint !== nextFingerprint) {
+        nextVerification[mode] = createNotVerifiedState(
+          nextFingerprint,
+          current,
+        );
+        verificationChanged = true;
+        continue;
+      }
+
+      if (current.status === 'verifying') {
+        const startedAtMs = current.verificationStartedAt
+          ? Date.parse(current.verificationStartedAt)
+          : Number.NaN;
+        if (
+          !Number.isFinite(startedAtMs) ||
+          Date.now() - startedAtMs > VERIFICATION_STALE_MS
+        ) {
+          nextVerification[mode] = {
+            ...current,
+            status: 'not_verified',
+            verificationStartedAt: null,
+            lastVerificationError:
+              'Previous verification attempt expired before completion.',
+          };
+          verificationChanged = true;
+        }
+      }
+    }
+
+    if (!authModeChanged && !verificationChanged) {
+      return nextRows;
+    }
+
+    const updatedAt = new Date().toISOString();
+    const tx = getDb().transaction(() => {
+      if (authModeChanged && nextRows.authMode) {
+        this.upsertSettingRow(
+          EXECUTOR_KEY_AUTH_MODE,
+          nextRows.authMode,
+          updatedAt,
+          null,
+        );
+      }
+      if (verificationChanged) {
+        this.writeOptionalSettingRow(
+          EXECUTOR_KEY_AUTH_VERIFICATION,
+          stringifyVerificationState(nextVerification),
+          updatedAt,
+          null,
+        );
+      }
+    });
+
+    tx();
+
+    return {
+      ...nextRows,
+      authVerificationJson: stringifyVerificationState(nextVerification),
+    };
+  }
+
+  private computeNextReconcileAt(
+    authVerificationJson: string | null,
+  ): number | null {
+    const verificationState = parseVerificationStateJson(authVerificationJson);
+    let nextReconcileAt: number | null = null;
+
+    for (const mode of VERIFIABLE_EXECUTOR_AUTH_MODES) {
+      const current = verificationState[mode];
+      if (current?.status !== 'verifying') continue;
+      const startedAtMs = current.verificationStartedAt
+        ? Date.parse(current.verificationStartedAt)
+        : Number.NaN;
+      if (!Number.isFinite(startedAtMs)) {
+        return Date.now();
+      }
+      const expiryMs = startedAtMs + VERIFICATION_STALE_MS;
+      if (nextReconcileAt === null || expiryMs < nextReconcileAt) {
+        nextReconcileAt = expiryMs;
+      }
+    }
+
+    return nextReconcileAt;
+  }
+
+  private reconcileVerificationStateForConfigChange(
+    previousRows: StoredRows,
+    nextConfig: {
+      apiKey: string | null;
+      oauthToken: string | null;
+      authToken: string | null;
+      baseUrl: string | null;
+    },
+    currentState: VerificationStateMap,
+  ): VerificationStateMap {
+    const nextRows: StoredRows = {
+      ...previousRows,
+      ...nextConfig,
+    };
+    const next: VerificationStateMap = {};
+
+    for (const mode of VERIFIABLE_EXECUTOR_AUTH_MODES) {
+      const current = currentState[mode];
+      const nextFingerprint = computeModeFingerprint(mode, nextRows);
+      if (!nextFingerprint) continue;
+
+      if (!current || current.fingerprint !== nextFingerprint) {
+        next[mode] = createNotVerifiedState(nextFingerprint, current);
+        continue;
+      }
+
+      next[mode] = current;
+    }
+
+    return next;
   }
 
   private getLastUpdatedMeta(): {
@@ -764,6 +1494,7 @@ export class ExecutorSettingsService {
     updatedAt: string,
     updatedBy: string | null,
   ): void {
+    this.rowsCache = null;
     getDb()
       .prepare(
         `
@@ -785,6 +1516,7 @@ export class ExecutorSettingsService {
     updatedBy: string | null,
   ): void {
     if (!value) {
+      this.rowsCache = null;
       getDb().prepare(`DELETE FROM settings_kv WHERE key = ?`).run(key);
       return;
     }
@@ -849,6 +1581,16 @@ export class ExecutorSettingsService {
       );
     }
     return normalized;
+  }
+
+  private validateAuthMode(value: ExecutorAuthMode): ExecutorAuthMode {
+    if (!isExecutorAuthMode(value)) {
+      throw new ExecutorSettingsValidationError(
+        'invalid_auth_mode',
+        'Executor auth mode must be one of subscription, api_key, advanced_bearer, or none',
+      );
+    }
+    return value;
   }
 }
 

--- a/src/clawrocket/talks/executor-subscription-host-auth.test.ts
+++ b/src/clawrocket/talks/executor-subscription-host-auth.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ExecutorSubscriptionHostAuthService } from './executor-subscription-host-auth.js';
+
+describe('ExecutorSubscriptionHostAuthService', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('prefers service-env oauth tokens as an importable host source', async () => {
+    const service = new ExecutorSubscriptionHostAuthService({
+      env: {
+        USER: 'clawrocket',
+        CLAUDE_CODE_OAUTH_TOKEN: 'oauth-host-token',
+      },
+      serviceUser: 'clawrocket',
+      serviceUid: 1001,
+      serviceHomePath: '/srv/clawrocket',
+      runCommand: vi.fn(async () => ({ stdout: '1.0.0', stderr: '' })),
+    });
+
+    const status = await service.getStatusView();
+    const probe = await service.probeImportSource();
+
+    expect(status.serviceEnvOauthPresent).toBe(true);
+    expect(status.hostLoginDetected).toBe(true);
+    expect(status.importAvailable).toBe(true);
+    expect(status.hostCredentialFingerprint).toBeTruthy();
+    expect(probe.importSource).toBe('service_env');
+    expect(probe.importCredential).toBe('oauth-host-token');
+  });
+
+  it('reports missing Claude CLI cleanly', async () => {
+    const service = new ExecutorSubscriptionHostAuthService({
+      env: {
+        USER: 'clawrocket',
+      },
+      serviceUser: 'clawrocket',
+      serviceUid: 1001,
+      serviceHomePath: '/srv/clawrocket',
+      runCommand: vi.fn(async () => {
+        const error = new Error('not found') as Error & { code?: string };
+        error.code = 'ENOENT';
+        throw error;
+      }),
+    });
+
+    const status = await service.getStatusView();
+
+    expect(status.claudeCliInstalled).toBe(false);
+    expect(status.hostLoginDetected).toBe(false);
+    expect(status.importAvailable).toBe(false);
+    expect(status.message).toContain('CLI was not found');
+  });
+
+  it('detects logged-in Claude CLI state even when auto-import is unavailable', async () => {
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: '1.0.0', stderr: '' })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          loggedIn: true,
+          authMethod: 'oauth',
+          apiProvider: 'firstParty',
+        }),
+        stderr: '',
+      });
+
+    const service = new ExecutorSubscriptionHostAuthService({
+      env: {
+        USER: 'clawrocket',
+      },
+      serviceUser: 'clawrocket',
+      serviceUid: 1001,
+      serviceHomePath: '/srv/clawrocket',
+      runCommand,
+    });
+
+    const status = await service.getStatusView();
+
+    expect(status.claudeCliInstalled).toBe(true);
+    expect(status.hostLoginDetected).toBe(true);
+    expect(status.importAvailable).toBe(false);
+    expect(status.message).toContain('could not be imported automatically');
+  });
+
+  it('times out stale host probes instead of hanging forever', async () => {
+    vi.useFakeTimers();
+    const service = new ExecutorSubscriptionHostAuthService({
+      env: {
+        USER: 'clawrocket',
+      },
+      serviceUser: 'clawrocket',
+      serviceUid: 1001,
+      serviceHomePath: '/srv/clawrocket',
+      runCommand: vi.fn(
+        async () =>
+          await new Promise<{ stdout: string; stderr: string }>(() => {
+            // Intentionally never resolves.
+          }),
+      ),
+    });
+
+    const promise = service.getStatusView();
+    await vi.advanceTimersByTimeAsync(5_100);
+    const status = await promise;
+
+    expect(status.importAvailable).toBe(false);
+    expect(status.message).toContain('timed out');
+  });
+});

--- a/src/clawrocket/talks/executor-subscription-host-auth.ts
+++ b/src/clawrocket/talks/executor-subscription-host-auth.ts
@@ -1,0 +1,358 @@
+import { execFile, type ExecFileException } from 'child_process';
+import { existsSync } from 'fs';
+import os from 'os';
+
+import { logger } from '../../logger.js';
+import { fingerprintStableJson } from './json-fingerprint.js';
+
+const CLAUDE_VERSION_TIMEOUT_MS = 2_000;
+const CLAUDE_AUTH_STATUS_TIMEOUT_MS = 2_000;
+const HOST_PROBE_TIMEOUT_MS = 5_000;
+
+export type SubscriptionHostRuntimeContext =
+  | 'host'
+  | 'systemd'
+  | 'container'
+  | 'unknown';
+
+export interface SubscriptionHostStatusView {
+  serviceUser: string | null;
+  serviceUid: number | null;
+  serviceHomePath: string;
+  runtimeContext: SubscriptionHostRuntimeContext;
+  claudeCliInstalled: boolean | null;
+  hostLoginDetected: boolean;
+  serviceEnvOauthPresent: boolean;
+  importAvailable: boolean;
+  hostCredentialFingerprint: string | null;
+  message: string;
+  recommendedCommands: string[];
+}
+
+export interface SubscriptionHostImportProbe extends SubscriptionHostStatusView {
+  importSource: 'service_env' | 'unsupported' | 'none';
+  importCredential: string | null;
+}
+
+interface ClaudeAuthStatusJson {
+  loggedIn?: boolean;
+  authMethod?: string;
+  apiProvider?: string;
+}
+
+interface CommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+type RunCommand = (
+  file: string,
+  args: string[],
+  timeoutMs: number,
+) => Promise<CommandResult>;
+
+function detectRuntimeContext(
+  env: NodeJS.ProcessEnv,
+): SubscriptionHostRuntimeContext {
+  if (env.INVOCATION_ID || env.JOURNAL_STREAM) {
+    return 'systemd';
+  }
+  if (
+    env.CONTAINER ||
+    env.KUBERNETES_SERVICE_HOST ||
+    existsSync('/.dockerenv')
+  ) {
+    return 'container';
+  }
+  return 'host';
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error('host_probe_timeout'));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function defaultRunCommand(): RunCommand {
+  return async (file, args, timeoutMs) =>
+    new Promise<CommandResult>((resolve, reject) => {
+      execFile(
+        file,
+        args,
+        {
+          timeout: timeoutMs,
+          encoding: 'utf8',
+          maxBuffer: 128 * 1024,
+          windowsHide: true,
+        },
+        (
+          error: ExecFileException | null,
+          stdout: string | Buffer,
+          stderr: string | Buffer,
+        ) => {
+          const normalizedStdout = String(stdout ?? '');
+          const normalizedStderr = String(stderr ?? '');
+          if (error) {
+            reject(
+              Object.assign(error, {
+                stdout: normalizedStdout,
+                stderr: normalizedStderr,
+              }),
+            );
+            return;
+          }
+          resolve({
+            stdout: normalizedStdout,
+            stderr: normalizedStderr,
+          });
+        },
+      );
+    });
+}
+
+function buildRecommendedCommands(
+  env: NodeJS.ProcessEnv,
+  serviceUser: string | null,
+): string[] {
+  const shellUser = env.SUDO_USER || env.LOGNAME || env.USER || null;
+  const prefix =
+    serviceUser && shellUser && shellUser !== serviceUser
+      ? `sudo -u ${serviceUser} -H `
+      : '';
+  return [
+    `${prefix}claude config set -g forceLoginMethod claudeai`,
+    `${prefix}claude login`,
+  ];
+}
+
+function buildBaseStatus(input: {
+  env: NodeJS.ProcessEnv;
+  serviceUser: string | null;
+  serviceUid: number | null;
+  serviceHomePath: string;
+}): SubscriptionHostStatusView {
+  return {
+    serviceUser: input.serviceUser,
+    serviceUid: input.serviceUid,
+    serviceHomePath: input.serviceHomePath,
+    runtimeContext: detectRuntimeContext(input.env),
+    claudeCliInstalled: null,
+    hostLoginDetected: false,
+    serviceEnvOauthPresent: false,
+    importAvailable: false,
+    hostCredentialFingerprint: null,
+    message: '',
+    recommendedCommands: buildRecommendedCommands(
+      input.env,
+      input.serviceUser,
+    ),
+  };
+}
+
+export class ExecutorSubscriptionHostAuthService {
+  private readonly runCommand: RunCommand;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly serviceUser: string | null;
+  private readonly serviceUid: number | null;
+  private readonly serviceHomePath: string;
+
+  constructor(input?: {
+    runCommand?: RunCommand;
+    env?: NodeJS.ProcessEnv;
+    serviceUser?: string | null;
+    serviceUid?: number | null;
+    serviceHomePath?: string;
+  }) {
+    this.runCommand = input?.runCommand || defaultRunCommand();
+    this.env = input?.env || process.env;
+    this.serviceUser =
+      input?.serviceUser ?? os.userInfo().username ?? this.env.USER ?? null;
+    this.serviceUid =
+      input?.serviceUid ??
+      (typeof process.getuid === 'function' ? process.getuid() : null);
+    this.serviceHomePath = input?.serviceHomePath || os.homedir();
+  }
+
+  async getStatusView(): Promise<SubscriptionHostStatusView> {
+    const probe = await this.probeImportSource();
+    return {
+      serviceUser: probe.serviceUser,
+      serviceUid: probe.serviceUid,
+      serviceHomePath: probe.serviceHomePath,
+      runtimeContext: probe.runtimeContext,
+      claudeCliInstalled: probe.claudeCliInstalled,
+      hostLoginDetected: probe.hostLoginDetected,
+      serviceEnvOauthPresent: probe.serviceEnvOauthPresent,
+      importAvailable: probe.importAvailable,
+      hostCredentialFingerprint: probe.hostCredentialFingerprint,
+      message: probe.message,
+      recommendedCommands: probe.recommendedCommands,
+    };
+  }
+
+  async probeImportSource(): Promise<SubscriptionHostImportProbe> {
+    return withTimeout(this.probeInternal(), HOST_PROBE_TIMEOUT_MS).catch(
+      (error) => {
+        const status = buildBaseStatus({
+          env: this.env,
+          serviceUser: this.serviceUser,
+          serviceUid: this.serviceUid,
+          serviceHomePath: this.serviceHomePath,
+        });
+
+        if (error instanceof Error && error.message === 'host_probe_timeout') {
+          return {
+            ...status,
+            message:
+              'Host Claude login detection timed out. Please try again, or use the advanced manual token flow.',
+            importSource: 'none' as const,
+            importCredential: null,
+          };
+        }
+
+        logger.warn(
+          { err: error },
+          'Subscription host auth probe failed unexpectedly',
+        );
+        return {
+          ...status,
+          message:
+            'Host Claude login detection failed unexpectedly. Use the advanced manual token flow if needed.',
+          importSource: 'none' as const,
+          importCredential: null,
+        };
+      },
+    );
+  }
+
+  private async probeInternal(): Promise<SubscriptionHostImportProbe> {
+    const status = buildBaseStatus({
+      env: this.env,
+      serviceUser: this.serviceUser,
+      serviceUid: this.serviceUid,
+      serviceHomePath: this.serviceHomePath,
+    });
+    const envOauthToken = this.env.CLAUDE_CODE_OAUTH_TOKEN?.trim() || null;
+    status.serviceEnvOauthPresent = Boolean(envOauthToken);
+
+    const claudeCliInstalled = await this.detectClaudeCliInstalled();
+    status.claudeCliInstalled = claudeCliInstalled;
+
+    if (envOauthToken) {
+      const hostCredentialFingerprint = fingerprintStableJson({
+        source: 'service_env',
+        credential: envOauthToken,
+      });
+      return {
+        ...status,
+        hostLoginDetected: true,
+        importAvailable: true,
+        hostCredentialFingerprint,
+        message:
+          'A Claude Code OAuth token is already present in the ClawRocket service environment and can be imported into settings.',
+        importSource: 'service_env',
+        importCredential: envOauthToken,
+      };
+    }
+
+    if (claudeCliInstalled !== true) {
+      return {
+        ...status,
+        message:
+          claudeCliInstalled === false
+            ? 'Claude Code CLI was not found for the ClawRocket service user. Install Claude Code, then sign in as the same OS user that runs ClawRocket.'
+            : 'Claude Code CLI detection is unavailable in this environment. Use the advanced manual token flow if needed.',
+        importSource: 'none',
+        importCredential: null,
+      };
+    }
+
+    const cliStatus = await this.readClaudeAuthStatus();
+    if (!cliStatus.loggedIn) {
+      return {
+        ...status,
+        message:
+          'No Claude Code login was detected for the ClawRocket service user. Run the recommended CLI commands as this same OS user, then check again.',
+        importSource: 'none',
+        importCredential: null,
+      };
+    }
+
+    return {
+      ...status,
+      hostLoginDetected: true,
+      importAvailable: false,
+      message:
+        'Claude Code login was detected for this service user, but the current authenticated state could not be imported automatically. Use the advanced manual token flow with `claude setup-token`.',
+      importSource: 'unsupported',
+      importCredential: null,
+    };
+  }
+
+  private async detectClaudeCliInstalled(): Promise<boolean | null> {
+    try {
+      await this.runCommand('claude', ['--version'], CLAUDE_VERSION_TIMEOUT_MS);
+      return true;
+    } catch (error) {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        (error as { code?: string }).code === 'ENOENT'
+      ) {
+        return false;
+      }
+      if (
+        error &&
+        typeof error === 'object' &&
+        'killed' in error &&
+        (error as { killed?: boolean }).killed
+      ) {
+        return null;
+      }
+      return null;
+    }
+  }
+
+  private async readClaudeAuthStatus(): Promise<ClaudeAuthStatusJson> {
+    try {
+      const result = await this.runCommand(
+        'claude',
+        ['auth', 'status', '--json'],
+        CLAUDE_AUTH_STATUS_TIMEOUT_MS,
+      );
+      const parsed = JSON.parse(result.stdout) as ClaudeAuthStatusJson;
+      return {
+        loggedIn: Boolean(parsed.loggedIn),
+        authMethod:
+          typeof parsed.authMethod === 'string' ? parsed.authMethod : undefined,
+        apiProvider:
+          typeof parsed.apiProvider === 'string'
+            ? parsed.apiProvider
+            : undefined,
+      };
+    } catch (error) {
+      logger.warn(
+        { err: error },
+        'Failed to read Claude CLI auth status during host subscription probe',
+      );
+      return {
+        loggedIn: false,
+        authMethod: 'none',
+      };
+    }
+  }
+}

--- a/src/clawrocket/talks/json-fingerprint.ts
+++ b/src/clawrocket/talks/json-fingerprint.ts
@@ -1,0 +1,12 @@
+import { createHash } from 'crypto';
+
+export function stableJson(value: unknown): string {
+  if (!value || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  return JSON.stringify(value, Object.keys(value as object).sort());
+}
+
+export function fingerprintStableJson(value: unknown): string {
+  return createHash('sha256').update(stableJson(value)).digest('hex');
+}

--- a/src/clawrocket/web/index.ts
+++ b/src/clawrocket/web/index.ts
@@ -10,6 +10,7 @@ import {
   ExecutorSettingsService,
   setActiveExecutorSettingsService,
 } from '../talks/executor-settings.js';
+import { ExecutorCredentialVerifier } from '../talks/executor-credentials-verifier.js';
 import { DirectTalkExecutor } from '../talks/direct-executor.js';
 import { TalkRunWorker } from '../talks/run-worker.js';
 
@@ -26,6 +27,9 @@ export async function startWebServer(): Promise<WebServerHandle> {
     executorSettings.getConfigVersion(),
   );
   setActiveExecutorSettingsService(executorSettings);
+  const executorVerifier = new ExecutorCredentialVerifier({
+    executorSettings,
+  });
 
   logger.info(
     {
@@ -46,6 +50,7 @@ export async function startWebServer(): Promise<WebServerHandle> {
     port: WEB_PORT,
     runWorker,
     executorSettings,
+    executorVerifier,
   });
 
   let bound: { host: string; port: number };

--- a/src/clawrocket/web/routes/settings.test.ts
+++ b/src/clawrocket/web/routes/settings.test.ts
@@ -198,4 +198,253 @@ describe('settings routes', () => {
     await vi.runAllTimersAsync();
     expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGTERM');
   });
+
+  it('starts async executor verification for owners and admins', async () => {
+    const scheduleVerification = vi.fn(() => ({
+      scheduled: true,
+      mode: 'subscription',
+      code: 'scheduled',
+      message: 'Verification started.',
+    }));
+    server = createWebServer({
+      host: '127.0.0.1',
+      port: 0,
+      executorVerifier: {
+        scheduleVerification,
+      } as any,
+    });
+
+    const response = await server.request('/api/v1/settings/executor/verify', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer owner-token',
+        'Idempotency-Key': 'verify-owner-1',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as any;
+    expect(body.ok).toBe(true);
+    expect(body.data.scheduled).toBe(true);
+    expect(scheduleVerification).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns subscription host status with service-user context', async () => {
+    server = createWebServer({
+      host: '127.0.0.1',
+      port: 0,
+      subscriptionHostAuth: {
+        async getStatusView() {
+          return {
+            serviceUser: 'clawrocket',
+            serviceUid: 1001,
+            serviceHomePath: '/srv/clawrocket',
+            runtimeContext: 'systemd',
+            claudeCliInstalled: true,
+            hostLoginDetected: true,
+            serviceEnvOauthPresent: false,
+            importAvailable: false,
+            hostCredentialFingerprint: null,
+            message: 'Host login detected.',
+            recommendedCommands: ['sudo -u clawrocket -H claude login'],
+          };
+        },
+      } as any,
+    });
+
+    const response = await server.request(
+      '/api/v1/settings/executor/subscription-host-status',
+      {
+        headers: {
+          Authorization: 'Bearer owner-token',
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as any;
+    expect(body.ok).toBe(true);
+    expect(body.data.serviceUser).toBe('clawrocket');
+    expect(body.data.runtimeContext).toBe('systemd');
+    expect(body.data.recommendedCommands[0]).toContain('sudo -u clawrocket');
+  });
+
+  it('imports a host subscription credential and persists subscription mode', async () => {
+    server = createWebServer({
+      host: '127.0.0.1',
+      port: 0,
+      subscriptionHostAuth: {
+        async getStatusView() {
+          return {
+            serviceUser: 'clawrocket',
+            serviceUid: 1001,
+            serviceHomePath: '/srv/clawrocket',
+            runtimeContext: 'host',
+            claudeCliInstalled: true,
+            hostLoginDetected: true,
+            serviceEnvOauthPresent: true,
+            importAvailable: true,
+            hostCredentialFingerprint: 'fingerprint-1',
+            message: 'Ready to import.',
+            recommendedCommands: [],
+          };
+        },
+        async probeImportSource() {
+          return {
+            serviceUser: 'clawrocket',
+            serviceUid: 1001,
+            serviceHomePath: '/srv/clawrocket',
+            runtimeContext: 'host',
+            claudeCliInstalled: true,
+            hostLoginDetected: true,
+            serviceEnvOauthPresent: true,
+            importAvailable: true,
+            hostCredentialFingerprint: 'fingerprint-1',
+            message: 'Ready to import.',
+            recommendedCommands: [],
+            importSource: 'service_env',
+            importCredential: 'oauth-imported',
+          };
+        },
+      } as any,
+    });
+
+    const response = await server.request(
+      '/api/v1/settings/executor/subscription/import',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer owner-token',
+          'Content-Type': 'application/json',
+          'Idempotency-Key': 'subscription-import-1',
+        },
+        body: JSON.stringify({
+          expectedFingerprint: 'fingerprint-1',
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as any;
+    expect(body.ok).toBe(true);
+    expect(body.data.status).toBe('imported');
+    expect(body.data.settings.executorAuthMode).toBe('subscription');
+    expect(body.data.settings.hasOauthToken).toBe(true);
+  });
+
+  it('returns no_change when the imported subscription credential already matches settings', async () => {
+    server = createWebServer({
+      host: '127.0.0.1',
+      port: 0,
+      subscriptionHostAuth: {
+        async getStatusView() {
+          throw new Error('unused');
+        },
+        async probeImportSource() {
+          return {
+            serviceUser: 'clawrocket',
+            serviceUid: 1001,
+            serviceHomePath: '/srv/clawrocket',
+            runtimeContext: 'host',
+            claudeCliInstalled: true,
+            hostLoginDetected: true,
+            serviceEnvOauthPresent: true,
+            importAvailable: true,
+            hostCredentialFingerprint: 'fingerprint-1',
+            message: 'Ready to import.',
+            recommendedCommands: [],
+            importSource: 'service_env',
+            importCredential: 'oauth-imported',
+          };
+        },
+      } as any,
+    });
+
+    const firstResponse = await server.request(
+      '/api/v1/settings/executor/subscription/import',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer owner-token',
+          'Content-Type': 'application/json',
+          'Idempotency-Key': 'subscription-import-initial',
+        },
+        body: JSON.stringify({
+          expectedFingerprint: 'fingerprint-1',
+        }),
+      },
+    );
+    expect(firstResponse.status).toBe(200);
+
+    const response = await server.request(
+      '/api/v1/settings/executor/subscription/import',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer owner-token',
+          'Content-Type': 'application/json',
+          'Idempotency-Key': 'subscription-import-no-change',
+        },
+        body: JSON.stringify({
+          expectedFingerprint: 'fingerprint-1',
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as any;
+    expect(body.ok).toBe(true);
+    expect(body.data.status).toBe('no_change');
+    expect(body.data.settings.executorAuthMode).toBe('subscription');
+    expect(body.data.settings.hasOauthToken).toBe(true);
+  });
+
+  it('rejects stale host import attempts when the fingerprint changed', async () => {
+    server = createWebServer({
+      host: '127.0.0.1',
+      port: 0,
+      subscriptionHostAuth: {
+        async getStatusView() {
+          throw new Error('unused');
+        },
+        async probeImportSource() {
+          return {
+            serviceUser: 'clawrocket',
+            serviceUid: 1001,
+            serviceHomePath: '/srv/clawrocket',
+            runtimeContext: 'host',
+            claudeCliInstalled: true,
+            hostLoginDetected: true,
+            serviceEnvOauthPresent: true,
+            importAvailable: true,
+            hostCredentialFingerprint: 'fresh-fingerprint',
+            message: 'Ready to import.',
+            recommendedCommands: [],
+            importSource: 'service_env',
+            importCredential: 'oauth-imported',
+          };
+        },
+      } as any,
+    });
+
+    const response = await server.request(
+      '/api/v1/settings/executor/subscription/import',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer owner-token',
+          'Content-Type': 'application/json',
+          'Idempotency-Key': 'subscription-import-stale',
+        },
+        body: JSON.stringify({
+          expectedFingerprint: 'stale-fingerprint',
+        }),
+      },
+    );
+
+    expect(response.status).toBe(409);
+    const body = (await response.json()) as any;
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('host_state_changed');
+  });
 });

--- a/src/clawrocket/web/server.ts
+++ b/src/clawrocket/web/server.ts
@@ -38,9 +38,13 @@ import {
 import { KeychainBridge, noopKeychainBridge } from '../secrets/keychain.js';
 import type { TalkRunWorkerControl } from '../talks/run-worker.js';
 import {
+  ExecutorAuthMode,
+  ExecutorSubscriptionImportResult,
   ExecutorSettingsService,
   ExecutorSettingsValidationError,
 } from '../talks/executor-settings.js';
+import { ExecutorCredentialVerifier } from '../talks/executor-credentials-verifier.js';
+import { ExecutorSubscriptionHostAuthService } from '../talks/executor-subscription-host-auth.js';
 import { validateCsrfToken } from './middleware/csrf.js';
 import {
   idempotencyPrecheck,
@@ -93,6 +97,8 @@ export interface WebServerOptions {
   runWorker: TalkRunWorkerControl;
   webAppDistDir: string;
   executorSettings: ExecutorSettingsService;
+  executorVerifier: ExecutorCredentialVerifier;
+  subscriptionHostAuth: ExecutorSubscriptionHostAuthService;
 }
 
 export interface WebServerHandle {
@@ -114,13 +120,22 @@ export function createWebServer(
     },
   };
 
+  const executorSettings =
+    input?.executorSettings || new ExecutorSettingsService();
   const opts: WebServerOptions = {
     host: input?.host ?? '127.0.0.1',
     port: input?.port ?? 3210,
     keychain: input?.keychain || noopKeychainBridge,
     runWorker: input?.runWorker || noopRunWorker,
     webAppDistDir: input?.webAppDistDir ?? DEFAULT_WEB_APP_DIST_DIR,
-    executorSettings: input?.executorSettings || new ExecutorSettingsService(),
+    executorSettings,
+    executorVerifier:
+      input?.executorVerifier ||
+      new ExecutorCredentialVerifier({
+        executorSettings,
+      }),
+    subscriptionHostAuth:
+      input?.subscriptionHostAuth || new ExecutorSubscriptionHostAuthService(),
   };
 
   // startWebServer() already runs bootstrap migration in production. Repeat it
@@ -457,6 +472,31 @@ function buildApp(opts: WebServerOptions): Hono {
     );
   });
 
+  app.get('/api/v1/settings/executor/subscription-host-status', async (c) => {
+    const auth = requireAuth(c);
+    if (!auth) return unauthorized(c);
+    if (auth.role !== 'owner' && auth.role !== 'admin') {
+      return forbidden(c, 'Owner or admin role required');
+    }
+
+    const rateResult = checkRateLimit({
+      principalId: auth.userId,
+      bucket: 'write',
+    });
+    if (!rateResult.allowed) {
+      return rateLimitedResponse(c, rateResult);
+    }
+
+    const data = await opts.subscriptionHostAuth.getStatusView();
+    return c.json(
+      {
+        ok: true,
+        data,
+      },
+      200,
+    );
+  });
+
   app.put('/api/v1/settings/executor', async (c) => {
     const auth = requireAuth(c);
     if (!auth) return unauthorized(c);
@@ -524,6 +564,7 @@ function buildApp(opts: WebServerOptions): Hono {
     }
 
     const payload = parseJsonPayload<{
+      executorAuthMode?: ExecutorAuthMode;
       anthropicApiKey?: string | null;
       claudeOauthToken?: string | null;
       anthropicAuthToken?: string | null;
@@ -545,10 +586,17 @@ function buildApp(opts: WebServerOptions): Hono {
     }
 
     try {
-      const data = opts.executorSettings.saveExecutorConfig(
-        payload.data,
-        auth.userId,
-      );
+      opts.executorSettings.saveExecutorConfig(payload.data, auth.userId);
+      const latestSettings = opts.executorSettings.getSettingsView();
+      if (
+        latestSettings.executorAuthMode === 'api_key' ||
+        latestSettings.executorAuthMode === 'advanced_bearer'
+      ) {
+        opts.executorVerifier.scheduleVerification(
+          latestSettings.executorAuthMode,
+        );
+      }
+      const data = opts.executorSettings.getSettingsView();
       const serialized = JSON.stringify({ ok: true, data });
       saveIdempotencyResult({
         userId: auth.userId,
@@ -580,6 +628,233 @@ function buildApp(opts: WebServerOptions): Hono {
       }
       throw err;
     }
+  });
+
+  app.post('/api/v1/settings/executor/verify', async (c) => {
+    const auth = requireAuth(c);
+    if (!auth) return unauthorized(c);
+    if (auth.role !== 'owner' && auth.role !== 'admin') {
+      return forbidden(c, 'Owner or admin role required');
+    }
+
+    const rateResult = checkRateLimit({
+      principalId: auth.userId,
+      bucket: 'write',
+    });
+    if (!rateResult.allowed) {
+      return rateLimitedResponse(c, rateResult);
+    }
+
+    const csrf = validateCsrfToken({
+      method: c.req.method,
+      authType: auth.authType,
+      cookieHeader: c.req.header('cookie'),
+      csrfHeader: c.req.header('x-csrf-token'),
+    });
+    if (!csrf.ok) {
+      return c.json(
+        {
+          ok: false,
+          error: {
+            code: 'csrf_failed',
+            message: csrf.reason,
+          },
+        },
+        403,
+      );
+    }
+
+    const result = opts.executorVerifier.scheduleVerification();
+    if (!result.scheduled && result.code !== 'already_verifying') {
+      return c.json(
+        {
+          ok: false,
+          error: {
+            code: result.code,
+            message: result.message,
+          },
+        },
+        409,
+      );
+    }
+
+    return c.json(
+      {
+        ok: true,
+        data: {
+          scheduled: result.scheduled || result.code === 'already_verifying',
+          code: result.code,
+          message: result.message,
+        },
+      },
+      200,
+    );
+  });
+
+  app.post('/api/v1/settings/executor/subscription/import', async (c) => {
+    const auth = requireAuth(c);
+    if (!auth) return unauthorized(c);
+    if (auth.role !== 'owner' && auth.role !== 'admin') {
+      return forbidden(c, 'Owner or admin role required');
+    }
+
+    const rateResult = checkRateLimit({
+      principalId: auth.userId,
+      bucket: 'write',
+    });
+    if (!rateResult.allowed) {
+      return rateLimitedResponse(c, rateResult);
+    }
+
+    const csrf = validateCsrfToken({
+      method: c.req.method,
+      authType: auth.authType,
+      cookieHeader: c.req.header('cookie'),
+      csrfHeader: c.req.header('x-csrf-token'),
+    });
+    if (!csrf.ok) {
+      return c.json(
+        {
+          ok: false,
+          error: {
+            code: 'csrf_failed',
+            message: csrf.reason,
+          },
+        },
+        403,
+      );
+    }
+
+    const bodyText = await c.req.text();
+    const idempotencyKey = c.req.header('idempotency-key') || null;
+    const precheck = idempotencyPrecheck({
+      userId: auth.userId,
+      idempotencyKey,
+      method: c.req.method,
+      path: c.req.path,
+      bodyText,
+    });
+    if (precheck.error) {
+      return c.json(
+        {
+          ok: false,
+          error: {
+            code: 'idempotency_error',
+            message: precheck.error,
+          },
+        },
+        400,
+      );
+    }
+
+    if (precheck.replay && precheck.response) {
+      return new Response(precheck.response.responseBody, {
+        status: precheck.response.statusCode,
+        headers: {
+          'content-type': 'application/json; charset=utf-8',
+          'x-idempotent-replay': 'true',
+        },
+      });
+    }
+
+    const payload = parseJsonPayload<{
+      expectedFingerprint?: string | null;
+    }>(bodyText);
+    if (!payload.ok) {
+      return c.json(
+        {
+          ok: false,
+          error: {
+            code: 'invalid_json',
+            message: payload.error,
+          },
+        },
+        400,
+      );
+    }
+
+    const expectedFingerprint = payload.data.expectedFingerprint?.trim() || null;
+    const probe = await opts.subscriptionHostAuth.probeImportSource();
+    if (!probe.importAvailable || !probe.importCredential) {
+      const code =
+        probe.hostLoginDetected || probe.serviceEnvOauthPresent
+          ? 'host_import_unavailable'
+          : 'host_login_not_detected';
+      return c.json(
+        {
+          ok: false,
+          error: {
+            code,
+            message: probe.message,
+          },
+        },
+        409,
+      );
+    }
+
+    if (
+      !expectedFingerprint ||
+      !probe.hostCredentialFingerprint ||
+      expectedFingerprint !== probe.hostCredentialFingerprint
+    ) {
+      return c.json(
+        {
+          ok: false,
+          error: {
+            code: 'host_state_changed',
+            message:
+              'Host Claude login changed since the last check. Please check again and retry import.',
+          },
+        },
+        409,
+      );
+    }
+
+    let data: ExecutorSubscriptionImportResult;
+    try {
+      data = opts.executorSettings.importSubscriptionCredential(
+        probe.importCredential,
+        auth.userId,
+      );
+    } catch (err) {
+      if (err instanceof ExecutorSettingsValidationError) {
+        return c.json(
+          {
+            ok: false,
+            error: {
+              code: err.code,
+              message: err.message,
+              details: err.details,
+            },
+          },
+          400,
+        );
+      }
+      throw err;
+    }
+
+    const safeData = {
+      status: data.status,
+      settings: data.settings,
+    };
+    const serialized = JSON.stringify({
+      ok: true,
+      data: safeData,
+    });
+    saveIdempotencyResult({
+      userId: auth.userId,
+      idempotencyKey,
+      method: c.req.method,
+      path: c.req.path,
+      requestHash: precheck.requestHash,
+      statusCode: 200,
+      responseBody: serialized,
+    });
+
+    return new Response(serialized, {
+      status: 200,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    });
   });
 
   app.get('/api/v1/settings/executor-status', async (c) => {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -307,7 +307,7 @@ export async function runContainerAgent(
     let stderrTruncated = false;
 
     // Pass secrets via stdin (never written to disk or mounted as files)
-    input.secrets = readSecrets();
+    input.secrets = input.secrets ?? readSecrets();
     container.stdin.write(JSON.stringify(input));
     container.stdin.end();
     // Remove secrets from input so they don't appear in logs

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('runAgent', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('fails fast before starting the container when executor auth is blocked', async () => {
+    const runContainerAgent = vi.fn();
+
+    vi.doMock('./clawrocket/talks/executor-settings.js', () => ({
+      getActiveExecutorSettingsService: () => ({
+        getExecutionBlockedReason: () =>
+          'Anthropic credentials are not configured for the selected core executor mode.',
+      }),
+    }));
+
+    vi.doMock('./container-runner.js', async () => {
+      const actual = await vi.importActual<
+        typeof import('./container-runner.js')
+      >('./container-runner.js');
+      return {
+        ...actual,
+        runContainerAgent,
+      };
+    });
+
+    const { runAgent } = await import('./index.js');
+
+    const result = await runAgent(
+      {
+        name: 'Blocked Group',
+        folder: 'blocked-group',
+        trigger: '@blocked',
+        added_at: new Date().toISOString(),
+        requiresTrigger: false,
+        isMain: false,
+      },
+      'Hello',
+      'chat:blocked',
+    );
+
+    expect(result).toBe('error');
+    expect(runContainerAgent).not.toHaveBeenCalled();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import { findChannel, formatMessages, formatOutbound } from './router.js';
 import { startSchedulerLoop } from './task-scheduler.js';
 import { Channel, NewMessage, RegisteredGroup } from './types.js';
 import { startWebServer } from './clawrocket/web/index.js';
+import { getActiveExecutorSettingsService } from './clawrocket/talks/executor-settings.js';
 import { InstanceCoordinator } from './instance-coordinator.js';
 import { logger } from './logger.js';
 
@@ -254,12 +255,19 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   return true;
 }
 
-async function runAgent(
+export async function runAgent(
   group: RegisteredGroup,
   prompt: string,
   chatJid: string,
   onOutput?: (output: ContainerOutput) => Promise<void>,
 ): Promise<'success' | 'error'> {
+  const blockedReason =
+    getActiveExecutorSettingsService().getExecutionBlockedReason();
+  if (blockedReason) {
+    logger.error({ group: group.name, reason: blockedReason }, 'Agent error');
+    return 'error';
+  }
+
   const isMain = group.isMain === true;
   const sessionId = sessions[group.folder];
 

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -146,9 +146,20 @@ export type ExecutorSettings = {
   configuredAliasMap: Record<string, string>;
   effectiveAliasMap: Record<string, string>;
   defaultAlias: string;
+  executorAuthMode: 'subscription' | 'api_key' | 'advanced_bearer' | 'none';
   hasApiKey: boolean;
   hasOauthToken: boolean;
   hasAuthToken: boolean;
+  activeCredentialConfigured: boolean;
+  verificationStatus:
+    | 'missing'
+    | 'not_verified'
+    | 'verifying'
+    | 'verified'
+    | 'invalid'
+    | 'unavailable';
+  lastVerifiedAt: string | null;
+  lastVerificationError: string | null;
   anthropicBaseUrl: string;
   isConfigured: boolean;
   configVersion: number;
@@ -158,6 +169,7 @@ export type ExecutorSettings = {
 };
 
 export type ExecutorSettingsUpdate = {
+  executorAuthMode?: 'subscription' | 'api_key' | 'advanced_bearer' | 'none';
   anthropicApiKey?: string | null;
   claudeOauthToken?: string | null;
   anthropicAuthToken?: string | null;
@@ -171,13 +183,42 @@ export type ExecutorStatus = {
   restartSupported: boolean;
   pendingRestartReasons: string[];
   activeRunCount: number;
+  executorAuthMode: 'subscription' | 'api_key' | 'advanced_bearer' | 'none';
+  activeCredentialConfigured: boolean;
+  verificationStatus:
+    | 'missing'
+    | 'not_verified'
+    | 'verifying'
+    | 'verified'
+    | 'invalid'
+    | 'unavailable';
+  lastVerifiedAt: string | null;
+  lastVerificationError: string | null;
   hasProviderAuth: boolean;
   hasValidAliasMap: boolean;
-  detectedAuthMethod: 'oauth' | 'api_key' | 'auth_token' | 'none';
   configVersion: number;
   isConfigured: boolean;
   bootId: string;
   configErrors: string[];
+};
+
+export type ExecutorSubscriptionHostStatus = {
+  serviceUser: string | null;
+  serviceUid: number | null;
+  serviceHomePath: string;
+  runtimeContext: 'host' | 'systemd' | 'container' | 'unknown';
+  claudeCliInstalled: boolean | null;
+  hostLoginDetected: boolean;
+  serviceEnvOauthPresent: boolean;
+  importAvailable: boolean;
+  hostCredentialFingerprint: string | null;
+  message: string;
+  recommendedCommands: string[];
+};
+
+export type ExecutorSubscriptionImportResult = {
+  status: 'imported' | 'no_change';
+  settings: ExecutorSettings;
 };
 
 type ApiEnvelope<T> =
@@ -354,6 +395,42 @@ export async function updateExecutorSettings(
 
 export async function getExecutorStatus(): Promise<ExecutorStatus> {
   return apiRequest<ExecutorStatus>('/api/v1/settings/executor-status');
+}
+
+export async function verifyExecutorCredentials(): Promise<{
+  scheduled: boolean;
+  code: string;
+  message: string;
+}> {
+  return apiRequest<{
+    scheduled: boolean;
+    code: string;
+    message: string;
+  }>('/api/v1/settings/executor/verify', {
+    method: 'POST',
+    headers: buildMutationHeaders({ includeJson: false }),
+  });
+}
+
+export async function getExecutorSubscriptionHostStatus(): Promise<ExecutorSubscriptionHostStatus> {
+  return apiRequest<ExecutorSubscriptionHostStatus>(
+    '/api/v1/settings/executor/subscription-host-status',
+  );
+}
+
+export async function importExecutorSubscriptionFromHost(
+  expectedFingerprint: string,
+): Promise<ExecutorSubscriptionImportResult> {
+  return apiRequest<ExecutorSubscriptionImportResult>(
+    '/api/v1/settings/executor/subscription/import',
+    {
+      method: 'POST',
+      headers: buildMutationHeaders({ includeJson: true }),
+      body: JSON.stringify({
+        expectedFingerprint,
+      }),
+    },
+  );
 }
 
 export async function restartService(): Promise<{

--- a/webapp/src/pages/SettingsPage.test.tsx
+++ b/webapp/src/pages/SettingsPage.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -19,9 +19,14 @@ describe('SettingsPage', () => {
           configuredAliasMap: { Gemini: 'gemini-pro' },
           effectiveAliasMap: { Mock: 'default', Gemini: 'gemini-pro' },
           defaultAlias: 'Gemini',
+          executorAuthMode: 'api_key',
           hasApiKey: true,
           hasOauthToken: false,
           hasAuthToken: false,
+          activeCredentialConfigured: true,
+          verificationStatus: 'verified',
+          lastVerifiedAt: '2026-03-05T12:00:00.000Z',
+          lastVerificationError: null,
           anthropicBaseUrl: 'https://api.example.test',
           isConfigured: true,
           configVersion: 1,
@@ -37,9 +42,13 @@ describe('SettingsPage', () => {
           restartSupported: true,
           pendingRestartReasons: ['Alias model map changed'],
           activeRunCount: 2,
+          executorAuthMode: 'api_key',
+          activeCredentialConfigured: true,
+          verificationStatus: 'verified',
+          lastVerifiedAt: '2026-03-05T12:00:00.000Z',
+          lastVerificationError: null,
           hasProviderAuth: true,
           hasValidAliasMap: false,
-          detectedAuthMethod: 'api_key',
           configVersion: 1,
           isConfigured: true,
           bootId: 'boot-1',
@@ -57,7 +66,7 @@ describe('SettingsPage', () => {
       await screen.findByText('Configuration errors detected.'),
     ).toBeTruthy();
     expect(await screen.findByText('Alias model map changed')).toBeTruthy();
-    expect(await screen.findByText('Detected auth')).toBeTruthy();
+    expect(await screen.findByText('Selected auth mode')).toBeTruthy();
     expect(
       await screen.findByRole('button', {
         name: 'Restart ClawRocket Service',
@@ -73,9 +82,14 @@ describe('SettingsPage', () => {
           configuredAliasMap: {},
           effectiveAliasMap: { Mock: 'default' },
           defaultAlias: 'Mock',
+          executorAuthMode: 'none',
           hasApiKey: false,
           hasOauthToken: false,
           hasAuthToken: false,
+          activeCredentialConfigured: false,
+          verificationStatus: 'missing',
+          lastVerifiedAt: null,
+          lastVerificationError: null,
           anthropicBaseUrl: '',
           isConfigured: false,
           configVersion: 0,
@@ -91,9 +105,13 @@ describe('SettingsPage', () => {
           restartSupported: true,
           pendingRestartReasons: ['Default alias changed from Mock to Gemini'],
           activeRunCount: 0,
+          executorAuthMode: 'none',
+          activeCredentialConfigured: false,
+          verificationStatus: 'missing',
+          lastVerifiedAt: null,
+          lastVerificationError: null,
           hasProviderAuth: false,
           hasValidAliasMap: true,
-          detectedAuthMethod: 'none',
           configVersion: 0,
           isConfigured: false,
           bootId: 'boot-2',
@@ -126,9 +144,14 @@ describe('SettingsPage', () => {
           configuredAliasMap: {},
           effectiveAliasMap: { Mock: 'default' },
           defaultAlias: 'Mock',
+          executorAuthMode: 'none',
           hasApiKey: false,
           hasOauthToken: false,
           hasAuthToken: false,
+          activeCredentialConfigured: false,
+          verificationStatus: 'missing',
+          lastVerifiedAt: null,
+          lastVerificationError: null,
           anthropicBaseUrl: '',
           isConfigured: false,
           configVersion: 0,
@@ -144,9 +167,13 @@ describe('SettingsPage', () => {
           restartSupported: false,
           pendingRestartReasons: [],
           activeRunCount: 0,
+          executorAuthMode: 'none',
+          activeCredentialConfigured: false,
+          verificationStatus: 'missing',
+          lastVerifiedAt: null,
+          lastVerificationError: null,
           hasProviderAuth: false,
           hasValidAliasMap: true,
-          detectedAuthMethod: 'none',
           configVersion: 0,
           isConfigured: false,
           bootId: 'boot-3',
@@ -213,6 +240,284 @@ describe('SettingsPage', () => {
     expect((await screen.findAllByText('Anthropic Prod')).length).toBeGreaterThan(0);
     expect(await screen.findByRole('heading', { name: 'Routes' })).toBeTruthy();
     expect(await screen.findByDisplayValue('route.primary')).toBeTruthy();
+  });
+
+  it('preserves explicit credential clears when switching auth modes before save', async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn();
+    const responses = [
+      jsonResponse(200, {
+        ok: true,
+        data: {
+          configuredAliasMap: {},
+          effectiveAliasMap: { Mock: 'default' },
+          defaultAlias: 'Mock',
+          executorAuthMode: 'api_key',
+          hasApiKey: true,
+          hasOauthToken: true,
+          hasAuthToken: false,
+          activeCredentialConfigured: true,
+          verificationStatus: 'verified',
+          lastVerifiedAt: '2026-03-05T12:00:00.000Z',
+          lastVerificationError: null,
+          anthropicBaseUrl: '',
+          isConfigured: true,
+          configVersion: 3,
+          lastUpdatedAt: '2026-03-05T12:00:00.000Z',
+          lastUpdatedBy: { id: 'owner-1', displayName: 'Owner' },
+          configErrors: [],
+        },
+      }),
+      jsonResponse(200, {
+        ok: true,
+        data: {
+          mode: 'real',
+          restartSupported: true,
+          pendingRestartReasons: [],
+          activeRunCount: 0,
+          executorAuthMode: 'api_key',
+          activeCredentialConfigured: true,
+          verificationStatus: 'verified',
+          lastVerifiedAt: '2026-03-05T12:00:00.000Z',
+          lastVerificationError: null,
+          hasProviderAuth: true,
+          hasValidAliasMap: true,
+          configVersion: 3,
+          isConfigured: true,
+          bootId: 'boot-4',
+          configErrors: [],
+        },
+      }),
+      jsonResponse(200, {
+        ok: true,
+        data: {
+          configuredAliasMap: {},
+          effectiveAliasMap: { Mock: 'default' },
+          defaultAlias: 'Mock',
+          executorAuthMode: 'subscription',
+          hasApiKey: false,
+          hasOauthToken: true,
+          hasAuthToken: false,
+          activeCredentialConfigured: true,
+          verificationStatus: 'verified',
+          lastVerifiedAt: '2026-03-05T12:00:00.000Z',
+          lastVerificationError: null,
+          anthropicBaseUrl: '',
+          isConfigured: true,
+          configVersion: 4,
+          lastUpdatedAt: '2026-03-06T12:00:00.000Z',
+          lastUpdatedBy: { id: 'owner-1', displayName: 'Owner' },
+          configErrors: [],
+        },
+      }),
+      jsonResponse(200, {
+        ok: true,
+        data: {
+          mode: 'real',
+          restartSupported: true,
+          pendingRestartReasons: [],
+          activeRunCount: 0,
+          executorAuthMode: 'subscription',
+          activeCredentialConfigured: true,
+          verificationStatus: 'verified',
+          lastVerifiedAt: '2026-03-05T12:00:00.000Z',
+          lastVerificationError: null,
+          hasProviderAuth: true,
+          hasValidAliasMap: true,
+          configVersion: 4,
+          isConfigured: true,
+          bootId: 'boot-5',
+          configErrors: [],
+        },
+      }),
+    ];
+
+    fetchMock.mockImplementation(async (_input, init) => {
+      const next = responses.shift();
+      if (!next) {
+        throw new Error('No mocked response left for fetch()');
+      }
+      return next;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<SettingsPage onUnauthorized={vi.fn()} userRole="owner" />);
+
+    await screen.findByRole('heading', { name: 'Executor Settings' });
+    await user.click(screen.getByRole('button', { name: 'Clear API Key' }));
+    await user.selectOptions(
+      screen.getByLabelText('Active auth mode'),
+      'subscription',
+    );
+    await user.click(
+      screen.getByRole('button', { name: 'Save Credential Settings' }),
+    );
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    });
+
+    const saveCall = fetchMock.mock.calls[2];
+    const body = JSON.parse(String(saveCall?.[1]?.body ?? '{}')) as Record<
+      string,
+      string | null
+    >;
+
+    expect(body.executorAuthMode).toBe('subscription');
+    expect(body.anthropicApiKey).toBeNull();
+  });
+
+  it('guides subscription users through host check and import', async () => {
+    const user = userEvent.setup();
+    let imported = false;
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input, init) => {
+        const url = String(input);
+        const method = init?.method || 'GET';
+
+        if (url.endsWith('/api/v1/settings/executor') && method === 'GET') {
+          return jsonResponse(200, {
+            ok: true,
+            data: {
+              configuredAliasMap: {},
+              effectiveAliasMap: { Mock: 'default' },
+              defaultAlias: 'Mock',
+              executorAuthMode: imported ? 'subscription' : 'none',
+              hasApiKey: false,
+              hasOauthToken: imported,
+              hasAuthToken: false,
+              activeCredentialConfigured: imported,
+              verificationStatus: imported ? 'not_verified' : 'missing',
+              lastVerifiedAt: null,
+              lastVerificationError: null,
+              anthropicBaseUrl: '',
+              isConfigured: imported,
+              configVersion: imported ? 2 : 1,
+              lastUpdatedAt: null,
+              lastUpdatedBy: null,
+              configErrors: [],
+            },
+          });
+        }
+
+        if (url.endsWith('/api/v1/settings/executor-status') && method === 'GET') {
+          return jsonResponse(200, {
+            ok: true,
+            data: {
+              mode: imported ? 'real' : 'mock',
+              restartSupported: false,
+              pendingRestartReasons: [],
+              activeRunCount: 0,
+              executorAuthMode: imported ? 'subscription' : 'none',
+              activeCredentialConfigured: imported,
+              verificationStatus: imported ? 'not_verified' : 'missing',
+              lastVerifiedAt: null,
+              lastVerificationError: null,
+              hasProviderAuth: imported,
+              hasValidAliasMap: true,
+              configVersion: imported ? 2 : 1,
+              isConfigured: imported,
+              bootId: imported ? 'boot-imported' : 'boot-initial',
+              configErrors: [],
+            },
+          });
+        }
+
+        if (
+          url.endsWith('/api/v1/settings/executor/subscription-host-status') &&
+          method === 'GET'
+        ) {
+          return jsonResponse(200, {
+            ok: true,
+            data: {
+              serviceUser: 'clawrocket',
+              serviceUid: 1001,
+              serviceHomePath: '/srv/clawrocket',
+              runtimeContext: 'systemd',
+              claudeCliInstalled: true,
+              hostLoginDetected: true,
+              serviceEnvOauthPresent: true,
+              importAvailable: true,
+              hostCredentialFingerprint: 'fingerprint-1',
+              message:
+                'A Claude Code OAuth token is already present in the ClawRocket service environment and can be imported into settings.',
+              recommendedCommands: ['sudo -u clawrocket -H claude login'],
+            },
+          });
+        }
+
+        if (
+          url.endsWith('/api/v1/settings/executor/subscription/import') &&
+          method === 'POST'
+        ) {
+          imported = true;
+          return jsonResponse(200, {
+            ok: true,
+            data: {
+              status: 'imported',
+              settings: {
+                configuredAliasMap: {},
+                effectiveAliasMap: { Mock: 'default' },
+                defaultAlias: 'Mock',
+                executorAuthMode: 'subscription',
+                hasApiKey: false,
+                hasOauthToken: true,
+                hasAuthToken: false,
+                activeCredentialConfigured: true,
+                verificationStatus: 'not_verified',
+                lastVerifiedAt: null,
+                lastVerificationError: null,
+                anthropicBaseUrl: '',
+                isConfigured: true,
+                configVersion: 2,
+                lastUpdatedAt: null,
+                lastUpdatedBy: null,
+                configErrors: [],
+              },
+            },
+          });
+        }
+
+        throw new Error(`Unexpected fetch: ${method} ${url}`);
+      }),
+    );
+
+    render(<SettingsPage onUnauthorized={vi.fn()} userRole="owner" />);
+
+    await screen.findByRole('heading', { name: 'Executor Settings' });
+    await user.selectOptions(
+      screen.getByLabelText('Active auth mode'),
+      'subscription',
+    );
+    await user.click(
+      screen.getByRole('button', { name: 'Check host Claude login' }),
+    );
+
+    expect(await screen.findByText('Checked as user')).toBeTruthy();
+    expect(await screen.findByText('clawrocket')).toBeTruthy();
+    expect(
+      (
+        await screen.findAllByText(
+          /already present in the ClawRocket service environment/i,
+        )
+      ).length,
+    ).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole('button', { name: 'Import from host' }));
+
+    expect(
+      await screen.findByText(
+        /Subscription credential imported from the service host/i,
+      ),
+    ).toBeTruthy();
+    const selectedModeLabel = await screen.findByText('Selected auth mode');
+    expect(
+      within(selectedModeLabel.parentElement as HTMLElement).getByText(
+        'Subscription (Claude Pro/Max)',
+      ),
+    ).toBeTruthy();
   });
 });
 

--- a/webapp/src/pages/SettingsPage.tsx
+++ b/webapp/src/pages/SettingsPage.tsx
@@ -1,15 +1,19 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   ApiError,
   ExecutorSettings,
+  ExecutorSubscriptionHostStatus,
   ExecutorStatus,
   getExecutorSettings,
+  getExecutorSubscriptionHostStatus,
   getExecutorStatus,
   getHealthStatus,
+  importExecutorSubscriptionFromHost,
   restartService,
   UnauthorizedError,
   updateExecutorSettings,
+  verifyExecutorCredentials,
 } from '../lib/api';
 import { TalkLlmSettingsCard } from '../components/TalkLlmSettingsCard';
 
@@ -24,6 +28,8 @@ type Props = {
   userRole: string;
 };
 
+type AuthMode = ExecutorSettings['executorAuthMode'];
+
 function createRowId(): string {
   const randomUUID = globalThis.crypto?.randomUUID;
   if (typeof randomUUID === 'function') {
@@ -32,9 +38,7 @@ function createRowId(): string {
   return `alias-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
-function configuredAliasRows(
-  aliasMap: Record<string, string>,
-): AliasRow[] {
+function configuredAliasRows(aliasMap: Record<string, string>): AliasRow[] {
   return Object.entries(aliasMap).map(([alias, model]) => ({
     id: createRowId(),
     alias,
@@ -42,26 +46,45 @@ function configuredAliasRows(
   }));
 }
 
-function formatDetectedAuth(
-  method: ExecutorStatus['detectedAuthMethod'],
-): string {
-  switch (method) {
-    case 'oauth':
-      return 'OAuth token';
-    case 'api_key':
-      return 'API key';
-    case 'auth_token':
-      return 'Auth token';
-    default:
-      return 'None';
-  }
-}
-
 function formatDateTime(value: string | null): string {
   if (!value) return 'Never configured';
   const parsed = new Date(value);
   if (Number.isNaN(parsed.valueOf())) return value;
   return parsed.toLocaleString();
+}
+
+function formatAuthMode(mode: AuthMode): string {
+  switch (mode) {
+    case 'subscription':
+      return 'Subscription (Claude Pro/Max)';
+    case 'api_key':
+      return 'API Key (Anthropic Console)';
+    case 'advanced_bearer':
+      return 'Advanced bearer / gateway';
+    default:
+      return 'None';
+  }
+}
+
+function formatVerificationStatus(
+  status: ExecutorStatus['verificationStatus'],
+): string {
+  switch (status) {
+    case 'missing':
+      return 'Missing';
+    case 'not_verified':
+      return 'Not verified';
+    case 'verifying':
+      return 'Verifying…';
+    case 'verified':
+      return 'Valid';
+    case 'invalid':
+      return 'Invalid';
+    case 'unavailable':
+      return 'Unavailable';
+    default:
+      return status;
+  }
 }
 
 function sleep(ms: number): Promise<void> {
@@ -89,16 +112,34 @@ function normalizeAliasDraft(rows: AliasRow[]): Record<string, string> {
   return normalized;
 }
 
+function standbyCredentials(settings: ExecutorSettings): string[] {
+  const items: string[] = [];
+  if (settings.hasOauthToken && settings.executorAuthMode !== 'subscription') {
+    items.push('Subscription login configured');
+  }
+  if (settings.hasApiKey && settings.executorAuthMode !== 'api_key') {
+    items.push('API Key configured');
+  }
+  if (
+    settings.hasAuthToken &&
+    settings.executorAuthMode !== 'advanced_bearer'
+  ) {
+    items.push('Advanced bearer configured');
+  }
+  return items;
+}
+
 export function SettingsPage({ onUnauthorized, userRole }: Props) {
   const [settings, setSettings] = useState<ExecutorSettings | null>(null);
   const [status, setStatus] = useState<ExecutorStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [busySection, setBusySection] = useState<
-    'credentials' | 'runtime' | 'aliases' | 'restart' | null
+    'credentials' | 'verification' | 'aliases' | 'restart' | null
   >(null);
   const [pageError, setPageError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
+  const [authModeDraft, setAuthModeDraft] = useState<AuthMode>('none');
   const [apiKeyDraft, setApiKeyDraft] = useState('');
   const [oauthDraft, setOauthDraft] = useState('');
   const [authTokenDraft, setAuthTokenDraft] = useState('');
@@ -109,11 +150,20 @@ export function SettingsPage({ onUnauthorized, userRole }: Props) {
   const [clearBaseUrl, setClearBaseUrl] = useState(false);
   const [aliasRows, setAliasRows] = useState<AliasRow[]>([]);
   const [defaultAliasDraft, setDefaultAliasDraft] = useState('Mock');
+  const [subscriptionHostStatus, setSubscriptionHostStatus] =
+    useState<ExecutorSubscriptionHostStatus | null>(null);
+  const [subscriptionHostBusy, setSubscriptionHostBusy] = useState<
+    'checking' | 'importing' | null
+  >(null);
+  const [showSubscriptionAdvanced, setShowSubscriptionAdvanced] =
+    useState(false);
+  const verificationPollAttemptsRef = useRef(0);
 
   const applySettingsDrafts = (nextSettings: ExecutorSettings): void => {
     setSettings(nextSettings);
     setAliasRows(configuredAliasRows(nextSettings.configuredAliasMap));
     setDefaultAliasDraft(nextSettings.defaultAlias);
+    setAuthModeDraft(nextSettings.executorAuthMode);
     setBaseUrlDraft(nextSettings.anthropicBaseUrl || '');
     setApiKeyDraft('');
     setOauthDraft('');
@@ -150,6 +200,53 @@ export function SettingsPage({ onUnauthorized, userRole }: Props) {
     void loadPage();
   }, []);
 
+  useEffect(() => {
+    if (status?.verificationStatus !== 'verifying') {
+      verificationPollAttemptsRef.current = 0;
+      return;
+    }
+
+    let cancelled = false;
+    let timer: number | null = null;
+
+    const scheduleNextPoll = (): void => {
+      const attempt = verificationPollAttemptsRef.current;
+      const delayMs = attempt < 5 ? 2_000 : attempt < 15 ? 5_000 : 10_000;
+      timer = window.setTimeout(() => {
+        void getExecutorStatus()
+          .then((nextStatus) => {
+            if (cancelled) return;
+            verificationPollAttemptsRef.current += 1;
+            setStatus(nextStatus);
+            if (nextStatus.verificationStatus === 'verifying') {
+              scheduleNextPoll();
+            }
+          })
+          .catch((err) => {
+            if (cancelled) return;
+            if (err instanceof UnauthorizedError) {
+              onUnauthorized();
+              return;
+            }
+            setPageError(
+              err instanceof ApiError
+                ? err.message
+                : 'Failed to refresh verification status.',
+            );
+          });
+      }, delayMs);
+    };
+
+    scheduleNextPoll();
+
+    return () => {
+      cancelled = true;
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+    };
+  }, [status?.verificationStatus, onUnauthorized]);
+
   const configErrors = useMemo(() => {
     const combined = new Set<string>();
     for (const error of settings?.configErrors || []) combined.add(error);
@@ -162,7 +259,10 @@ export function SettingsPage({ onUnauthorized, userRole }: Props) {
     return Object.fromEntries(
       Object.entries(settings.effectiveAliasMap).filter(
         ([alias]) =>
-          !Object.prototype.hasOwnProperty.call(settings.configuredAliasMap, alias),
+          !Object.prototype.hasOwnProperty.call(
+            settings.configuredAliasMap,
+            alias,
+          ),
       ),
     );
   }, [settings]);
@@ -187,37 +287,73 @@ export function SettingsPage({ onUnauthorized, userRole }: Props) {
   };
 
   const saveCredentials = async (): Promise<void> => {
+    if (!settings) return;
+
     setBusySection('credentials');
     setPageError(null);
     setNotice(null);
 
     try {
-      const update: Record<string, string | null> = {};
-      if (clearApiKey) update.anthropicApiKey = null;
-      else if (apiKeyDraft.trim()) update.anthropicApiKey = apiKeyDraft.trim();
-      if (clearOauth) update.claudeOauthToken = null;
-      else if (oauthDraft.trim()) update.claudeOauthToken = oauthDraft.trim();
-      if (clearAuthToken) update.anthropicAuthToken = null;
-      else if (authTokenDraft.trim()) {
-        update.anthropicAuthToken = authTokenDraft.trim();
+      const update: Record<string, string | null> = {
+        executorAuthMode: authModeDraft,
+      };
+
+      if (clearOauth) {
+        update.claudeOauthToken = null;
+      } else if (authModeDraft === 'subscription') {
+        if (oauthDraft.trim()) {
+          update.claudeOauthToken = oauthDraft.trim();
+        }
       }
 
-      if (Object.keys(update).length === 0) {
-        setNotice('No credential changes to save.');
-        return;
+      if (clearApiKey) {
+        update.anthropicApiKey = null;
+      } else if (authModeDraft === 'api_key') {
+        if (apiKeyDraft.trim()) {
+          update.anthropicApiKey = apiKeyDraft.trim();
+        }
+      }
+
+      if (clearAuthToken) {
+        update.anthropicAuthToken = null;
+      } else if (authModeDraft === 'advanced_bearer') {
+        if (authTokenDraft.trim()) {
+          update.anthropicAuthToken = authTokenDraft.trim();
+        }
+      }
+
+      if (clearBaseUrl) {
+        update.anthropicBaseUrl = null;
+      } else if (
+        (authModeDraft === 'api_key' || authModeDraft === 'advanced_bearer') &&
+        baseUrlDraft.trim() !== (settings.anthropicBaseUrl || '')
+      ) {
+        update.anthropicBaseUrl = baseUrlDraft.trim();
       }
 
       const nextSettings = await updateExecutorSettings(update);
       applySettingsDrafts(nextSettings);
       const nextStatus = await getExecutorStatus();
       setStatus(nextStatus);
-      setNotice(
-        nextStatus.pendingRestartReasons.some((reason) =>
-          reason.includes('Executor mode'),
-        )
-          ? 'Credentials saved. Restart required to change executor mode.'
-          : 'Credentials saved. Changes take effect on the next talk run.',
-      );
+
+      if (
+        nextSettings.executorAuthMode === 'api_key' ||
+        nextSettings.executorAuthMode === 'advanced_bearer'
+      ) {
+        setNotice(
+          nextStatus.verificationStatus === 'verifying'
+            ? 'Credentials saved. Verification is running in the background.'
+            : 'Credentials saved. Use Re-verify if you want to validate the active credential now.',
+        );
+      } else if (nextSettings.executorAuthMode === 'subscription') {
+        setNotice(
+          'Credentials saved. Use Check host Claude login for guided setup, or Verify subscription to confirm the current environment can execute with the selected subscription credential.',
+        );
+      } else {
+        setNotice(
+          'Credentials saved. Core executor runs will remain unavailable until an active Anthropic auth mode is configured.',
+        );
+      }
     } catch (err) {
       handleApiFailure(err, 'Failed to save credentials.');
     } finally {
@@ -225,33 +361,79 @@ export function SettingsPage({ onUnauthorized, userRole }: Props) {
     }
   };
 
-  const saveRuntimeConfig = async (): Promise<void> => {
-    setBusySection('runtime');
+  const handleVerify = async (): Promise<void> => {
+    setBusySection('verification');
     setPageError(null);
     setNotice(null);
 
     try {
-      const update =
-        clearBaseUrl || baseUrlDraft.trim() !== (settings?.anthropicBaseUrl || '')
-          ? {
-              anthropicBaseUrl: clearBaseUrl ? null : baseUrlDraft.trim(),
-            }
-          : null;
-
-      if (!update) {
-        setNotice('No runtime-config changes to save.');
-        return;
-      }
-
-      const nextSettings = await updateExecutorSettings(update);
-      applySettingsDrafts(nextSettings);
+      const result = await verifyExecutorCredentials();
       const nextStatus = await getExecutorStatus();
       setStatus(nextStatus);
-      setNotice('Runtime config saved. Base URL changes apply on the next talk run.');
+      setNotice(result.message);
     } catch (err) {
-      handleApiFailure(err, 'Failed to save runtime config.');
+      handleApiFailure(err, 'Failed to start verification.');
     } finally {
       setBusySection(null);
+    }
+  };
+
+  const checkSubscriptionHostLogin = async (): Promise<void> => {
+    setSubscriptionHostBusy('checking');
+    setPageError(null);
+    setNotice(null);
+
+    try {
+      const nextHostStatus = await getExecutorSubscriptionHostStatus();
+      setSubscriptionHostStatus(nextHostStatus);
+      if (
+        !nextHostStatus.importAvailable &&
+        !nextHostStatus.serviceEnvOauthPresent &&
+        (!nextHostStatus.claudeCliInstalled || nextHostStatus.hostLoginDetected)
+      ) {
+        setShowSubscriptionAdvanced(true);
+      }
+      setNotice(nextHostStatus.message);
+    } catch (err) {
+      handleApiFailure(err, 'Failed to check Claude host login.');
+    } finally {
+      setSubscriptionHostBusy(null);
+    }
+  };
+
+  const importSubscriptionFromHost = async (): Promise<void> => {
+    if (!subscriptionHostStatus?.hostCredentialFingerprint) return;
+
+    setSubscriptionHostBusy('importing');
+    setPageError(null);
+    setNotice(null);
+
+    try {
+      const result = await importExecutorSubscriptionFromHost(
+        subscriptionHostStatus.hostCredentialFingerprint,
+      );
+      applySettingsDrafts(result.settings);
+      const nextStatus = await getExecutorStatus();
+      setStatus(nextStatus);
+      const latestHostStatus = await getExecutorSubscriptionHostStatus();
+      setSubscriptionHostStatus(latestHostStatus);
+      setNotice(
+        result.status === 'no_change'
+          ? 'The host subscription credential is already imported into settings.'
+          : 'Subscription credential imported from the service host. Use Verify subscription to confirm this environment can execute with it.',
+      );
+    } catch (err) {
+      handleApiFailure(err, 'Failed to import subscription credential from host.');
+      if (err instanceof ApiError && err.code === 'host_state_changed') {
+        try {
+          const latestHostStatus = await getExecutorSubscriptionHostStatus();
+          setSubscriptionHostStatus(latestHostStatus);
+        } catch {
+          // Ignore refresh failures after the primary error.
+        }
+      }
+    } finally {
+      setSubscriptionHostBusy(null);
     }
   };
 
@@ -273,7 +455,9 @@ export function SettingsPage({ onUnauthorized, userRole }: Props) {
       applySettingsDrafts(nextSettings);
       const nextStatus = await getExecutorStatus();
       setStatus(nextStatus);
-      setNotice('Alias settings saved. Restart required for constructor-captured changes.');
+      setNotice(
+        'Alias settings saved. Restart required for constructor-captured changes.',
+      );
     } catch (err) {
       handleApiFailure(err, 'Failed to save alias settings.');
     } finally {
@@ -341,7 +525,17 @@ export function SettingsPage({ onUnauthorized, userRole }: Props) {
   }
 
   const seedAliases = Object.entries(settings.effectiveAliasMap).filter(
-    ([alias]) => !Object.prototype.hasOwnProperty.call(settings.configuredAliasMap, alias),
+    ([alias]) =>
+      !Object.prototype.hasOwnProperty.call(settings.configuredAliasMap, alias),
+  );
+  const standby = standbyCredentials(settings);
+  const showBaseUrl =
+    authModeDraft === 'api_key' || authModeDraft === 'advanced_bearer';
+  const verifyButtonLabel =
+    authModeDraft === 'subscription' ? 'Verify subscription' : 'Re-verify';
+  const showSubscriptionImportButton = Boolean(
+    subscriptionHostStatus?.importAvailable &&
+      subscriptionHostStatus.hostCredentialFingerprint,
   );
 
   return (
@@ -349,12 +543,19 @@ export function SettingsPage({ onUnauthorized, userRole }: Props) {
       <header className="page-header">
         <div>
           <h1>Executor Settings</h1>
-          <p>Manage Anthropic-compatible executor credentials, aliases, and restart-required changes.</p>
+          <p>
+            Manage Anthropic auth mode, aliases, and restart-required changes
+            for the core executor.
+          </p>
         </div>
       </header>
 
-      {pageError ? <div className="settings-banner settings-banner-error">{pageError}</div> : null}
-      {notice ? <div className="settings-banner settings-banner-success">{notice}</div> : null}
+      {pageError ? (
+        <div className="settings-banner settings-banner-error">{pageError}</div>
+      ) : null}
+      {notice ? (
+        <div className="settings-banner settings-banner-success">{notice}</div>
+      ) : null}
       {configErrors.length > 0 ? (
         <div className="settings-banner settings-banner-error">
           <strong>Configuration errors detected.</strong>
@@ -387,12 +588,18 @@ export function SettingsPage({ onUnauthorized, userRole }: Props) {
             <strong>{status.mode}</strong>
           </div>
           <div>
-            <span className="settings-label">Detected auth</span>
-            <strong>{formatDetectedAuth(status.detectedAuthMethod)}</strong>
+            <span className="settings-label">Selected auth mode</span>
+            <strong>{formatAuthMode(status.executorAuthMode)}</strong>
           </div>
           <div>
-            <span className="settings-label">Provider auth</span>
-            <strong>{status.hasProviderAuth ? 'Configured' : 'Missing'}</strong>
+            <span className="settings-label">Credential</span>
+            <strong>
+              {status.activeCredentialConfigured ? 'Configured' : 'Missing'}
+            </strong>
+          </div>
+          <div>
+            <span className="settings-label">Verification</span>
+            <strong>{formatVerificationStatus(status.verificationStatus)}</strong>
           </div>
           <div>
             <span className="settings-label">Alias map</span>
@@ -400,137 +607,364 @@ export function SettingsPage({ onUnauthorized, userRole }: Props) {
           </div>
           <div>
             <span className="settings-label">Config status</span>
-            <strong>{settings.isConfigured ? 'Owned by settings page' : 'Using bootstrap defaults'}</strong>
+            <strong>
+              {settings.isConfigured
+                ? 'Owned by settings page'
+                : 'Using bootstrap defaults'}
+            </strong>
           </div>
           <div>
             <span className="settings-label">Active runs</span>
             <strong>{status.activeRunCount}</strong>
           </div>
+          <div>
+            <span className="settings-label">Last verified</span>
+            <strong>{formatDateTime(status.lastVerifiedAt)}</strong>
+          </div>
         </div>
+        {status.lastVerificationError ? (
+          <p className="settings-copy">
+            <strong>Verification note:</strong> {status.lastVerificationError}
+          </p>
+        ) : null}
       </section>
 
       <section className="settings-card">
         <h2>Anthropic Credentials</h2>
         <p className="settings-copy">
-          Detected auth is a best-effort hint based on configured credentials, not a verified SDK contract.
+          Choose the active auth mode for the core executor. Stored standby
+          credentials remain visible but are not exported unless their mode is
+          selected.
         </p>
-        <div className="settings-form-grid">
-          <label>
-            <span>API Key</span>
-            <input
-              type="password"
-              value={apiKeyDraft}
-              onChange={(event) => {
-                setApiKeyDraft(event.target.value);
-                setClearApiKey(false);
-              }}
-              placeholder={settings.hasApiKey ? 'Configured' : 'Not configured'}
-            />
-          </label>
-          <button
-            type="button"
-            className="secondary-btn"
-            onClick={() => {
-              setApiKeyDraft('');
-              setClearApiKey(true);
-            }}
+
+        <label className="settings-field-span">
+          <span>Active auth mode</span>
+          <select
+            value={authModeDraft}
+            onChange={(event) => setAuthModeDraft(event.target.value as AuthMode)}
           >
-            Clear API Key
-          </button>
-          <label>
-            <span>OAuth Token</span>
-            <input
-              type="password"
-              value={oauthDraft}
-              onChange={(event) => {
-                setOauthDraft(event.target.value);
-                setClearOauth(false);
-              }}
-              placeholder={settings.hasOauthToken ? 'Configured' : 'Not configured'}
-            />
-          </label>
-          <button
-            type="button"
-            className="secondary-btn"
-            onClick={() => {
-              setOauthDraft('');
-              setClearOauth(true);
-            }}
-          >
-            Clear OAuth Token
-          </button>
-          <label>
-            <span>Auth Token</span>
-            <input
-              type="password"
-              value={authTokenDraft}
-              onChange={(event) => {
-                setAuthTokenDraft(event.target.value);
-                setClearAuthToken(false);
-              }}
-              placeholder={settings.hasAuthToken ? 'Configured' : 'Not configured'}
-            />
-          </label>
-          <button
-            type="button"
-            className="secondary-btn"
-            onClick={() => {
-              setAuthTokenDraft('');
-              setClearAuthToken(true);
-            }}
-          >
-            Clear Auth Token
-          </button>
-        </div>
-        {status.mode === 'real' ? (
+            <option value="subscription">Subscription (Claude Pro/Max)</option>
+            <option value="api_key">API Key (Anthropic Console)</option>
+            <option value="advanced_bearer">Advanced bearer / gateway</option>
+            <option value="none">None</option>
+          </select>
+        </label>
+
+        {authModeDraft === 'subscription' ? (
+          <>
+            <p className="settings-copy">
+              Use the Claude Code / Claude.ai subscription path for Claude Pro or
+              Max. Run Claude login on the machine running ClawRocket, as the
+              same OS user that runs the ClawRocket process. API-key mode takes
+              precedence over subscription usage when it is selected.
+            </p>
+            <div className="settings-grid settings-status-grid">
+              <div>
+                <span className="settings-label">Checked as user</span>
+                <strong>
+                  {subscriptionHostStatus?.serviceUser || 'Unknown service user'}
+                </strong>
+              </div>
+              <div>
+                <span className="settings-label">Home</span>
+                <strong>
+                  {subscriptionHostStatus?.serviceHomePath || 'Unknown'}
+                </strong>
+              </div>
+              <div>
+                <span className="settings-label">Host CLI</span>
+                <strong>
+                  {subscriptionHostStatus
+                    ? subscriptionHostStatus.claudeCliInstalled === true
+                      ? 'Installed'
+                      : subscriptionHostStatus.claudeCliInstalled === false
+                        ? 'Not found'
+                        : 'Unavailable'
+                    : 'Not checked'}
+                </strong>
+              </div>
+              <div>
+                <span className="settings-label">Host login</span>
+                <strong>
+                  {subscriptionHostStatus
+                    ? subscriptionHostStatus.hostLoginDetected
+                      ? 'Detected'
+                      : 'Not detected'
+                    : 'Not checked'}
+                </strong>
+              </div>
+            </div>
+
+            <div className="settings-button-row">
+              <button
+                type="button"
+                className="secondary-btn"
+                disabled={subscriptionHostBusy === 'checking'}
+                onClick={() => void checkSubscriptionHostLogin()}
+              >
+                {subscriptionHostBusy === 'checking'
+                  ? 'Checking…'
+                  : 'Check host Claude login'}
+              </button>
+              {showSubscriptionImportButton ? (
+                <button
+                  type="button"
+                  className="secondary-btn"
+                  disabled={subscriptionHostBusy === 'importing'}
+                  onClick={() => void importSubscriptionFromHost()}
+                >
+                  {subscriptionHostBusy === 'importing'
+                    ? 'Importing…'
+                    : 'Import from host'}
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="secondary-btn"
+                onClick={() =>
+                  setShowSubscriptionAdvanced((current) => !current)
+                }
+              >
+                {showSubscriptionAdvanced
+                  ? 'Hide manual token entry'
+                  : 'Paste Claude Code OAuth token manually'}
+              </button>
+            </div>
+
+            {subscriptionHostStatus ? (
+              <div className="settings-host-status">
+                <p className="settings-copy">{subscriptionHostStatus.message}</p>
+                {subscriptionHostStatus.recommendedCommands.length > 0 ? (
+                  <div className="settings-command-list">
+                    <strong>Recommended commands</strong>
+                    <ul>
+                      {subscriptionHostStatus.recommendedCommands.map((command) => (
+                        <li key={command}>
+                          <code>{command}</code>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+
+            {showSubscriptionAdvanced ? (
+              <div className="settings-advanced-box">
+                <p className="settings-copy">
+                  Manual fallback is intended for headless or unsupported host
+                  setups. You can generate a long-lived token with{' '}
+                  <code>claude setup-token</code>, then paste it here.
+                </p>
+                <div className="settings-form-grid">
+                  <label>
+                    <span>Claude Code OAuth Token</span>
+                    <input
+                      type="password"
+                      value={oauthDraft}
+                      onChange={(event) => {
+                        setOauthDraft(event.target.value);
+                        setClearOauth(false);
+                      }}
+                      placeholder={
+                        settings.hasOauthToken ? 'Configured' : 'Not configured'
+                      }
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    className="secondary-btn"
+                    onClick={() => {
+                      setOauthDraft('');
+                      setClearOauth(true);
+                    }}
+                  >
+                    Clear OAuth Token
+                  </button>
+                </div>
+              </div>
+            ) : null}
+          </>
+        ) : null}
+
+        {authModeDraft === 'api_key' ? (
+          <>
+            <p className="settings-copy">
+              Use an Anthropic Console API key for normal API billing. Saving this
+              mode auto-starts verification in the background.
+            </p>
+            <div className="settings-form-grid">
+              <label>
+                <span>API Key</span>
+                <input
+                  type="password"
+                  value={apiKeyDraft}
+                  onChange={(event) => {
+                    setApiKeyDraft(event.target.value);
+                    setClearApiKey(false);
+                  }}
+                  placeholder={
+                    settings.hasApiKey ? 'Configured' : 'Not configured'
+                  }
+                />
+              </label>
+              <button
+                type="button"
+                className="secondary-btn"
+                onClick={() => {
+                  setApiKeyDraft('');
+                  setClearApiKey(true);
+                }}
+              >
+                Clear API Key
+              </button>
+            </div>
+          </>
+        ) : null}
+
+        {authModeDraft === 'advanced_bearer' ? (
+          <>
+            <p className="settings-copy">
+              Advanced bearer mode is intended for custom bearer-token or gateway
+              deployments. Saving this mode auto-starts verification in the
+              background.
+            </p>
+            <div className="settings-form-grid">
+              <label>
+                <span>Auth Token</span>
+                <input
+                  type="password"
+                  value={authTokenDraft}
+                  onChange={(event) => {
+                    setAuthTokenDraft(event.target.value);
+                    setClearAuthToken(false);
+                  }}
+                  placeholder={
+                    settings.hasAuthToken ? 'Configured' : 'Not configured'
+                  }
+                />
+              </label>
+              <button
+                type="button"
+                className="secondary-btn"
+                onClick={() => {
+                  setAuthTokenDraft('');
+                  setClearAuthToken(true);
+                }}
+              >
+                Clear Auth Token
+              </button>
+            </div>
+          </>
+        ) : null}
+
+        {authModeDraft === 'none' ? (
           <p className="settings-copy">
-            Clearing credentials while running in real mode may cause talk execution to fail until a replacement is saved or the service is restarted.
+            The core executor will not export Anthropic credentials while None is
+            selected. Real core runs will fail fast until you choose a mode and
+            configure its credential.
           </p>
         ) : null}
-        <button
-          type="button"
-          className="primary-btn"
-          disabled={busySection === 'credentials'}
-          onClick={() => void saveCredentials()}
-        >
-          {busySection === 'credentials' ? 'Saving…' : 'Save Credentials'}
-        </button>
-      </section>
 
-      <section className="settings-card">
-        <h2>Runtime Config</h2>
-        <div className="settings-form-grid">
-          <label className="settings-field-span">
-            <span>Base URL</span>
-            <input
-              type="text"
-              value={baseUrlDraft}
-              onChange={(event) => {
-                setBaseUrlDraft(event.target.value);
-                setClearBaseUrl(false);
-              }}
-              placeholder="https://api.anthropic.com"
-            />
-          </label>
+        {showBaseUrl ? (
+          <>
+            <p className="settings-copy">
+              Anthropic/Gateway Base URL applies to API Key and Advanced bearer
+              modes only.
+            </p>
+            <div className="settings-form-grid">
+              <label>
+                <span>Anthropic/Gateway Base URL</span>
+                <input
+                  type="text"
+                  value={baseUrlDraft}
+                  onChange={(event) => {
+                    setBaseUrlDraft(event.target.value);
+                    setClearBaseUrl(false);
+                  }}
+                  placeholder="https://api.anthropic.com"
+                />
+              </label>
+              <button
+                type="button"
+                className="secondary-btn"
+                onClick={() => {
+                  setBaseUrlDraft('');
+                  setClearBaseUrl(true);
+                }}
+              >
+                Clear Base URL
+              </button>
+            </div>
+          </>
+        ) : null}
+
+        <div className="settings-grid settings-status-grid">
+          <div>
+            <span className="settings-label">Selected mode</span>
+            <strong>{formatAuthMode(status.executorAuthMode)}</strong>
+          </div>
+          <div>
+            <span className="settings-label">Configured</span>
+            <strong>
+              {status.activeCredentialConfigured ? 'Yes' : 'No'}
+            </strong>
+          </div>
+          <div>
+            <span className="settings-label">Status</span>
+            <strong>{formatVerificationStatus(status.verificationStatus)}</strong>
+          </div>
+          <div>
+            <span className="settings-label">Last verified</span>
+            <strong>{formatDateTime(status.lastVerifiedAt)}</strong>
+          </div>
+        </div>
+
+        {standby.length > 0 ? (
+          <div className="settings-standby-list">
+            <strong>Stored standby credentials</strong>
+            <ul>
+              {standby.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {status.lastVerificationError ? (
+          <p className="settings-copy">
+            <strong>Current verification note:</strong>{' '}
+            {status.lastVerificationError}
+          </p>
+        ) : null}
+
+        <div className="settings-button-row">
           <button
             type="button"
-            className="secondary-btn"
-            onClick={() => {
-              setBaseUrlDraft('');
-              setClearBaseUrl(true);
-            }}
+            className="primary-btn"
+            disabled={busySection === 'credentials'}
+            onClick={() => void saveCredentials()}
           >
-            Clear Base URL
+            {busySection === 'credentials'
+              ? 'Saving…'
+              : 'Save Credential Settings'}
           </button>
+          {authModeDraft !== 'none' ? (
+            <button
+              type="button"
+              className="secondary-btn"
+              disabled={
+                busySection === 'verification' ||
+                status.verificationStatus === 'verifying'
+              }
+              onClick={() => void handleVerify()}
+            >
+              {busySection === 'verification'
+                ? 'Starting…'
+                : verifyButtonLabel}
+            </button>
+          ) : null}
         </div>
-        <button
-          type="button"
-          className="primary-btn"
-          disabled={busySection === 'runtime'}
-          onClick={() => void saveRuntimeConfig()}
-        >
-          {busySection === 'runtime' ? 'Saving…' : 'Save Runtime Config'}
-        </button>
       </section>
 
       <section className="settings-card">
@@ -635,12 +1069,14 @@ export function SettingsPage({ onUnauthorized, userRole }: Props) {
         <h2>Restart ClawRocket Service</h2>
         {!status.restartSupported ? (
           <p className="settings-copy">
-            Service restart is only available when running under the systemd service with <code>CLAWROCKET_SELF_RESTART=1</code>.
+            Service restart is only available when running under the systemd
+            service with <code>CLAWROCKET_SELF_RESTART=1</code>.
           </p>
         ) : null}
         {status.activeRunCount > 0 ? (
           <p className="settings-copy">
-            There are {status.activeRunCount} active runs that will be interrupted and marked as failed on next startup.
+            There are {status.activeRunCount} active runs that will be interrupted
+            and marked as failed on next startup.
           </p>
         ) : null}
         {userRole !== 'owner' ? (
@@ -675,7 +1111,7 @@ export function SettingsPage({ onUnauthorized, userRole }: Props) {
         </p>
       </section>
 
-      {(userRole === 'owner' || userRole === 'admin') ? (
+      {userRole === 'owner' || userRole === 'admin' ? (
         <TalkLlmSettingsCard onUnauthorized={onUnauthorized} />
       ) : null}
     </section>

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -331,6 +331,37 @@ a {
   margin-top: 1rem;
 }
 
+.settings-host-status {
+  margin-top: 1rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid #dde4f2;
+  border-radius: 10px;
+  background: #f6f9ff;
+}
+
+.settings-command-list {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.settings-command-list ul {
+  margin: 0.25rem 0 0;
+  padding-left: 1.2rem;
+}
+
+.settings-command-list code {
+  background: #eef4ff;
+  padding: 0.15rem 0.35rem;
+  border-radius: 8px;
+  word-break: break-all;
+}
+
+.settings-advanced-box {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px dashed #c8d3e9;
+}
+
 .settings-standby-list {
   margin: 1rem 0;
 }


### PR DESCRIPTION
## Summary
- add a guided Anthropic subscription setup flow based on host detection, import, and explicit verification
- keep executor auth mode as the source of truth so only the selected Anthropic credential mode is exported at runtime
- add host-status and host-import APIs for Claude Code subscription setup
- improve executor credential verification, status reporting, and tests across backend and webapp

## What Changed
- add host-auth probing/import service:
  - `src/clawrocket/talks/executor-subscription-host-auth.ts`
  - `src/clawrocket/talks/executor-subscription-host-auth.test.ts`
- add shared fingerprint helper:
  - `src/clawrocket/talks/json-fingerprint.ts`
- extend executor settings and verification plumbing:
  - `src/clawrocket/talks/executor-settings.ts`
  - `src/clawrocket/talks/executor-settings.test.ts`
  - `src/clawrocket/talks/executor-credentials-verifier.ts`
  - `src/clawrocket/talks/executor-credentials-verifier.test.ts`
- add host subscription routes:
  - `GET /api/v1/settings/executor/subscription-host-status`
  - `POST /api/v1/settings/executor/subscription/import`
  - files:
    - `src/clawrocket/web/server.ts`
    - `src/clawrocket/web/routes/settings.test.ts`
- update core startup and container integration for mode-aware executor auth:
  - `src/index.ts`
  - `src/index.test.ts`
  - `src/container-runner.ts`
  - `src/clawrocket/web/index.ts`
- rebuild the executor settings UI for subscription mode:
  - service user/home context display
  - `Check host Claude login`
  - `Import from host`
  - advanced manual OAuth fallback
  - files:
    - `webapp/src/pages/SettingsPage.tsx`
    - `webapp/src/pages/SettingsPage.test.tsx`
    - `webapp/src/lib/api.ts`
    - `webapp/src/styles.css`

## UX Notes
- subscription mode is now host-login-first instead of raw token-entry-first
- the UI tells users to run Claude login on the same machine and as the same OS user that runs ClawRocket
- host import uses a fingerprint check and returns a clear `host_state_changed` error if the host auth changed between check and import
- manual OAuth token entry remains available behind the advanced fallback
- API key and advanced bearer flows remain supported

## Current Limitation
- automatic host import currently supports service-host OAuth already available in `CLAUDE_CODE_OAUTH_TOKEN`
- when Claude CLI login is detected but the authenticated state cannot be imported safely, the UI fails closed and routes the user to the manual fallback instead of scraping undocumented Claude Code internals

## Validation
- `npm -C ClawRocket run typecheck`
- `npm -C ClawRocket run test`
- `npm --prefix ClawRocket/webapp run typecheck`
- `npm --prefix ClawRocket/webapp run test`
