### PR TITLE
fix(db): migrate registered agent column before index

### DIFF
--- a/src/clawrocket/db/init.test.ts
+++ b/src/clawrocket/db/init.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { _initTestDatabase as _initCoreTestDatabase, getDb } from '../../db.js';
+import { _initClawrocketTestSchema } from './index.js';
+
+describe('clawrocket schema init', () => {
+  it('adds registered_agent_id to legacy talk_agents tables before creating its index', () => {
+    _initCoreTestDatabase();
+
+    const database = getDb();
+    database.exec(`
+      CREATE TABLE talk_agents (
+        id TEXT PRIMARY KEY,
+        talk_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        persona_role TEXT NOT NULL,
+        route_id TEXT NOT NULL,
+        is_primary INTEGER NOT NULL DEFAULT 0,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+    `);
+
+    expect(() => _initClawrocketTestSchema()).not.toThrow();
+
+    const columns = database
+      .prepare(`PRAGMA table_info('talk_agents')`)
+      .all() as Array<{ name: string }>;
+    expect(
+      columns.some((column) => column.name === 'registered_agent_id'),
+    ).toBe(true);
+
+    const indexes = database
+      .prepare(`PRAGMA index_list('talk_agents')`)
+      .all() as Array<{ name: string }>;
+    expect(
+      indexes.some(
+        (index) => index.name === 'idx_talk_agents_registered_agent_id',
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/clawrocket/db/init.ts
+++ b/src/clawrocket/db/init.ts
@@ -381,8 +381,6 @@ function createClawrocketSchema(database: Database.Database): void {
       ON talk_agents(talk_id, sort_order, created_at);
     CREATE INDEX IF NOT EXISTS idx_talk_agents_route_id
       ON talk_agents(route_id);
-    CREATE INDEX IF NOT EXISTS idx_talk_agents_registered_agent_id
-      ON talk_agents(registered_agent_id);
 
     CREATE TABLE IF NOT EXISTS llm_attempts (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -484,6 +482,11 @@ function createClawrocketSchema(database: Database.Database): void {
   } catch {
     /* column already exists */
   }
+
+  database.exec(`
+    CREATE INDEX IF NOT EXISTS idx_talk_agents_registered_agent_id
+      ON talk_agents(registered_agent_id)
+  `);
 
   const staleSessions = database
     .prepare(


### PR DESCRIPTION
## Summary
- fix ClawRocket startup on existing databases after the AI Agents schema changes
- create the `talk_agents.registered_agent_id` index only after the legacy column migration runs
- add a regression test covering an older `talk_agents` table without `registered_agent_id`

## Root Cause
Existing databases already had a `talk_agents` table, so `CREATE TABLE IF NOT EXISTS` did not add the new `registered_agent_id` column. During schema init, SQLite then tried to create an index on that missing column before the migration block later added it, causing startup to fail with:

`SqliteError: no such column: registered_agent_id`

## What Changed
- move `idx_talk_agents_registered_agent_id` creation out of the main schema batch
- create that index after the `ALTER TABLE talk_agents ADD COLUMN registered_agent_id ...` migration block
- add `src/clawrocket/db/init.test.ts` to verify legacy databases initialize cleanly

## Validation
- `npm -C ClawRocket run typecheck`
- `npm -C ClawRocket run test`
