### PR TITLE
feat(agents): simplify ai agents and talk roles

### DIFF
--- a/src/clawrocket/db/init.ts
+++ b/src/clawrocket/db/init.ts
@@ -367,11 +367,15 @@ function createClawrocketSchema(database: Database.Database): void {
       id TEXT PRIMARY KEY,
       talk_id TEXT NOT NULL REFERENCES talks(id) ON DELETE CASCADE,
       name TEXT NOT NULL,
+      source_kind TEXT NOT NULL DEFAULT 'provider'
+        CHECK(source_kind IN ('claude_default', 'provider')),
       persona_role TEXT NOT NULL
         CHECK(persona_role IN ('assistant', 'analyst', 'critic', 'strategist', 'devils-advocate', 'synthesizer', 'editor')),
       -- Prevent deleting a route while Talk agents still reference it.
       route_id TEXT NOT NULL REFERENCES talk_routes(id) ON DELETE RESTRICT,
       registered_agent_id TEXT REFERENCES registered_agents(id) ON DELETE SET NULL,
+      provider_id TEXT REFERENCES llm_providers(id) ON DELETE SET NULL,
+      model_id TEXT,
       is_primary INTEGER NOT NULL DEFAULT 0,
       sort_order INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL,
@@ -479,6 +483,28 @@ function createClawrocketSchema(database: Database.Database): void {
     database.exec(
       `ALTER TABLE talk_agents ADD COLUMN registered_agent_id TEXT REFERENCES registered_agents(id) ON DELETE SET NULL`,
     );
+  } catch {
+    /* column already exists */
+  }
+
+  try {
+    database.exec(
+      `ALTER TABLE talk_agents ADD COLUMN source_kind TEXT NOT NULL DEFAULT 'provider' CHECK(source_kind IN ('claude_default', 'provider'))`,
+    );
+  } catch {
+    /* column already exists */
+  }
+
+  try {
+    database.exec(
+      `ALTER TABLE talk_agents ADD COLUMN provider_id TEXT REFERENCES llm_providers(id) ON DELETE SET NULL`,
+    );
+  } catch {
+    /* column already exists */
+  }
+
+  try {
+    database.exec(`ALTER TABLE talk_agents ADD COLUMN model_id TEXT`);
   } catch {
     /* column already exists */
   }

--- a/src/clawrocket/db/llm-accessors.ts
+++ b/src/clawrocket/db/llm-accessors.ts
@@ -21,6 +21,7 @@ import type {
   ProviderSecretPayload,
   RegisteredAgentRecord,
   TalkAgentRecord,
+  TalkAgentSourceKind,
   TalkPersonaRole,
   TalkRouteRecord,
   TalkRouteStepRecord,
@@ -29,6 +30,7 @@ import type {
 
 const TALK_DEFAULT_ROUTE_KEY = 'talkLlm.defaultRouteId';
 const DEFAULT_REGISTERED_AGENT_KEY = 'agents.defaultRegisteredAgentId';
+const DEFAULT_CLAUDE_MODEL_KEY = 'agents.defaultClaudeModelId';
 const BUILTIN_MOCK_PROVIDER_ID = 'builtin.mock';
 const BUILTIN_MOCK_ROUTE_ID = 'route.default.mock';
 
@@ -76,9 +78,12 @@ export interface TalkLlmSettingsSnapshot {
 export interface TalkAgentInput {
   id?: string;
   name: string;
+  sourceKind: TalkAgentSourceKind;
   personaRole: TalkPersonaRole;
   routeId: string;
   registeredAgentId?: string | null;
+  providerId?: string | null;
+  modelId?: string | null;
   isPrimary: boolean;
   sortOrder: number;
 }
@@ -121,12 +126,12 @@ export interface RegisteredAgentSnapshot {
 
 export interface TalkAgentInstanceSnapshot {
   id: string;
-  registeredAgentId: string | null;
   name: string;
+  sourceKind: TalkAgentSourceKind;
   role: TalkPersonaRole;
   isLead: boolean;
   displayOrder: number;
-  status: 'active' | 'archived' | 'legacy';
+  status: 'active' | 'archived';
   providerId: string | null;
   providerName: string | null;
   modelId: string | null;
@@ -135,7 +140,9 @@ export interface TalkAgentInstanceSnapshot {
 
 export interface TalkAgentInstanceInput {
   id?: string;
-  registeredAgentId?: string | null;
+  sourceKind: TalkAgentSourceKind;
+  providerId?: string | null;
+  modelId: string;
   role: TalkPersonaRole;
   isLead: boolean;
   displayOrder: number;
@@ -153,6 +160,92 @@ export interface ResolvedTalkAgent {
   agent: TalkAgentRecord;
   route: TalkRouteRecord;
   steps: ResolvedTalkRouteStep[];
+  sourceKind: TalkAgentSourceKind;
+  providerId: string | null;
+  modelId: string | null;
+}
+
+function buildTalkAgentRouteId(agentId: string): string {
+  return `route.talk-agent.${agentId}`;
+}
+
+function resolveProviderDisplayName(providerId: string | null): string | null {
+  if (!providerId) return null;
+  if (providerId === 'provider.anthropic') return 'Claude';
+  return getLlmProviderById(providerId)?.name || null;
+}
+
+function resolveModelDisplayName(
+  providerId: string | null,
+  modelId: string | null,
+): string | null {
+  if (!providerId || !modelId) return null;
+  const knownProvider = KNOWN_PROVIDER_CATALOG.find(
+    (provider) => provider.id === providerId,
+  );
+  const knownModel = knownProvider?.modelSuggestions.find(
+    (model) => model.modelId === modelId,
+  );
+  if (knownModel) return knownModel.displayName;
+  return getLlmProviderModel(providerId, modelId)?.display_name || modelId;
+}
+
+function buildTalkAgentName(input: {
+  sourceKind: TalkAgentSourceKind;
+  providerId: string | null;
+}): string {
+  if (input.sourceKind === 'claude_default') return 'Claude';
+  return resolveProviderDisplayName(input.providerId) || 'Provider';
+}
+
+function upsertTalkAgentRoute(input: {
+  agentId: string;
+  sourceKind: TalkAgentSourceKind;
+  providerId: string | null;
+  modelId: string | null;
+  updatedBy?: string | null;
+  updatedAt?: string;
+}): string {
+  const routeId = buildTalkAgentRouteId(input.agentId);
+  const providerId =
+    input.sourceKind === 'claude_default'
+      ? 'provider.anthropic'
+      : input.providerId;
+  if (!providerId || !input.modelId) {
+    throw new Error('talk agent route requires provider and model');
+  }
+
+  ensureKnownProviderExists(providerId, input.updatedAt);
+  const provider = getLlmProviderById(providerId);
+  if (!provider) {
+    throw new Error(`provider not found: ${providerId}`);
+  }
+
+  ensureProviderModelExists({
+    providerId,
+    modelId: input.modelId,
+    updatedAt: input.updatedAt,
+  });
+
+  upsertTalkRoute({
+    id: routeId,
+    name: `${buildTalkAgentName({
+      sourceKind: input.sourceKind,
+      providerId,
+    })} Route`,
+    enabled: true,
+    steps: [
+      {
+        position: 0,
+        providerId,
+        modelId: input.modelId,
+      },
+    ],
+    updatedBy: input.updatedBy,
+    updatedAt: input.updatedAt,
+  });
+
+  return routeId;
 }
 
 const KNOWN_PROVIDER_CATALOG: Array<{
@@ -361,6 +454,29 @@ function getKnownProviderTemplate(
   providerId: string,
 ): (typeof KNOWN_PROVIDER_CATALOG)[number] | undefined {
   return KNOWN_PROVIDER_CATALOG.find((provider) => provider.id === providerId);
+}
+
+function ensureKnownProviderExists(
+  providerId: string,
+  updatedAt?: string,
+): void {
+  // Built-in providers are seeded from the static known-provider catalog.
+  if (getLlmProviderById(providerId)) return;
+  const template = getKnownProviderTemplate(providerId);
+  if (!template) {
+    throw new Error(`unknown provider template: ${providerId}`);
+  }
+  upsertLlmProvider({
+    id: template.id,
+    name: template.name,
+    providerKind: template.providerKind,
+    apiFormat: template.apiFormat,
+    baseUrl: template.baseUrl,
+    authScheme: template.authScheme,
+    enabled: true,
+    coreCompatibility: 'none',
+    updatedAt,
+  });
 }
 
 function getFallbackModelMetadata(
@@ -952,6 +1068,77 @@ export function getDefaultRegisteredAgentId(): string | null {
   return row?.value || null;
 }
 
+export function listAdditionalProviderCredentialCards(): AgentProviderCardSnapshot[] {
+  return listKnownProviderCredentialCards().filter(
+    (provider) =>
+      provider.id !== 'provider.anthropic' && provider.id !== 'provider.custom',
+  );
+}
+
+export function listClaudeModelSuggestions(): ProviderModelSuggestion[] {
+  const anthropic = listKnownProviderCredentialCards().find(
+    (provider) => provider.id === 'provider.anthropic',
+  );
+  return anthropic?.modelSuggestions || [];
+}
+
+export function getDefaultClaudeModelId(): string {
+  const configured = getDb()
+    .prepare(
+      `
+      SELECT value
+      FROM settings_kv
+      WHERE key = ?
+      LIMIT 1
+    `,
+    )
+    .get(DEFAULT_CLAUDE_MODEL_KEY) as { value: string } | undefined;
+  if (configured?.value) return configured.value;
+
+  const fallback = listClaudeModelSuggestions()[0];
+  return fallback?.modelId || 'claude-sonnet-4-5';
+}
+
+export function setDefaultClaudeModelId(
+  modelId: string,
+  updatedBy?: string | null,
+  updatedAt?: string,
+): void {
+  const normalized = modelId.trim();
+  if (!normalized) {
+    throw new Error('default Claude model is required');
+  }
+
+  const knownSuggestion = listClaudeModelSuggestions().find(
+    (suggestion) => suggestion.modelId === normalized,
+  );
+  ensureKnownProviderExists('provider.anthropic', updatedAt);
+  ensureProviderModelExists({
+    providerId: 'provider.anthropic',
+    modelId: normalized,
+    displayName: knownSuggestion?.displayName,
+    updatedAt,
+  });
+
+  getDb()
+    .prepare(
+      `
+      INSERT INTO settings_kv (key, value, updated_at, updated_by)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(key) DO UPDATE SET
+        value = excluded.value,
+        updated_at = excluded.updated_at,
+        updated_by = excluded.updated_by
+    `,
+    )
+    .run(
+      DEFAULT_CLAUDE_MODEL_KEY,
+      normalized,
+      normalizeTimestamp(updatedAt),
+      updatedBy || null,
+    );
+}
+
 export function setDefaultRegisteredAgentId(
   registeredAgentId: string | null,
   updatedBy?: string | null,
@@ -1359,9 +1546,12 @@ export function replaceTalkAgents(
     id: agent.id || `agent_${randomUUID()}`,
     talkId,
     name: agent.name.trim(),
+    sourceKind: agent.sourceKind,
     personaRole: agent.personaRole,
     routeId: agent.routeId,
     registeredAgentId: agent.registeredAgentId || null,
+    providerId: agent.providerId || null,
+    modelId: agent.modelId || null,
     isPrimary: agent.isPrimary,
     sortOrder: normalizeSortOrder(index, agent.sortOrder),
   }));
@@ -1371,9 +1561,9 @@ export function replaceTalkAgents(
     const stmt = getDb().prepare(
       `
       INSERT INTO talk_agents (
-        id, talk_id, name, persona_role, route_id, registered_agent_id,
-        is_primary, sort_order, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        id, talk_id, name, source_kind, persona_role, route_id, registered_agent_id,
+        provider_id, model_id, is_primary, sort_order, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
     );
     for (const agent of normalized) {
@@ -1381,9 +1571,12 @@ export function replaceTalkAgents(
         agent.id,
         talkId,
         agent.name,
+        agent.sourceKind,
         agent.personaRole,
         agent.routeId,
         agent.registeredAgentId,
+        agent.providerId,
+        agent.modelId,
         agent.isPrimary ? 1 : 0,
         agent.sortOrder,
         updatedAt,
@@ -1400,42 +1593,27 @@ export function resetTalkAgentsToDefault(
   talkId: string,
   now?: string,
 ): TalkAgentRecord[] {
-  const defaultRegisteredAgentId = getDefaultRegisteredAgentId();
-  const defaultRegisteredAgent = defaultRegisteredAgentId
-    ? getRegisteredAgentById(defaultRegisteredAgentId)
-    : undefined;
-  if (defaultRegisteredAgent && defaultRegisteredAgent.enabled === 1) {
-    return replaceTalkAgents(
-      talkId,
-      [
-        {
-          id: `agent_${randomUUID()}`,
-          name: defaultRegisteredAgent.name,
-          personaRole: 'assistant',
-          routeId: defaultRegisteredAgent.route_id,
-          registeredAgentId: defaultRegisteredAgent.id,
-          isPrimary: true,
-          sortOrder: 0,
-        },
-      ],
-      now,
-    );
-  }
-
-  const fallbackRouteId =
-    getDefaultTalkRouteId() ||
-    listTalkRoutes().find((route) => route.enabled === 1)?.id ||
-    BUILTIN_MOCK_ROUTE_ID;
+  const agentId = `agent_${randomUUID()}`;
+  const modelId = getDefaultClaudeModelId();
+  const routeId = upsertTalkAgentRoute({
+    agentId,
+    sourceKind: 'claude_default',
+    providerId: 'provider.anthropic',
+    modelId,
+    updatedAt: now,
+  });
 
   return replaceTalkAgents(
     talkId,
     [
       {
-        id: `agent_${randomUUID()}`,
-        name: buildDefaultTalkAgentName(fallbackRouteId),
+        id: agentId,
+        name: 'Claude',
+        sourceKind: 'claude_default',
         personaRole: 'assistant',
-        routeId: fallbackRouteId,
-        registeredAgentId: null,
+        routeId,
+        providerId: 'provider.anthropic',
+        modelId,
         isPrimary: true,
         sortOrder: 0,
       },
@@ -1457,29 +1635,30 @@ export function listTalkAgentInstances(
   talkId: string,
 ): TalkAgentInstanceSnapshot[] {
   const existing = ensureTalkHasDefaultAgent(talkId);
-  const registeredAgentsById = new Map(
-    listRegisteredAgents().map((agent) => [agent.id, agent]),
-  );
   return existing.map((agent) => {
-    const registeredAgent = agent.registered_agent_id
-      ? registeredAgentsById.get(agent.registered_agent_id)
-      : undefined;
+    const sourceKind = agent.source_kind as TalkAgentInstanceSnapshot['sourceKind'];
+    const providerId =
+      sourceKind === 'claude_default'
+        ? 'provider.anthropic'
+        : agent.provider_id || null;
+    const providerName = resolveProviderDisplayName(providerId);
+    const modelId = agent.model_id || null;
+    const modelDisplayName = resolveModelDisplayName(providerId, modelId);
     return {
       id: agent.id,
-      registeredAgentId: agent.registered_agent_id,
-      name: registeredAgent?.name || agent.name,
+      name: buildTalkAgentName({
+        sourceKind,
+        providerId,
+      }),
+      sourceKind,
       role: agent.persona_role,
       isLead: agent.is_primary === 1,
       displayOrder: agent.sort_order,
-      status: registeredAgent
-        ? registeredAgent.enabled
-          ? 'active'
-          : 'archived'
-        : 'legacy',
-      providerId: registeredAgent?.providerId || null,
-      providerName: registeredAgent?.providerName || null,
-      modelId: registeredAgent?.modelId || null,
-      modelDisplayName: registeredAgent?.modelDisplayName || null,
+      status: 'active',
+      providerId,
+      providerName,
+      modelId,
+      modelDisplayName,
     };
   });
 }
@@ -1494,34 +1673,39 @@ export function replaceTalkAgentInstances(
   );
   const normalized: TalkAgentInput[] = agents.map((agent, index) => {
     const existing = agent.id ? existingById.get(agent.id) : undefined;
-    if (agent.registeredAgentId) {
-      const registeredAgent = getRegisteredAgentById(agent.registeredAgentId);
-      if (!registeredAgent) {
-        throw new Error(
-          `registered agent not found: ${agent.registeredAgentId}`,
-        );
-      }
-      return {
-        id: agent.id,
-        name: registeredAgent.name,
-        personaRole: agent.role,
-        routeId: registeredAgent.route_id,
-        registeredAgentId: registeredAgent.id,
-        isPrimary: agent.isLead,
-        sortOrder: normalizeSortOrder(index, agent.displayOrder),
-      };
-    }
+    const id = agent.id || `agent_${randomUUID()}`;
+    const sourceKind = agent.sourceKind;
+    const providerId =
+      sourceKind === 'claude_default'
+        ? 'provider.anthropic'
+        : agent.providerId || null;
 
-    if (!existing || existing.registered_agent_id) {
-      throw new Error('legacy talk agents cannot be created manually');
+    if (!agent.modelId?.trim()) {
+      throw new Error('talk agent model is required');
     }
+    if (sourceKind === 'provider' && !providerId) {
+      throw new Error('provider-backed talk agents require a provider');
+    }
+    const routeId = upsertTalkAgentRoute({
+      agentId: id,
+      sourceKind,
+      providerId,
+      modelId: agent.modelId.trim(),
+      updatedAt: now,
+    });
 
     return {
-      id: existing.id,
-      name: existing.name,
+      id,
+      name: buildTalkAgentName({
+        sourceKind,
+        providerId,
+      }),
+      sourceKind,
       personaRole: agent.role,
-      routeId: existing.route_id,
+      routeId,
       registeredAgentId: null,
+      providerId,
+      modelId: agent.modelId.trim(),
       isPrimary: agent.isLead,
       sortOrder: normalizeSortOrder(index, agent.displayOrder),
     };
@@ -1541,12 +1725,7 @@ export function resolveTalkAgent(
       : undefined) || agents.find((entry) => entry.is_primary === 1);
   if (!agent) return null;
 
-  const registeredAgent = agent.registered_agent_id
-    ? getRegisteredAgentById(agent.registered_agent_id)
-    : undefined;
-  const effectiveAgent = registeredAgent
-    ? ({ ...agent, name: registeredAgent.name } as TalkAgentRecord)
-    : agent;
+  const sourceKind = agent.source_kind as TalkAgentSourceKind;
 
   const route = getTalkRouteById(agent.route_id);
   if (!route) return null;
@@ -1570,7 +1749,17 @@ export function resolveTalkAgent(
     });
   }
 
-  return { agent: effectiveAgent, route, steps };
+  return {
+    agent,
+    route,
+    steps,
+    sourceKind,
+    providerId:
+      sourceKind === 'claude_default'
+        ? 'provider.anthropic'
+        : agent.provider_id || null,
+    modelId: agent.model_id || null,
+  };
 }
 
 export function listTalkLlmSettingsSnapshot(): TalkLlmSettingsSnapshot {

--- a/src/clawrocket/llm/types.ts
+++ b/src/clawrocket/llm/types.ts
@@ -85,13 +85,18 @@ export type TalkPersonaRole =
   | 'synthesizer'
   | 'editor';
 
+export type TalkAgentSourceKind = 'claude_default' | 'provider';
+
 export interface TalkAgentRecord {
   id: string;
   talk_id: string;
   name: string;
+  source_kind: TalkAgentSourceKind;
   persona_role: TalkPersonaRole;
   route_id: string;
   registered_agent_id: string | null;
+  provider_id: string | null;
+  model_id: string | null;
   is_primary: number;
   sort_order: number;
   created_at: string;

--- a/src/clawrocket/talks/direct-executor.test.ts
+++ b/src/clawrocket/talks/direct-executor.test.ts
@@ -74,6 +74,9 @@ function configureTalkRuntime(input: {
   agentName?: string;
 }): void {
   const routeId = input.agentRouteId || input.routes[0]?.id || 'route.primary';
+  const selectedRoute =
+    input.routes.find((route) => route.id === routeId) || input.routes[0];
+  const selectedStep = selectedRoute?.steps[0];
   replaceTalkLlmSettingsSnapshot({
     defaultRouteId: routeId,
     providers: input.providers,
@@ -82,8 +85,11 @@ function configureTalkRuntime(input: {
   replaceTalkAgents(TALK_ID, [
     {
       name: input.agentName || 'Primary Agent',
+      sourceKind: 'provider',
       personaRole: 'assistant',
       routeId,
+      providerId: selectedStep?.providerId || null,
+      modelId: selectedStep?.modelId || null,
       isPrimary: true,
       sortOrder: 0,
     },

--- a/src/clawrocket/talks/direct-executor.ts
+++ b/src/clawrocket/talks/direct-executor.ts
@@ -1,6 +1,9 @@
+import { ChildProcess } from 'child_process';
 import { setTimeout as sleep } from 'timers/promises';
 
+import { runContainerAgent, type ContainerOutput } from '../../container-runner.js';
 import { logger } from '../../logger.js';
+import type { RegisteredGroup } from '../../types.js';
 import {
   createLlmAttempt,
   getProviderSecretByProviderId,
@@ -8,6 +11,7 @@ import {
   resolveTalkAgent,
   setTalkRunExecutorProfile,
 } from '../db/index.js';
+import { TALK_EXECUTOR_WEB_GROUP_FOLDER } from '../config.js';
 import { decryptProviderSecret } from '../llm/provider-secret-store.js';
 import type {
   LlmFailureClass,
@@ -28,6 +32,8 @@ import type {
   TalkExecutorOutput,
 } from './executor.js';
 import { TalkExecutorError } from './executor.js';
+import { getActiveExecutorSettingsService } from './executor-settings.js';
+import type { TalkPersonaRole } from '../llm/types.js';
 
 const DEFAULT_RESPONSE_START_TIMEOUT_MS = 60_000;
 const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 20_000;
@@ -68,6 +74,8 @@ interface SseEvent {
 
 export interface DirectTalkExecutorOptions {
   fetchImpl?: typeof fetch;
+  runContainer?: typeof runContainerAgent;
+  groupFolder?: string;
 }
 
 function abortError(reason?: unknown): Error {
@@ -436,6 +444,107 @@ function classifyHttpFailure(response: {
   };
 }
 
+function renderPromptTranscript(
+  promptMessages: PromptMessage[],
+): string {
+  return promptMessages
+    .map((message) => {
+      const label =
+        message.role === 'system'
+          ? 'SYSTEM'
+          : message.role === 'assistant'
+            ? 'ASSISTANT'
+            : 'USER';
+      return `${label}:\n${message.text}`;
+    })
+    .join('\n\n');
+}
+
+function looksLikeClaudeAuthFailure(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes('oauth') ||
+    normalized.includes('login') ||
+    normalized.includes('credential') ||
+    normalized.includes('api key') ||
+    normalized.includes('authentication') ||
+    normalized.includes('authorization') ||
+    normalized.includes('auth token')
+  );
+}
+
+function classifyClaudeDefaultFailure(error: unknown): ClassifiedTalkError {
+  if (error instanceof ContextAssemblyError) {
+    return {
+      code: error.code,
+      message: error.message,
+      failureClass: 'invalid_request',
+      retryable: false,
+    };
+  }
+
+  if (error instanceof TalkExecutorError) {
+    if (error.code === 'executor_not_configured') {
+      return {
+        code: error.code,
+        message: error.sourceMessage,
+        failureClass: 'configuration',
+        retryable: false,
+      };
+    }
+    if (error.code === 'executor_container_error') {
+      const sourceMessage = error.sourceMessage || error.message;
+      if (looksLikeClaudeAuthFailure(sourceMessage)) {
+        return {
+          code: 'provider_auth_failed',
+          message: sourceMessage,
+          failureClass: 'auth',
+          retryable: false,
+        };
+      }
+      if (sourceMessage.toLowerCase().includes('timeout')) {
+        return {
+          code: 'provider_timeout',
+          message: sourceMessage,
+          failureClass: 'timeout',
+          retryable: true,
+        };
+      }
+      return {
+        code: error.code,
+        message: sourceMessage,
+        failureClass: 'unknown',
+        retryable: false,
+      };
+    }
+    return {
+      code: error.code,
+      message: error.sourceMessage,
+      failureClass: 'unknown',
+      retryable: false,
+    };
+  }
+
+  return {
+    code: 'execution_failed',
+    message:
+      error instanceof Error ? error.message : 'Unknown Claude execution failure',
+    failureClass: 'unknown',
+    retryable: false,
+  };
+}
+
+function createWebTalkGroup(groupFolder: string): RegisteredGroup {
+  return {
+    name: 'Web Talk Executor',
+    folder: groupFolder,
+    trigger: '@web',
+    added_at: '1970-01-01T00:00:00.000Z',
+    requiresTrigger: false,
+    isMain: false,
+  };
+}
+
 function buildAnthropicMessages(promptMessages: PromptMessage[]): {
   system: string;
   messages: Array<{ role: 'user' | 'assistant'; content: string }>;
@@ -470,9 +579,13 @@ function buildOpenAiMessages(promptMessages: PromptMessage[]): Array<{
 
 export class DirectTalkExecutor implements TalkExecutor {
   private readonly fetchImpl: typeof fetch;
+  private readonly runContainer: typeof runContainerAgent;
+  private readonly groupFolder: string;
 
   constructor(options: DirectTalkExecutorOptions = {}) {
     this.fetchImpl = options.fetchImpl || fetch;
+    this.runContainer = options.runContainer || runContainerAgent;
+    this.groupFolder = options.groupFolder || TALK_EXECUTOR_WEB_GROUP_FOLDER;
   }
 
   async execute(
@@ -504,6 +617,34 @@ export class DirectTalkExecutor implements TalkExecutor {
       throw new TalkExecutorError(
         'route_unavailable',
         'The selected talk route does not have any configured steps.',
+      );
+    }
+
+    if (resolved.sourceKind === 'claude_default') {
+      const primaryStep = resolved.steps[0];
+      if (!resolved.modelId && !primaryStep?.model.model_id) {
+        throw new TalkExecutorError(
+          'route_unavailable',
+          'The selected Claude agent does not have a configured model.',
+        );
+      }
+
+      return this.executeClaudeDefaultAttempt(
+        {
+          input,
+          agentId: resolved.agent.id,
+          agentName: resolved.agent.name,
+          routeId: resolved.route.id,
+          routeStepPosition: primaryStep?.routeStep.position ?? 0,
+          providerId: 'provider.anthropic',
+          modelId: resolved.modelId || primaryStep.model.model_id,
+        },
+        talk.topic_title,
+        resolved.agent.persona_role,
+        primaryStep?.model.context_window_tokens ?? 200_000,
+        primaryStep?.model.default_max_output_tokens ?? 4_096,
+        signal,
+        emit,
       );
     }
 
@@ -789,6 +930,243 @@ export class DirectTalkExecutor implements TalkExecutor {
         outputTokens: Math.ceil(content.length / 4),
       },
     };
+  }
+
+  private async executeClaudeDefaultAttempt(
+    context: AttemptContext,
+    talkTitle: string | null,
+    personaRole: TalkPersonaRole,
+    modelContextWindowTokens: number,
+    maxOutputTokens: number,
+    signal: AbortSignal,
+    emit?: (event: TalkExecutionEvent) => void,
+  ): Promise<TalkExecutorOutput> {
+    const settingsService = getActiveExecutorSettingsService();
+    const blockedReason = settingsService.getExecutionBlockedReason();
+    if (blockedReason) {
+      createLlmAttempt({
+        runId: context.input.runId,
+        talkId: context.input.talkId,
+        agentId: context.agentId,
+        routeId: context.routeId,
+        routeStepPosition: context.routeStepPosition,
+        providerId: context.providerId,
+        modelId: context.modelId,
+        status: 'failed',
+        failureClass: 'configuration',
+      });
+      emit?.({
+        type: 'talk_response_failed',
+        runId: context.input.runId,
+        talkId: context.input.talkId,
+        agentId: context.agentId,
+        routeStepPosition: context.routeStepPosition,
+        providerId: context.providerId,
+        modelId: context.modelId,
+        errorCode: 'executor_not_configured',
+        errorMessage: blockedReason,
+      });
+      throw new TalkExecutorError('executor_not_configured', blockedReason);
+    }
+
+    setTalkRunExecutorProfile({
+      runId: context.input.runId,
+      executorAlias: 'Claude',
+      executorModel: context.modelId,
+    });
+
+    const startedAt = Date.now();
+    try {
+      const prompt = assembleTalkPromptContext({
+        talkId: context.input.talkId,
+        talkTitle,
+        currentRunId: context.input.runId,
+        currentUserMessageId: context.input.triggerMessageId,
+        currentUserMessage: context.input.triggerContent,
+        agent: {
+          id: context.agentId,
+          name: context.agentName,
+          personaRole,
+        },
+        modelContextWindowTokens,
+        maxOutputTokens,
+      });
+
+      emit?.({
+        type: 'talk_response_started',
+        runId: context.input.runId,
+        talkId: context.input.talkId,
+        agentId: context.agentId,
+        agentName: context.agentName,
+        routeStepPosition: context.routeStepPosition,
+        providerId: context.providerId,
+        modelId: context.modelId,
+      });
+
+      const group = createWebTalkGroup(this.groupFolder);
+      const chunks: string[] = [];
+      let processRef: ChildProcess | null = null;
+      const onAbort = () => {
+        if (processRef && !processRef.killed) {
+          processRef.kill('SIGTERM');
+        }
+      };
+
+      signal.addEventListener('abort', onAbort, { once: true });
+      try {
+        const result = await this.runContainer(
+          group,
+          {
+            prompt: renderPromptTranscript(prompt.messages),
+            model: context.modelId,
+            toolProfile: 'web_talk',
+            groupFolder: this.groupFolder,
+            chatJid: `talk:${context.input.talkId}`,
+            isMain: false,
+            assistantName: context.agentName,
+            secrets: settingsService.getExecutorSecrets(),
+          },
+          (proc) => {
+            processRef = proc;
+            if (signal.aborted && !proc.killed) {
+              proc.kill('SIGTERM');
+            }
+          },
+          async (streamOutput: ContainerOutput) => {
+            if (!streamOutput.result) return;
+            chunks.push(streamOutput.result);
+            emit?.({
+              type: 'talk_response_delta',
+              runId: context.input.runId,
+              talkId: context.input.talkId,
+              agentId: context.agentId,
+              agentName: context.agentName,
+              deltaText: streamOutput.result,
+              routeStepPosition: context.routeStepPosition,
+              providerId: context.providerId,
+              modelId: context.modelId,
+            });
+          },
+        );
+
+        if (signal.aborted) {
+          throw abortError(signal.reason);
+        }
+
+        if (result.status === 'error') {
+          throw new TalkExecutorError(
+            'executor_container_error',
+            'Claude execution failed.',
+            {
+              sourceMessage:
+                result.error || 'Claude container execution failed.',
+            },
+          );
+        }
+
+        if (chunks.length === 0 && result.result?.trim()) {
+          chunks.push(result.result);
+          emit?.({
+            type: 'talk_response_delta',
+            runId: context.input.runId,
+            talkId: context.input.talkId,
+            agentId: context.agentId,
+            agentName: context.agentName,
+            deltaText: result.result,
+            routeStepPosition: context.routeStepPosition,
+            providerId: context.providerId,
+            modelId: context.modelId,
+          });
+        }
+
+        const content = chunks.join('').trim() || result.result?.trim() || 'No response generated.';
+        createLlmAttempt({
+          runId: context.input.runId,
+          talkId: context.input.talkId,
+          agentId: context.agentId,
+          routeId: context.routeId,
+          routeStepPosition: context.routeStepPosition,
+          providerId: context.providerId,
+          modelId: context.modelId,
+          status: 'success',
+          latencyMs: Date.now() - startedAt,
+          inputTokens: prompt.estimatedInputTokens,
+          outputTokens: null,
+          estimatedCostUsd: null,
+        });
+        emit?.({
+          type: 'talk_response_completed',
+          runId: context.input.runId,
+          talkId: context.input.talkId,
+          agentId: context.agentId,
+          agentName: context.agentName,
+          routeStepPosition: context.routeStepPosition,
+          providerId: context.providerId,
+          modelId: context.modelId,
+        });
+        return {
+          content,
+          metadataJson: JSON.stringify({
+            agentId: context.agentId,
+            agentName: context.agentName,
+            personaRole,
+            routeId: context.routeId,
+            providerId: context.providerId,
+            modelId: context.modelId,
+            sourceKind: 'claude_default',
+          }),
+          agentId: context.agentId,
+          agentName: context.agentName,
+          providerId: context.providerId,
+          modelId: context.modelId,
+        };
+      } finally {
+        signal.removeEventListener('abort', onAbort);
+      }
+    } catch (error) {
+      if (signal.aborted) {
+        createLlmAttempt({
+          runId: context.input.runId,
+          talkId: context.input.talkId,
+          agentId: context.agentId,
+          routeId: context.routeId,
+          routeStepPosition: context.routeStepPosition,
+          providerId: context.providerId,
+          modelId: context.modelId,
+          status: 'cancelled',
+          latencyMs: Date.now() - startedAt,
+        });
+        throw abortError(signal.reason);
+      }
+
+      const classified = classifyClaudeDefaultFailure(error);
+      createLlmAttempt({
+        runId: context.input.runId,
+        talkId: context.input.talkId,
+        agentId: context.agentId,
+        routeId: context.routeId,
+        routeStepPosition: context.routeStepPosition,
+        providerId: context.providerId,
+        modelId: context.modelId,
+        status: 'failed',
+        failureClass: classified.failureClass,
+        latencyMs: Date.now() - startedAt,
+      });
+      emit?.({
+        type: 'talk_response_failed',
+        runId: context.input.runId,
+        talkId: context.input.talkId,
+        agentId: context.agentId,
+        routeStepPosition: context.routeStepPosition,
+        providerId: context.providerId,
+        modelId: context.modelId,
+        errorCode: classified.code,
+        errorMessage: classified.message,
+      });
+      throw new TalkExecutorError(classified.code, classified.message, {
+        sourceMessage: classified.message,
+      });
+    }
   }
 
   private async executeProviderAttempt(

--- a/src/clawrocket/talks/executor-settings.ts
+++ b/src/clawrocket/talks/executor-settings.ts
@@ -165,6 +165,9 @@ export interface ExecutorSettingsView {
   hasApiKey: boolean;
   hasOauthToken: boolean;
   hasAuthToken: boolean;
+  apiKeyHint: string | null;
+  oauthTokenHint: string | null;
+  authTokenHint: string | null;
   activeCredentialConfigured: boolean;
   verificationStatus: ExecutorVerificationStatus;
   lastVerifiedAt: string | null;
@@ -175,6 +178,13 @@ export interface ExecutorSettingsView {
   lastUpdatedAt: string | null;
   lastUpdatedBy: SettingsActor | null;
   configErrors: string[];
+}
+
+function maskStoredCredential(value: string | null): string | null {
+  if (!value?.trim()) return null;
+  const trimmed = value.trim();
+  const suffix = trimmed.slice(-4);
+  return `••••${suffix}`;
 }
 
 export interface ExecutorStatusView {
@@ -1191,6 +1201,9 @@ export class ExecutorSettingsService {
       hasApiKey: Boolean(rows.apiKey),
       hasOauthToken: Boolean(rows.oauthToken),
       hasAuthToken: Boolean(rows.authToken),
+      apiKeyHint: maskStoredCredential(rows.apiKey),
+      oauthTokenHint: maskStoredCredential(rows.oauthToken),
+      authTokenHint: maskStoredCredential(rows.authToken),
       activeCredentialConfigured: config.activeCredentialConfigured,
       verificationStatus: config.verificationStatus,
       lastVerifiedAt: config.lastVerifiedAt,

--- a/src/clawrocket/web/routes/agents.ts
+++ b/src/clawrocket/web/routes/agents.ts
@@ -1,23 +1,12 @@
 import {
-  createRegisteredAgent,
-  deleteRegisteredAgent,
-  duplicateRegisteredAgent,
-  getDefaultRegisteredAgentId,
-  getLlmProviderById,
-  getProviderSecretByProviderId,
-  getRegisteredAgentById,
-  listKnownProviderCredentialCards,
-  listRegisteredAgents,
-  setDefaultRegisteredAgentId,
-  setRegisteredAgentEnabled,
-  updateRegisteredAgentName,
+  getDefaultClaudeModelId,
+  listAdditionalProviderCredentialCards,
+  listClaudeModelSuggestions,
+  setDefaultClaudeModelId,
   upsertKnownProviderCredential,
 } from '../../db/index.js';
 import { ProviderCredentialsVerifier } from '../../agents/provider-credentials-verifier.js';
-import type {
-  AgentProviderCardSnapshot,
-  RegisteredAgentSnapshot,
-} from '../../db/llm-accessors.js';
+import type { AgentProviderCardSnapshot } from '../../db/llm-accessors.js';
 import type { LlmAuthScheme, ProviderSecretPayload } from '../../llm/types.js';
 import { ApiEnvelope, AuthContext } from '../types.js';
 
@@ -26,19 +15,21 @@ function canManageAgents(auth: AuthContext): boolean {
 }
 
 export interface AiAgentsPageRecord {
-  defaultRegisteredAgentId: string | null;
-  providers: AgentProviderCardSnapshot[];
-  registeredAgents: RegisteredAgentSnapshot[];
-  onboardingRequired: boolean;
+  defaultClaudeModelId: string;
+  claudeModelSuggestions: Array<{
+    modelId: string;
+    displayName: string;
+    contextWindowTokens: number;
+    defaultMaxOutputTokens: number;
+  }>;
+  additionalProviders: AgentProviderCardSnapshot[];
 }
 
 function buildAgentsSnapshot(): AiAgentsPageRecord {
-  const registeredAgents = listRegisteredAgents();
   return {
-    defaultRegisteredAgentId: getDefaultRegisteredAgentId(),
-    providers: listKnownProviderCredentialCards(),
-    registeredAgents,
-    onboardingRequired: registeredAgents.length === 0,
+    defaultClaudeModelId: getDefaultClaudeModelId(),
+    claudeModelSuggestions: listClaudeModelSuggestions(),
+    additionalProviders: listAdditionalProviderCredentialCards(),
   };
 }
 
@@ -46,6 +37,49 @@ export function getAiAgentsRoute(input: { auth: AuthContext }): {
   statusCode: number;
   body: ApiEnvelope<AiAgentsPageRecord>;
 } {
+  return {
+    statusCode: 200,
+    body: {
+      ok: true,
+      data: buildAgentsSnapshot(),
+    },
+  };
+}
+
+export function updateDefaultClaudeModelRoute(input: {
+  auth: AuthContext;
+  modelId: string;
+}): {
+  statusCode: number;
+  body: ApiEnvelope<AiAgentsPageRecord>;
+} {
+  if (!canManageAgents(input.auth)) {
+    return {
+      statusCode: 403,
+      body: {
+        ok: false,
+        error: {
+          code: 'forbidden',
+          message: 'You do not have permission to update the default Claude model.',
+        },
+      },
+    };
+  }
+
+  if (!input.modelId.trim()) {
+    return {
+      statusCode: 400,
+      body: {
+        ok: false,
+        error: {
+          code: 'invalid_model',
+          message: 'A Claude model is required.',
+        },
+      },
+    };
+  }
+
+  setDefaultClaudeModelId(input.modelId.trim(), input.auth.userId);
   return {
     statusCode: 200,
     body: {
@@ -145,282 +179,4 @@ export async function verifyAiProviderCredentialRoute(input: {
       data: { provider },
     },
   };
-}
-
-export function createRegisteredAgentRoute(input: {
-  auth: AuthContext;
-  name: string;
-  providerId: string;
-  modelId: string;
-  modelDisplayName?: string | null;
-  setAsDefault?: boolean;
-}): {
-  statusCode: number;
-  body: ApiEnvelope<{
-    agent: RegisteredAgentSnapshot;
-    defaultRegisteredAgentId: string | null;
-  }>;
-} {
-  if (!canManageAgents(input.auth)) {
-    return {
-      statusCode: 403,
-      body: {
-        ok: false,
-        error: {
-          code: 'forbidden',
-          message: 'You do not have permission to create AI agents.',
-        },
-      },
-    };
-  }
-
-  const provider = getLlmProviderById(input.providerId);
-  if (!provider) {
-    return {
-      statusCode: 400,
-      body: {
-        ok: false,
-        error: {
-          code: 'provider_not_found',
-          message: 'Provider is not configured.',
-        },
-      },
-    };
-  }
-  if (!getProviderSecretByProviderId(input.providerId)) {
-    return {
-      statusCode: 400,
-      body: {
-        ok: false,
-        error: {
-          code: 'provider_missing_credential',
-          message:
-            'Configure the provider credential before creating an agent.',
-        },
-      },
-    };
-  }
-
-  try {
-    const agent = createRegisteredAgent({
-      name: input.name,
-      providerId: input.providerId,
-      modelId: input.modelId,
-      modelDisplayName: input.modelDisplayName || undefined,
-      updatedBy: input.auth.userId,
-      setAsDefault: input.setAsDefault,
-    });
-    return {
-      statusCode: 201,
-      body: {
-        ok: true,
-        data: {
-          agent,
-          defaultRegisteredAgentId: getDefaultRegisteredAgentId(),
-        },
-      },
-    };
-  } catch (error) {
-    return {
-      statusCode: 400,
-      body: {
-        ok: false,
-        error: {
-          code: 'registered_agent_create_failed',
-          message:
-            error instanceof Error
-              ? error.message
-              : 'Failed to create AI agent.',
-        },
-      },
-    };
-  }
-}
-
-export function updateRegisteredAgentRoute(input: {
-  auth: AuthContext;
-  agentId: string;
-  name?: string;
-  enabled?: boolean;
-  setAsDefault?: boolean;
-}): {
-  statusCode: number;
-  body: ApiEnvelope<{
-    agent: RegisteredAgentSnapshot;
-    defaultRegisteredAgentId: string | null;
-  }>;
-} {
-  if (!canManageAgents(input.auth)) {
-    return {
-      statusCode: 403,
-      body: {
-        ok: false,
-        error: {
-          code: 'forbidden',
-          message: 'You do not have permission to update AI agents.',
-        },
-      },
-    };
-  }
-
-  const existing = getRegisteredAgentById(input.agentId);
-  if (!existing) {
-    return {
-      statusCode: 404,
-      body: {
-        ok: false,
-        error: { code: 'agent_not_found', message: 'AI agent not found.' },
-      },
-    };
-  }
-
-  let agent: RegisteredAgentSnapshot | null = null;
-  try {
-    if (typeof input.name === 'string' && input.name.trim()) {
-      agent = updateRegisteredAgentName(input.agentId, input.name, undefined);
-    }
-    if (typeof input.enabled === 'boolean') {
-      agent = setRegisteredAgentEnabled(
-        input.agentId,
-        input.enabled,
-        undefined,
-      );
-    }
-    if (!agent) {
-      agent =
-        listRegisteredAgents().find((entry) => entry.id === input.agentId) ||
-        null;
-    }
-    if (!agent) {
-      throw new Error('AI agent not found after update.');
-    }
-    if (input.setAsDefault) {
-      setDefaultRegisteredAgentId(agent.id, input.auth.userId);
-    }
-    return {
-      statusCode: 200,
-      body: {
-        ok: true,
-        data: {
-          agent,
-          defaultRegisteredAgentId: getDefaultRegisteredAgentId(),
-        },
-      },
-    };
-  } catch (error) {
-    return {
-      statusCode: 400,
-      body: {
-        ok: false,
-        error: {
-          code: 'registered_agent_update_failed',
-          message:
-            error instanceof Error
-              ? error.message
-              : 'Failed to update AI agent.',
-        },
-      },
-    };
-  }
-}
-
-export function duplicateRegisteredAgentRoute(input: {
-  auth: AuthContext;
-  sourceAgentId: string;
-  name: string;
-  providerId: string;
-  modelId: string;
-  modelDisplayName?: string | null;
-}): {
-  statusCode: number;
-  body: ApiEnvelope<{ agent: RegisteredAgentSnapshot }>;
-} {
-  if (!canManageAgents(input.auth)) {
-    return {
-      statusCode: 403,
-      body: {
-        ok: false,
-        error: {
-          code: 'forbidden',
-          message: 'You do not have permission to duplicate AI agents.',
-        },
-      },
-    };
-  }
-
-  const existing = getRegisteredAgentById(input.sourceAgentId);
-  if (!existing) {
-    return {
-      statusCode: 404,
-      body: {
-        ok: false,
-        error: { code: 'agent_not_found', message: 'AI agent not found.' },
-      },
-    };
-  }
-
-  try {
-    const agent = duplicateRegisteredAgent({
-      sourceAgentId: input.sourceAgentId,
-      name: input.name,
-      providerId: input.providerId,
-      modelId: input.modelId,
-      modelDisplayName: input.modelDisplayName || undefined,
-      updatedBy: input.auth.userId,
-    });
-    return { statusCode: 201, body: { ok: true, data: { agent } } };
-  } catch (error) {
-    return {
-      statusCode: 400,
-      body: {
-        ok: false,
-        error: {
-          code: 'registered_agent_duplicate_failed',
-          message:
-            error instanceof Error
-              ? error.message
-              : 'Failed to duplicate AI agent.',
-        },
-      },
-    };
-  }
-}
-
-export function deleteRegisteredAgentRoute(input: {
-  auth: AuthContext;
-  agentId: string;
-}): { statusCode: number; body: ApiEnvelope<{ deleted: true }> } {
-  if (!canManageAgents(input.auth)) {
-    return {
-      statusCode: 403,
-      body: {
-        ok: false,
-        error: {
-          code: 'forbidden',
-          message: 'You do not have permission to delete AI agents.',
-        },
-      },
-    };
-  }
-  try {
-    deleteRegisteredAgent(input.agentId);
-    return {
-      statusCode: 200,
-      body: { ok: true, data: { deleted: true } },
-    };
-  } catch (error) {
-    return {
-      statusCode: 400,
-      body: {
-        ok: false,
-        error: {
-          code: 'registered_agent_delete_failed',
-          message:
-            error instanceof Error
-              ? error.message
-              : 'Failed to delete AI agent.',
-        },
-      },
-    };
-  }
 }

--- a/src/clawrocket/web/routes/talks.test.ts
+++ b/src/clawrocket/web/routes/talks.test.ts
@@ -140,7 +140,7 @@ describe('talk routes', () => {
     const ownTalk = memberBody.data.talks.find(
       (talk: any) => talk.id === 'talk-member',
     );
-    expect(ownTalk.agents).toEqual(['Mock']);
+    expect(ownTalk.agents).toEqual(['Claude']);
     const sharedTalk = memberBody.data.talks.find(
       (talk: any) => talk.id === 'talk-owner',
     );
@@ -221,7 +221,7 @@ describe('talk routes', () => {
     expect(byId['talk-models-array'].agents).toEqual(['GPT-4o', 'Opus']);
     expect(byId['talk-json-string'].agents).toEqual(['Gemini']);
     expect(byId['talk-delimited'].agents).toEqual(['Gemini', 'Opus4.6']);
-    expect(byId['talk-invalid-shape'].agents).toEqual(['Mock']);
+    expect(byId['talk-invalid-shape'].agents).toEqual(['Claude']);
     expect(byId['talk-many-agents'].agents).toEqual([
       'A1',
       'A2',
@@ -406,7 +406,7 @@ describe('talk routes', () => {
     });
     expect(clearRes.status).toBe(200);
     const clearBody = (await clearRes.json()) as any;
-    expect(clearBody.data.agents).toEqual(['Mock']);
+    expect(clearBody.data.agents).toEqual(['Claude']);
 
     const listRes = await server.request('/api/v1/talks', {
       headers: {
@@ -418,7 +418,7 @@ describe('talk routes', () => {
     const talk = listBody.data.talks.find(
       (row: any) => row.id === 'talk-owner',
     );
-    expect(talk.agents).toEqual(['Mock']);
+    expect(talk.agents).toEqual(['Claude']);
   });
 
   it('replays idempotent policy updates', async () => {

--- a/src/clawrocket/web/routes/talks.ts
+++ b/src/clawrocket/web/routes/talks.ts
@@ -56,19 +56,19 @@ interface TalkMessageApiRecord {
 
 export interface TalkAgentApiRecord {
   id: string;
-  registeredAgentId: string | null;
   name: string;
+  sourceKind: 'claude_default' | 'provider';
   role: TalkPersonaRole;
   isLead: boolean;
   displayOrder: number;
-  status: 'active' | 'archived' | 'legacy';
+  status: 'active' | 'archived';
   providerId: string | null;
   providerName: string | null;
   modelId: string | null;
   modelDisplayName: string | null;
 }
 
-const DEFAULT_TALK_AGENTS = ['Mock'];
+const DEFAULT_TALK_AGENTS = ['Claude'];
 const MAX_TALK_AGENT_BADGES = 6;
 const MAX_TALK_AGENTS = 12;
 const MAX_TALK_AGENT_NAME_CHARS = 80;
@@ -107,12 +107,12 @@ function toTalkApiRecord(talk: TalkWithAccessRecord): TalkApiRecord {
 
 function toTalkAgentApiRecord(agent: {
   id: string;
-  registeredAgentId: string | null;
   name: string;
+  sourceKind: 'claude_default' | 'provider';
   role: TalkPersonaRole;
   isLead: boolean;
   displayOrder: number;
-  status: 'active' | 'archived' | 'legacy';
+  status: 'active' | 'archived';
   providerId: string | null;
   providerName: string | null;
   modelId: string | null;
@@ -120,8 +120,8 @@ function toTalkAgentApiRecord(agent: {
 }): TalkAgentApiRecord {
   return {
     id: agent.id,
-    registeredAgentId: agent.registeredAgentId,
     name: agent.name,
+    sourceKind: agent.sourceKind,
     role: agent.role,
     isLead: agent.isLead,
     displayOrder: agent.displayOrder,
@@ -200,9 +200,17 @@ function validateAgentInputs(input: unknown): {
         : typeof raw.sortOrder === 'number'
           ? Math.max(0, Math.floor(raw.sortOrder))
           : index;
-    const registeredAgentId =
-      typeof raw.registeredAgentId === 'string' && raw.registeredAgentId.trim()
-        ? raw.registeredAgentId.trim()
+    const sourceKind =
+      raw.sourceKind === 'claude_default' || raw.sourceKind === 'provider'
+        ? raw.sourceKind
+        : null;
+    const providerId =
+      typeof raw.providerId === 'string' && raw.providerId.trim()
+        ? raw.providerId.trim()
+        : null;
+    const modelId =
+      typeof raw.modelId === 'string' && raw.modelId.trim()
+        ? raw.modelId.trim()
         : null;
 
     if (
@@ -219,13 +227,24 @@ function validateAgentInputs(input: unknown): {
     ) {
       return { error: 'each talk agent must have a valid role' };
     }
+    if (!sourceKind) {
+      return { error: 'each talk agent must have a valid source' };
+    }
+    if (!modelId) {
+      return { error: 'each talk agent must have a model' };
+    }
+    if (sourceKind === 'provider' && !providerId) {
+      return { error: 'provider talk agents must include a provider' };
+    }
     if (ids.has(id)) return { error: 'talk agent ids must be unique' };
     ids.add(id);
     if (isLead) leadCount += 1;
 
     normalized.push({
       id,
-      registeredAgentId,
+      sourceKind,
+      providerId,
+      modelId,
       role,
       isLead,
       displayOrder,
@@ -614,8 +633,20 @@ export function updateTalkPolicyRoute(input: {
   const agentInputs: TalkAgentInput[] = normalizedNames.map((name, index) => ({
     id: currentAgents[index]?.id || `agent_${randomUUID()}`,
     name,
+    sourceKind:
+      currentAgents[index]?.source_kind === 'claude_default'
+        ? 'claude_default'
+        : 'provider',
     personaRole: currentAgents[index]?.persona_role || 'assistant',
     routeId: currentAgents[index]?.route_id || primary.route_id,
+    providerId:
+      currentAgents[index]?.provider_id ||
+      primary.provider_id ||
+      'provider.anthropic',
+    modelId:
+      currentAgents[index]?.model_id ||
+      primary.model_id ||
+      null,
     isPrimary: index === 0,
     sortOrder: index,
   }));

--- a/src/clawrocket/web/server.ts
+++ b/src/clawrocket/web/server.ts
@@ -76,12 +76,9 @@ import {
   updateTalkPolicyRoute,
 } from './routes/talks.js';
 import {
-  createRegisteredAgentRoute,
-  deleteRegisteredAgentRoute,
-  duplicateRegisteredAgentRoute,
   getAiAgentsRoute,
   saveAiProviderCredentialRoute,
-  updateRegisteredAgentRoute,
+  updateDefaultClaudeModelRoute,
   verifyAiProviderCredentialRoute,
 } from './routes/agents.js';
 import {
@@ -1256,6 +1253,59 @@ function buildApp(opts: WebServerOptions): Hono {
     });
   });
 
+  app.put('/api/v1/agents/default-claude', async (c) => {
+    const auth = requireAuth(c);
+    if (!auth) return unauthorized(c);
+
+    const rateResult = checkRateLimit({
+      principalId: auth.userId,
+      bucket: 'write',
+    });
+    if (!rateResult.allowed) {
+      return rateLimitedResponse(c, rateResult);
+    }
+
+    const csrf = validateCsrfToken({
+      method: c.req.method,
+      authType: auth.authType,
+      cookieHeader: c.req.header('cookie'),
+      csrfHeader: c.req.header('x-csrf-token'),
+    });
+    if (!csrf.ok) {
+      return c.json(
+        { ok: false, error: { code: 'csrf_failed', message: csrf.reason } },
+        403,
+      );
+    }
+
+    const bodyText = await c.req.text();
+    const payload = parseJsonPayload<{ modelId?: string }>(bodyText);
+    if (!payload.ok) {
+      return c.json(
+        { ok: false, error: { code: 'invalid_json', message: payload.error } },
+        400,
+      );
+    }
+    if (!payload.data || typeof payload.data !== 'object') {
+      return c.json(
+        {
+          ok: false,
+          error: { code: 'invalid_json', message: 'JSON object expected.' },
+        },
+        400,
+      );
+    }
+
+    const result = updateDefaultClaudeModelRoute({
+      auth,
+      modelId: typeof payload.data.modelId === 'string' ? payload.data.modelId : '',
+    });
+    return new Response(JSON.stringify(result.body), {
+      status: result.statusCode,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    });
+  });
+
   app.put('/api/v1/agents/providers/:providerId', async (c) => {
     const auth = requireAuth(c);
     if (!auth) return unauthorized(c);
@@ -1367,224 +1417,6 @@ function buildApp(opts: WebServerOptions): Hono {
       providerId,
       verifier: providerVerifier,
     });
-    return new Response(JSON.stringify(result.body), {
-      status: result.statusCode,
-      headers: { 'content-type': 'application/json; charset=utf-8' },
-    });
-  });
-
-  app.post('/api/v1/agents/registered', async (c) => {
-    const auth = requireAuth(c);
-    if (!auth) return unauthorized(c);
-    const rateResult = checkRateLimit({
-      principalId: auth.userId,
-      bucket: 'write',
-    });
-    if (!rateResult.allowed) {
-      return rateLimitedResponse(c, rateResult);
-    }
-    const csrf = validateCsrfToken({
-      method: c.req.method,
-      authType: auth.authType,
-      cookieHeader: c.req.header('cookie'),
-      csrfHeader: c.req.header('x-csrf-token'),
-    });
-    if (!csrf.ok) {
-      return c.json(
-        { ok: false, error: { code: 'csrf_failed', message: csrf.reason } },
-        403,
-      );
-    }
-
-    const bodyText = await c.req.text();
-    const payload = parseJsonPayload<{
-      name?: string;
-      providerId?: string;
-      modelId?: string;
-      modelDisplayName?: string | null;
-      setAsDefault?: boolean;
-    }>(bodyText);
-    if (!payload.ok) {
-      return c.json(
-        { ok: false, error: { code: 'invalid_json', message: payload.error } },
-        400,
-      );
-    }
-    if (!payload.data || typeof payload.data !== 'object') {
-      return c.json(
-        {
-          ok: false,
-          error: { code: 'invalid_json', message: 'JSON object expected.' },
-        },
-        400,
-      );
-    }
-    const result = createRegisteredAgentRoute({
-      auth,
-      name: payload.data.name?.trim() || '',
-      providerId: payload.data.providerId?.trim() || '',
-      modelId: payload.data.modelId?.trim() || '',
-      modelDisplayName:
-        typeof payload.data.modelDisplayName === 'string'
-          ? payload.data.modelDisplayName
-          : undefined,
-      setAsDefault: payload.data.setAsDefault === true,
-    });
-    return new Response(JSON.stringify(result.body), {
-      status: result.statusCode,
-      headers: { 'content-type': 'application/json; charset=utf-8' },
-    });
-  });
-
-  app.patch('/api/v1/agents/registered/:agentId', async (c) => {
-    const auth = requireAuth(c);
-    if (!auth) return unauthorized(c);
-    const rateResult = checkRateLimit({
-      principalId: auth.userId,
-      bucket: 'write',
-    });
-    if (!rateResult.allowed) {
-      return rateLimitedResponse(c, rateResult);
-    }
-    const csrf = validateCsrfToken({
-      method: c.req.method,
-      authType: auth.authType,
-      cookieHeader: c.req.header('cookie'),
-      csrfHeader: c.req.header('x-csrf-token'),
-    });
-    if (!csrf.ok) {
-      return c.json(
-        { ok: false, error: { code: 'csrf_failed', message: csrf.reason } },
-        403,
-      );
-    }
-    const agentId = c.req.param('agentId');
-    const bodyText = await c.req.text();
-    const payload = parseJsonPayload<{
-      name?: string;
-      enabled?: boolean;
-      setAsDefault?: boolean;
-    }>(bodyText);
-    if (!payload.ok) {
-      return c.json(
-        { ok: false, error: { code: 'invalid_json', message: payload.error } },
-        400,
-      );
-    }
-    if (!payload.data || typeof payload.data !== 'object') {
-      return c.json(
-        {
-          ok: false,
-          error: { code: 'invalid_json', message: 'JSON object expected.' },
-        },
-        400,
-      );
-    }
-    const result = updateRegisteredAgentRoute({
-      auth,
-      agentId,
-      name:
-        typeof payload.data.name === 'string'
-          ? payload.data.name.trim()
-          : undefined,
-      enabled:
-        typeof payload.data.enabled === 'boolean'
-          ? payload.data.enabled
-          : undefined,
-      setAsDefault: payload.data.setAsDefault === true,
-    });
-    return new Response(JSON.stringify(result.body), {
-      status: result.statusCode,
-      headers: { 'content-type': 'application/json; charset=utf-8' },
-    });
-  });
-
-  app.post('/api/v1/agents/registered/:agentId/duplicate', async (c) => {
-    const auth = requireAuth(c);
-    if (!auth) return unauthorized(c);
-    const rateResult = checkRateLimit({
-      principalId: auth.userId,
-      bucket: 'write',
-    });
-    if (!rateResult.allowed) {
-      return rateLimitedResponse(c, rateResult);
-    }
-    const csrf = validateCsrfToken({
-      method: c.req.method,
-      authType: auth.authType,
-      cookieHeader: c.req.header('cookie'),
-      csrfHeader: c.req.header('x-csrf-token'),
-    });
-    if (!csrf.ok) {
-      return c.json(
-        { ok: false, error: { code: 'csrf_failed', message: csrf.reason } },
-        403,
-      );
-    }
-    const agentId = c.req.param('agentId');
-    const bodyText = await c.req.text();
-    const payload = parseJsonPayload<{
-      name?: string;
-      providerId?: string;
-      modelId?: string;
-      modelDisplayName?: string | null;
-    }>(bodyText);
-    if (!payload.ok) {
-      return c.json(
-        { ok: false, error: { code: 'invalid_json', message: payload.error } },
-        400,
-      );
-    }
-    if (!payload.data || typeof payload.data !== 'object') {
-      return c.json(
-        {
-          ok: false,
-          error: { code: 'invalid_json', message: 'JSON object expected.' },
-        },
-        400,
-      );
-    }
-    const result = duplicateRegisteredAgentRoute({
-      auth,
-      sourceAgentId: agentId,
-      name: payload.data.name?.trim() || '',
-      providerId: payload.data.providerId?.trim() || '',
-      modelId: payload.data.modelId?.trim() || '',
-      modelDisplayName:
-        typeof payload.data.modelDisplayName === 'string'
-          ? payload.data.modelDisplayName
-          : undefined,
-    });
-    return new Response(JSON.stringify(result.body), {
-      status: result.statusCode,
-      headers: { 'content-type': 'application/json; charset=utf-8' },
-    });
-  });
-
-  app.delete('/api/v1/agents/registered/:agentId', async (c) => {
-    const auth = requireAuth(c);
-    if (!auth) return unauthorized(c);
-    const rateResult = checkRateLimit({
-      principalId: auth.userId,
-      bucket: 'write',
-    });
-    if (!rateResult.allowed) {
-      return rateLimitedResponse(c, rateResult);
-    }
-    const csrf = validateCsrfToken({
-      method: c.req.method,
-      authType: auth.authType,
-      cookieHeader: c.req.header('cookie'),
-      csrfHeader: c.req.header('x-csrf-token'),
-    });
-    if (!csrf.ok) {
-      return c.json(
-        { ok: false, error: { code: 'csrf_failed', message: csrf.reason } },
-        403,
-      );
-    }
-    const agentId = c.req.param('agentId');
-    const result = deleteRegisteredAgentRoute({ auth, agentId });
     return new Response(JSON.stringify(result.body), {
       status: result.statusCode,
       headers: { 'content-type': 'application/json; charset=utf-8' },

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -151,7 +151,6 @@ export function App() {
               element={
                 <TalkDetailPage
                   onUnauthorized={handleUnauthorized}
-                  userRole={auth.user.role}
                 />
               }
             />

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -66,8 +66,8 @@ export type TalkPolicy = {
 
 export type TalkAgent = {
   id: string;
-  registeredAgentId: string | null;
   name: string;
+  sourceKind: 'claude_default' | 'provider';
   role:
     | 'assistant'
     | 'analyst'
@@ -78,7 +78,7 @@ export type TalkAgent = {
     | 'editor';
   isLead: boolean;
   displayOrder: number;
-  status: 'active' | 'archived' | 'legacy';
+  status: 'active' | 'archived';
   providerId: string | null;
   providerName: string | null;
   modelId: string | null;
@@ -117,30 +117,15 @@ export type AgentProviderCard = {
   }>;
 };
 
-export type RegisteredAgent = {
-  id: string;
-  name: string;
-  providerId: string;
-  providerName: string;
-  providerKind:
-    | 'anthropic'
-    | 'openai'
-    | 'gemini'
-    | 'deepseek'
-    | 'kimi'
-    | 'custom';
-  modelId: string;
-  modelDisplayName: string;
-  routeId: string;
-  enabled: boolean;
-  usageCount: number;
-};
-
 export type AiAgentsPageData = {
-  defaultRegisteredAgentId: string | null;
-  providers: AgentProviderCard[];
-  registeredAgents: RegisteredAgent[];
-  onboardingRequired: boolean;
+  defaultClaudeModelId: string;
+  claudeModelSuggestions: Array<{
+    modelId: string;
+    displayName: string;
+    contextWindowTokens: number;
+    defaultMaxOutputTokens: number;
+  }>;
+  additionalProviders: AgentProviderCard[];
 };
 
 export type TalkLlmProvider = {
@@ -213,6 +198,9 @@ export type ExecutorSettings = {
   hasApiKey: boolean;
   hasOauthToken: boolean;
   hasAuthToken: boolean;
+  apiKeyHint: string | null;
+  oauthTokenHint: string | null;
+  authTokenHint: string | null;
   activeCredentialConfigured: boolean;
   verificationStatus:
     | 'missing'
@@ -432,6 +420,16 @@ export async function getAiAgents(): Promise<AiAgentsPageData> {
   return apiRequest<AiAgentsPageData>('/api/v1/agents');
 }
 
+export async function updateDefaultClaudeModel(
+  modelId: string,
+): Promise<AiAgentsPageData> {
+  return apiRequest<AiAgentsPageData>('/api/v1/agents/default-claude', {
+    method: 'PUT',
+    headers: buildMutationHeaders({ includeJson: true }),
+    body: JSON.stringify({ modelId }),
+  });
+}
+
 export async function saveAiProviderCredential(input: {
   providerId: string;
   apiKey?: string | null;
@@ -461,72 +459,6 @@ export async function verifyAiProviderCredential(
     },
   );
   return envelope.provider;
-}
-
-export async function createRegisteredAgent(input: {
-  name: string;
-  providerId: string;
-  modelId: string;
-  modelDisplayName?: string | null;
-  setAsDefault?: boolean;
-}): Promise<{ agent: RegisteredAgent; defaultRegisteredAgentId: string | null }> {
-  return apiRequest<{ agent: RegisteredAgent; defaultRegisteredAgentId: string | null }>(
-    '/api/v1/agents/registered',
-    {
-      method: 'POST',
-      headers: buildMutationHeaders({ includeJson: true }),
-      body: JSON.stringify(input),
-    },
-  );
-}
-
-export async function updateRegisteredAgent(input: {
-  agentId: string;
-  name?: string;
-  enabled?: boolean;
-  setAsDefault?: boolean;
-}): Promise<{ agent: RegisteredAgent; defaultRegisteredAgentId: string | null }> {
-  return apiRequest<{ agent: RegisteredAgent; defaultRegisteredAgentId: string | null }>(
-    `/api/v1/agents/registered/${encodeURIComponent(input.agentId)}`,
-    {
-      method: 'PATCH',
-      headers: buildMutationHeaders({ includeJson: true }),
-      body: JSON.stringify({
-        name: input.name,
-        enabled: input.enabled,
-        setAsDefault: input.setAsDefault,
-      }),
-    },
-  );
-}
-
-export async function duplicateRegisteredAgent(input: {
-  sourceAgentId: string;
-  name: string;
-  providerId: string;
-  modelId: string;
-  modelDisplayName?: string | null;
-}): Promise<{ agent: RegisteredAgent }> {
-  return apiRequest<{ agent: RegisteredAgent }>(
-    `/api/v1/agents/registered/${encodeURIComponent(input.sourceAgentId)}/duplicate`,
-    {
-      method: 'POST',
-      headers: buildMutationHeaders({ includeJson: true }),
-      body: JSON.stringify(input),
-    },
-  );
-}
-
-export async function deleteRegisteredAgent(
-  agentId: string,
-): Promise<{ deleted: true }> {
-  return apiRequest<{ deleted: true }>(
-    `/api/v1/agents/registered/${encodeURIComponent(agentId)}`,
-    {
-      method: 'DELETE',
-      headers: buildMutationHeaders({ includeJson: false }),
-    },
-  );
 }
 
 export async function getTalkLlmSettings(): Promise<TalkLlmSettings> {

--- a/webapp/src/pages/AiAgentsPage.test.tsx
+++ b/webapp/src/pages/AiAgentsPage.test.tsx
@@ -1,16 +1,52 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 
 import { AiAgentsPage } from './AiAgentsPage';
-import type { AiAgentsPageData } from '../lib/api';
+import type {
+  AiAgentsPageData,
+  ExecutorSettings,
+  ExecutorStatus,
+} from '../lib/api';
 
 describe('AiAgentsPage', () => {
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it('renders the simplified Claude plus additional providers layout', async () => {
+    installAiAgentsFetch();
+
+    render(
+      <MemoryRouter initialEntries={['/app/agents']}>
+        <AiAgentsPage onUnauthorized={vi.fn()} userRole="owner" />
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole('heading', { name: 'AI Agents' });
+    expect(
+      screen.getByRole('heading', { name: 'Default Claude Agent' }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('heading', { name: 'Additional Providers' }),
+    ).toBeTruthy();
+    expect(screen.getByText('Subscription (Claude Pro/Max)')).toBeTruthy();
+    expect(
+      screen.getByText(
+        /Every new talk starts with Claude as the default agent/i,
+      ),
+    ).toBeTruthy();
+
+    const openAiCard = screen.getByRole('heading', { name: 'OpenAI' }).closest('article');
+    if (!openAiCard) {
+      throw new Error('Expected OpenAI provider card');
+    }
+    expect(
+      within(openAiCard).getByRole('link', { name: 'Get key from OpenAI' }),
+    ).toHaveAttribute('href', 'https://platform.openai.com/api-keys');
   });
 
   it('reports saved provider credentials honestly when verification does not pass', async () => {
@@ -24,9 +60,14 @@ describe('AiAgentsPage', () => {
     );
 
     await screen.findByRole('heading', { name: 'AI Agents' });
-    await user.click(screen.getByRole('button', { name: 'Configure' }));
-    await user.type(screen.getByLabelText('Token'), 'bad-token');
-    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    const openAiCard = screen.getByRole('heading', { name: 'OpenAI' }).closest('article');
+    if (!openAiCard) {
+      throw new Error('Expected OpenAI provider card');
+    }
+
+    await user.type(within(openAiCard).getByLabelText('API key'), 'bad-token');
+    await user.click(within(openAiCard).getByRole('button', { name: 'Save' }));
 
     expect(
       await screen.findByText('OpenAI credential saved. Verification status: invalid.'),
@@ -36,6 +77,8 @@ describe('AiAgentsPage', () => {
 
 function installAiAgentsFetch() {
   let snapshot = buildAiAgentsData();
+  let settings = buildExecutorSettings();
+  let status = buildExecutorStatus();
 
   vi.stubGlobal(
     'fetch',
@@ -54,10 +97,18 @@ function installAiAgentsFetch() {
         return jsonResponse(200, { ok: true, data: snapshot });
       }
 
+      if (url.endsWith('/api/v1/settings/executor') && method === 'GET') {
+        return jsonResponse(200, { ok: true, data: settings });
+      }
+
+      if (url.endsWith('/api/v1/settings/executor-status') && method === 'GET') {
+        return jsonResponse(200, { ok: true, data: status });
+      }
+
       if (url.endsWith('/api/v1/agents/providers/provider.openai') && method === 'PUT') {
         snapshot = {
           ...snapshot,
-          providers: snapshot.providers.map((provider) =>
+          additionalProviders: snapshot.additionalProviders.map((provider) =>
             provider.id === 'provider.openai'
               ? {
                   ...provider,
@@ -69,7 +120,7 @@ function installAiAgentsFetch() {
               : provider,
           ),
         };
-        const provider = snapshot.providers.find(
+        const provider = snapshot.additionalProviders.find(
           (entry) => entry.id === 'provider.openai',
         );
         return jsonResponse(200, { ok: true, data: { provider } });
@@ -82,9 +133,22 @@ function installAiAgentsFetch() {
 
 function buildAiAgentsData(): AiAgentsPageData {
   return {
-    defaultRegisteredAgentId: null,
-    onboardingRequired: true,
-    providers: [
+    defaultClaudeModelId: 'claude-sonnet-4-5',
+    claudeModelSuggestions: [
+      {
+        modelId: 'claude-sonnet-4-5',
+        displayName: 'Claude Sonnet 4.5',
+        contextWindowTokens: 200000,
+        defaultMaxOutputTokens: 4096,
+      },
+      {
+        modelId: 'claude-opus-4-1',
+        displayName: 'Claude Opus 4.1',
+        contextWindowTokens: 200000,
+        defaultMaxOutputTokens: 4096,
+      },
+    ],
+    additionalProviders: [
       {
         id: 'provider.openai',
         name: 'OpenAI',
@@ -107,8 +171,74 @@ function buildAiAgentsData(): AiAgentsPageData {
           },
         ],
       },
+      {
+        id: 'provider.gemini',
+        name: 'Google / Gemini',
+        providerKind: 'gemini',
+        apiFormat: 'openai_chat_completions',
+        baseUrl: 'https://generativelanguage.googleapis.com/openai',
+        authScheme: 'bearer',
+        enabled: true,
+        hasCredential: false,
+        credentialHint: null,
+        verificationStatus: 'missing',
+        lastVerifiedAt: null,
+        lastVerificationError: null,
+        modelSuggestions: [
+          {
+            modelId: 'gemini-2.5-flash',
+            displayName: 'Gemini 2.5 Flash',
+            contextWindowTokens: 1000000,
+            defaultMaxOutputTokens: 8192,
+          },
+        ],
+      },
     ],
-    registeredAgents: [],
+  };
+}
+
+function buildExecutorSettings(): ExecutorSettings {
+  return {
+    configuredAliasMap: {},
+    effectiveAliasMap: { Mock: 'mock' },
+    defaultAlias: 'Mock',
+    executorAuthMode: 'subscription',
+    hasApiKey: false,
+    hasOauthToken: false,
+    hasAuthToken: false,
+    apiKeyHint: null,
+    oauthTokenHint: null,
+    authTokenHint: null,
+    activeCredentialConfigured: false,
+    verificationStatus: 'missing',
+    lastVerifiedAt: null,
+    lastVerificationError: null,
+    anthropicBaseUrl: 'https://api.anthropic.com',
+    isConfigured: true,
+    configVersion: 1,
+    lastUpdatedAt: null,
+    lastUpdatedBy: null,
+    configErrors: [],
+  };
+}
+
+function buildExecutorStatus(): ExecutorStatus {
+  return {
+    mode: 'real',
+    restartSupported: false,
+    pendingRestartReasons: [],
+    activeRunCount: 0,
+    executorAuthMode: 'subscription',
+    activeCredentialConfigured: false,
+    verificationStatus: 'missing',
+    lastVerifiedAt: null,
+    lastVerificationError: null,
+    hasProviderAuth: false,
+    hasValidAliasMap: true,
+    configVersion: 1,
+    isConfigured: true,
+    bootId: 'boot-test',
+    configErrors: [],
   };
 }
 

--- a/webapp/src/pages/AiAgentsPage.tsx
+++ b/webapp/src/pages/AiAgentsPage.tsx
@@ -1,18 +1,24 @@
-import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 
 import {
   AgentProviderCard,
   AiAgentsPageData,
   ApiError,
-  createRegisteredAgent,
-  deleteRegisteredAgent,
-  duplicateRegisteredAgent,
+  ExecutorSettings,
+  ExecutorStatus,
+  ExecutorSubscriptionHostStatus,
   getAiAgents,
+  getExecutorSettings,
+  getExecutorStatus,
+  getExecutorSubscriptionHostStatus,
+  importExecutorSubscriptionFromHost,
   saveAiProviderCredential,
   UnauthorizedError,
-  updateRegisteredAgent,
+  updateDefaultClaudeModel,
+  updateExecutorSettings,
   verifyAiProviderCredential,
+  verifyExecutorCredentials,
 } from '../lib/api';
 
 type Props = {
@@ -20,34 +26,22 @@ type Props = {
   userRole: string;
 };
 
+type ClaudeAuthMode = 'subscription' | 'api_key';
+
 type ProviderDraft = {
   apiKey: string;
-  organizationId: string;
-  baseUrl: string;
-  authScheme: 'x_api_key' | 'bearer';
   expanded: boolean;
 };
 
-type AgentDraft = {
-  name: string;
-  providerId: string;
-  modelId: string;
-  modelDisplayName: string;
-  setAsDefault: boolean;
+const PROVIDER_DOCS_URL: Record<string, string> = {
+  'provider.openai': 'https://platform.openai.com/api-keys',
+  'provider.gemini': 'https://aistudio.google.com/app/apikey',
+  'provider.deepseek': 'https://platform.deepseek.com/api_keys',
+  'provider.kimi': 'https://platform.moonshot.ai/console/api-keys',
 };
 
 function canManageAgents(userRole: string): boolean {
   return userRole === 'owner' || userRole === 'admin';
-}
-
-function buildProviderDraft(provider: AgentProviderCard): ProviderDraft {
-  return {
-    apiKey: '',
-    organizationId: '',
-    baseUrl: provider.baseUrl,
-    authScheme: provider.authScheme,
-    expanded: provider.hasCredential,
-  };
 }
 
 function validateReturnTo(value: string | null): string | null {
@@ -57,22 +51,95 @@ function validateReturnTo(value: string | null): string | null {
   return value;
 }
 
+function formatClaudeAuthMode(mode: ExecutorSettings['executorAuthMode']): string {
+  switch (mode) {
+    case 'subscription':
+      return 'Subscription (Claude Pro/Max)';
+    case 'api_key':
+      return 'API';
+    case 'advanced_bearer':
+      return 'Advanced bearer / gateway';
+    default:
+      return 'None';
+  }
+}
+
 function formatVerificationStatus(
-  status: AgentProviderCard['verificationStatus'],
+  status: ExecutorStatus['verificationStatus'] | AgentProviderCard['verificationStatus'],
 ): string {
   switch (status) {
     case 'missing':
       return 'Missing';
     case 'not_verified':
       return 'Not verified';
+    case 'verifying':
+      return 'Verifying…';
     case 'verified':
-      return 'Verified';
+      return 'Configured';
     case 'invalid':
       return 'Invalid';
     case 'unavailable':
       return 'Unavailable';
     default:
       return status;
+  }
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return 'Never';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.valueOf())) return value;
+  return parsed.toLocaleString();
+}
+
+function buildProviderDraft(provider: AgentProviderCard): ProviderDraft {
+  return {
+    apiKey: '',
+    expanded: !provider.hasCredential,
+  };
+}
+
+function currentClaudeHint(
+  settings: ExecutorSettings,
+  mode: ClaudeAuthMode,
+): string | null {
+  return mode === 'subscription' ? settings.oauthTokenHint : settings.apiKeyHint;
+}
+
+function currentClaudeStored(
+  settings: ExecutorSettings,
+  mode: ClaudeAuthMode,
+): boolean {
+  return mode === 'subscription' ? settings.hasOauthToken : settings.hasApiKey;
+}
+
+function formatProviderVerificationSummary(
+  provider: AgentProviderCard,
+): string {
+  switch (provider.verificationStatus) {
+    case 'verified':
+      return 'Configured';
+    case 'invalid':
+      return 'Invalid';
+    case 'unavailable':
+      return 'Unavailable';
+    case 'not_verified':
+      return 'Needs verification';
+    case 'missing':
+    default:
+      return 'Not configured';
+  }
+}
+
+function formatProviderSaveNotice(provider: AgentProviderCard): string {
+  switch (provider.verificationStatus) {
+    case 'verified':
+      return `${provider.name} credential saved and verified.`;
+    case 'invalid':
+    case 'unavailable':
+      return `${provider.name} credential saved. Verification status: ${provider.verificationStatus}.`;
+    default:
+      return `${provider.name} credential saved.`;
   }
 }
 
@@ -83,42 +150,67 @@ export function AiAgentsPage({
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const [data, setData] = useState<AiAgentsPageData | null>(null);
+  const [settings, setSettings] = useState<ExecutorSettings | null>(null);
+  const [status, setStatus] = useState<ExecutorStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
   const [providerDrafts, setProviderDrafts] = useState<Record<string, ProviderDraft>>(
     {},
   );
-  const [busyKey, setBusyKey] = useState<string | null>(null);
-  const [agentDraft, setAgentDraft] = useState<AgentDraft>({
-    name: '',
-    providerId: 'provider.anthropic',
-    modelId: '',
-    modelDisplayName: '',
-    setAsDefault: false,
-  });
-  const [duplicateSourceId, setDuplicateSourceId] = useState<string | null>(null);
+  const [claudeModeDraft, setClaudeModeDraft] = useState<ClaudeAuthMode>('subscription');
+  const [claudeModelDraft, setClaudeModelDraft] = useState('');
+  const [claudeApiKeyDraft, setClaudeApiKeyDraft] = useState('');
+  const [claudeOauthDraft, setClaudeOauthDraft] = useState('');
+  const [clearClaudeApiKey, setClearClaudeApiKey] = useState(false);
+  const [clearClaudeOauth, setClearClaudeOauth] = useState(false);
+  const [showSubscriptionAdvanced, setShowSubscriptionAdvanced] = useState(false);
+  const [subscriptionHostStatus, setSubscriptionHostStatus] =
+    useState<ExecutorSubscriptionHostStatus | null>(null);
+  const [subscriptionHostBusy, setSubscriptionHostBusy] = useState<
+    'checking' | 'importing' | null
+  >(null);
+  const verificationPollAttemptsRef = useRef(0);
 
   const returnTo = validateReturnTo(searchParams.get('returnTo'));
-  const focus = searchParams.get('focus');
   const canManage = canManageAgents(userRole);
+
+  const syncDrafts = (
+    nextData: AiAgentsPageData,
+    nextSettings: ExecutorSettings,
+  ): void => {
+    setData(nextData);
+    setSettings(nextSettings);
+    setClaudeModeDraft(
+      nextSettings.executorAuthMode === 'api_key' ? 'api_key' : 'subscription',
+    );
+    setClaudeModelDraft(nextData.defaultClaudeModelId);
+    setClaudeApiKeyDraft('');
+    setClaudeOauthDraft('');
+    setClearClaudeApiKey(false);
+    setClearClaudeOauth(false);
+    setProviderDrafts((current) => {
+      const nextDrafts: Record<string, ProviderDraft> = {};
+      for (const provider of nextData.additionalProviders) {
+        nextDrafts[provider.id] = {
+          ...buildProviderDraft(provider),
+          expanded: current[provider.id]?.expanded || !provider.hasCredential,
+        };
+      }
+      return nextDrafts;
+    });
+  };
 
   const load = async (): Promise<void> => {
     try {
-      const next = await getAiAgents();
-      setData(next);
-      setProviderDrafts((current) => {
-        const nextDrafts: Record<string, ProviderDraft> = {};
-        for (const provider of next.providers) {
-          nextDrafts[provider.id] = {
-            ...buildProviderDraft(provider),
-            expanded:
-              current[provider.id]?.expanded ||
-              (focus === 'providers' && provider.id === 'provider.anthropic'),
-          };
-        }
-        return nextDrafts;
-      });
+      const [nextData, nextSettings, nextStatus] = await Promise.all([
+        getAiAgents(),
+        getExecutorSettings(),
+        getExecutorStatus(),
+      ]);
+      syncDrafts(nextData, nextSettings);
+      setStatus(nextStatus);
       setError(null);
     } catch (err) {
       if (err instanceof UnauthorizedError) {
@@ -135,33 +227,49 @@ export function AiAgentsPage({
     void load();
   }, []);
 
-  const configuredProviders = useMemo(
-    () => (data?.providers || []).filter((provider) => provider.hasCredential),
-    [data?.providers],
-  );
-
-  const selectedProvider =
-    data?.providers.find((provider) => provider.id === agentDraft.providerId) || null;
-
-  const modelSuggestions = selectedProvider?.modelSuggestions || [];
-
   useEffect(() => {
-    if (!data) return;
-    if (data.registeredAgents.length === 0) {
-      setAgentDraft((current) => ({
-        ...current,
-        providerId: 'provider.anthropic',
-      }));
-    } else if (
-      currentProviderMissing(data.providers, agentDraft.providerId) &&
-      configuredProviders[0]
-    ) {
-      setAgentDraft((current) => ({
-        ...current,
-        providerId: configuredProviders[0].id,
-      }));
+    if (status?.verificationStatus !== 'verifying') {
+      verificationPollAttemptsRef.current = 0;
+      return;
     }
-  }, [agentDraft.providerId, configuredProviders, data]);
+
+    let cancelled = false;
+    let timer: number | null = null;
+
+    const scheduleNext = (): void => {
+      const attempt = verificationPollAttemptsRef.current;
+      const delayMs = attempt < 5 ? 2_000 : attempt < 15 ? 5_000 : 10_000;
+      timer = window.setTimeout(() => {
+        void getExecutorStatus()
+          .then((nextStatus) => {
+            if (cancelled) return;
+            verificationPollAttemptsRef.current += 1;
+            setStatus(nextStatus);
+            if (nextStatus.verificationStatus === 'verifying') {
+              scheduleNext();
+            }
+          })
+          .catch((err) => {
+            if (cancelled) return;
+            if (err instanceof UnauthorizedError) {
+              onUnauthorized();
+              return;
+            }
+            setError(
+              err instanceof ApiError
+                ? err.message
+                : 'Failed to refresh Claude verification status.',
+            );
+          });
+      }, delayMs);
+    };
+
+    scheduleNext();
+    return () => {
+      cancelled = true;
+      if (timer !== null) clearTimeout(timer);
+    };
+  }, [status?.verificationStatus, onUnauthorized]);
 
   const updateProviderDraft = (
     providerId: string,
@@ -170,13 +278,7 @@ export function AiAgentsPage({
     setProviderDrafts((current) => ({
       ...current,
       [providerId]: {
-        ...(current[providerId] || {
-          apiKey: '',
-          organizationId: '',
-          baseUrl: '',
-          authScheme: 'bearer',
-          expanded: false,
-        }),
+        ...(current[providerId] || { apiKey: '', expanded: false }),
         ...patch,
       },
     }));
@@ -187,7 +289,7 @@ export function AiAgentsPage({
       current
         ? {
             ...current,
-            providers: current.providers.map((entry) =>
+            additionalProviders: current.additionalProviders.map((entry) =>
               entry.id === provider.id ? provider : entry,
             ),
           }
@@ -195,11 +297,123 @@ export function AiAgentsPage({
     );
     updateProviderDraft(provider.id, {
       apiKey: '',
-      organizationId: '',
-      baseUrl: provider.baseUrl,
-      authScheme: provider.authScheme,
-      expanded: provider.hasCredential,
+      expanded: !provider.hasCredential,
     });
+  };
+
+  const handleApiFailure = (err: unknown, fallback: string): void => {
+    if (err instanceof UnauthorizedError) {
+      onUnauthorized();
+      return;
+    }
+    setError(err instanceof ApiError ? err.message : fallback);
+  };
+
+  const handleSaveClaude = async (): Promise<void> => {
+    if (!data || !settings) return;
+
+    setBusyKey('claude-save');
+    setNotice(null);
+    setError(null);
+    try {
+      const update: Record<string, string | null> = {
+        executorAuthMode: claudeModeDraft,
+      };
+      if (claudeModeDraft === 'subscription') {
+        if (clearClaudeOauth) {
+          update.claudeOauthToken = null;
+        } else if (claudeOauthDraft.trim()) {
+          update.claudeOauthToken = claudeOauthDraft.trim();
+        }
+      } else if (clearClaudeApiKey) {
+        update.anthropicApiKey = null;
+      } else if (claudeApiKeyDraft.trim()) {
+        update.anthropicApiKey = claudeApiKeyDraft.trim();
+      }
+
+      const [nextSettings, nextAgents] = await Promise.all([
+        updateExecutorSettings(update),
+        claudeModelDraft !== data.defaultClaudeModelId
+          ? updateDefaultClaudeModel(claudeModelDraft)
+          : Promise.resolve(data),
+      ]);
+      syncDrafts(nextAgents, nextSettings);
+      const nextStatus = await getExecutorStatus();
+      setStatus(nextStatus);
+      setNotice(
+        claudeModeDraft === 'subscription'
+          ? 'Default Claude Agent updated for subscription mode.'
+          : 'Default Claude Agent updated for API mode.',
+      );
+    } catch (err) {
+      handleApiFailure(err, 'Failed to save Claude settings.');
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const handleVerifyClaude = async (): Promise<void> => {
+    setBusyKey('claude-verify');
+    setNotice(null);
+    setError(null);
+    try {
+      const result = await verifyExecutorCredentials();
+      const nextStatus = await getExecutorStatus();
+      setStatus(nextStatus);
+      setNotice(result.message || 'Claude verification started.');
+    } catch (err) {
+      handleApiFailure(err, 'Failed to verify Claude credentials.');
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const handleCheckSubscriptionHost = async (): Promise<void> => {
+    setSubscriptionHostBusy('checking');
+    setNotice(null);
+    setError(null);
+    try {
+      const nextHostStatus = await getExecutorSubscriptionHostStatus();
+      setSubscriptionHostStatus(nextHostStatus);
+      if (
+        !nextHostStatus.importAvailable &&
+        !nextHostStatus.serviceEnvOauthPresent &&
+        (!nextHostStatus.claudeCliInstalled || nextHostStatus.hostLoginDetected)
+      ) {
+        setShowSubscriptionAdvanced(true);
+      }
+    } catch (err) {
+      handleApiFailure(err, 'Failed to check Claude host login.');
+    } finally {
+      setSubscriptionHostBusy(null);
+    }
+  };
+
+  const handleImportSubscription = async (): Promise<void> => {
+    if (!subscriptionHostStatus?.hostCredentialFingerprint) return;
+    setSubscriptionHostBusy('importing');
+    setNotice(null);
+    setError(null);
+    try {
+      const result = await importExecutorSubscriptionFromHost(
+        subscriptionHostStatus.hostCredentialFingerprint,
+      );
+      const [nextAgents, nextStatus] = await Promise.all([
+        getAiAgents(),
+        getExecutorStatus(),
+      ]);
+      syncDrafts(nextAgents, result.settings);
+      setStatus(nextStatus);
+      setNotice(
+        result.status === 'no_change'
+          ? 'Claude subscription was already imported.'
+          : 'Claude subscription imported from the service host.',
+      );
+    } catch (err) {
+      handleApiFailure(err, 'Failed to import Claude subscription.');
+    } finally {
+      setSubscriptionHostBusy(null);
+    }
   };
 
   const handleSaveProvider = async (providerId: string): Promise<void> => {
@@ -212,28 +426,29 @@ export function AiAgentsPage({
       const provider = await saveAiProviderCredential({
         providerId,
         apiKey: draft.apiKey.trim() || null,
-        organizationId: draft.organizationId.trim() || null,
-        baseUrl: draft.baseUrl.trim() || null,
-        authScheme: draft.authScheme,
       });
       refreshProvider(provider);
-      if (!provider.hasCredential) {
-        setNotice(`${provider.name} credential cleared.`);
-      } else if (provider.verificationStatus === 'verified') {
-        setNotice(`${provider.name} credential saved and verified.`);
-      } else {
-        setNotice(
-          `${provider.name} credential saved. Verification status: ${formatVerificationStatus(
-            provider.verificationStatus,
-          ).toLowerCase()}.`,
-        );
-      }
+      setNotice(formatProviderSaveNotice(provider));
     } catch (err) {
-      if (err instanceof UnauthorizedError) {
-        onUnauthorized();
-        return;
-      }
-      setError(err instanceof ApiError ? err.message : 'Failed to save provider.');
+      handleApiFailure(err, 'Failed to save provider credential.');
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const handleClearProvider = async (providerId: string): Promise<void> => {
+    setBusyKey(`provider-save:${providerId}`);
+    setNotice(null);
+    setError(null);
+    try {
+      const provider = await saveAiProviderCredential({
+        providerId,
+        apiKey: null,
+      });
+      refreshProvider(provider);
+      setNotice(`${provider.name} credential deleted.`);
+    } catch (err) {
+      handleApiFailure(err, 'Failed to delete provider credential.');
     } finally {
       setBusyKey(null);
     }
@@ -248,152 +463,34 @@ export function AiAgentsPage({
       refreshProvider(provider);
       setNotice(`${provider.name} verification updated.`);
     } catch (err) {
-      if (err instanceof UnauthorizedError) {
-        onUnauthorized();
-        return;
-      }
-      setError(err instanceof ApiError ? err.message : 'Failed to verify provider.');
+      handleApiFailure(err, 'Failed to verify provider credential.');
     } finally {
       setBusyKey(null);
     }
   };
 
-  const handleCreateAgent = async (event: FormEvent) => {
-    event.preventDefault();
-    setBusyKey('agent-create');
-    setNotice(null);
-    setError(null);
-    try {
-      if (!agentDraft.name.trim() || !agentDraft.providerId || !agentDraft.modelId.trim()) {
-        throw new Error('Agent name, provider, and model are required.');
-      }
-      const result = duplicateSourceId
-        ? await duplicateRegisteredAgent({
-            sourceAgentId: duplicateSourceId,
-            name: agentDraft.name.trim(),
-            providerId: agentDraft.providerId,
-            modelId: agentDraft.modelId.trim(),
-            modelDisplayName: agentDraft.modelDisplayName.trim() || null,
-          })
-        : await createRegisteredAgent({
-            name: agentDraft.name.trim(),
-            providerId: agentDraft.providerId,
-            modelId: agentDraft.modelId.trim(),
-            modelDisplayName: agentDraft.modelDisplayName.trim() || null,
-            setAsDefault: agentDraft.setAsDefault,
-          });
+  const additionalProviders = data?.additionalProviders || [];
+  const selectedClaudeHint = settings ? currentClaudeHint(settings, claudeModeDraft) : null;
+  const selectedClaudeStored = settings
+    ? currentClaudeStored(settings, claudeModeDraft)
+    : false;
 
-      const next = await getAiAgents();
-      setData(next);
-      setAgentDraft({
-        name: '',
-        providerId: configuredProviders[0]?.id || 'provider.anthropic',
-        modelId: '',
-        modelDisplayName: '',
-        setAsDefault: false,
-      });
-      setDuplicateSourceId(null);
-      setNotice(
-        duplicateSourceId
-          ? 'AI agent duplicated successfully.'
-          : 'AI agent created successfully.',
-      );
-      if ('defaultRegisteredAgentId' in result) {
-        // noop; subsequent reload already applied the latest default.
-      }
-    } catch (err) {
-      if (err instanceof UnauthorizedError) {
-        onUnauthorized();
-        return;
-      }
-      setError(err instanceof ApiError ? err.message : err instanceof Error ? err.message : 'Failed to save AI agent.');
-    } finally {
-      setBusyKey(null);
+  const selectedClaudeStatus = useMemo(() => {
+    if (!settings || !status) return 'Loading…';
+    if (status.executorAuthMode !== claudeModeDraft) {
+      return 'Ready to save';
     }
-  };
-
-  const handleSetDefaultAgent = async (agentId: string): Promise<void> => {
-    setBusyKey(`default:${agentId}`);
-    setNotice(null);
-    setError(null);
-    try {
-      await updateRegisteredAgent({ agentId, setAsDefault: true });
-      const next = await getAiAgents();
-      setData(next);
-      setNotice('Default agent updated.');
-    } catch (err) {
-      if (err instanceof UnauthorizedError) {
-        onUnauthorized();
-        return;
-      }
-      setError(err instanceof ApiError ? err.message : 'Failed to update default agent.');
-    } finally {
-      setBusyKey(null);
+    if (!selectedClaudeStored) {
+      return 'Not configured';
     }
-  };
-
-  const handleToggleAgent = async (
-    agentId: string,
-    enabled: boolean,
-  ): Promise<void> => {
-    setBusyKey(`toggle:${agentId}`);
-    setNotice(null);
-    setError(null);
-    try {
-      await updateRegisteredAgent({ agentId, enabled });
-      const next = await getAiAgents();
-      setData(next);
-      setNotice(enabled ? 'AI agent re-enabled.' : 'AI agent archived.');
-    } catch (err) {
-      if (err instanceof UnauthorizedError) {
-        onUnauthorized();
-        return;
-      }
-      setError(err instanceof ApiError ? err.message : 'Failed to update AI agent.');
-    } finally {
-      setBusyKey(null);
-    }
-  };
-
-  const handleDeleteAgent = async (agentId: string): Promise<void> => {
-    if (!window.confirm('Delete this AI agent?')) return;
-    setBusyKey(`delete:${agentId}`);
-    setNotice(null);
-    setError(null);
-    try {
-      await deleteRegisteredAgent(agentId);
-      const next = await getAiAgents();
-      setData(next);
-      setNotice('AI agent deleted.');
-    } catch (err) {
-      if (err instanceof UnauthorizedError) {
-        onUnauthorized();
-        return;
-      }
-      setError(err instanceof ApiError ? err.message : 'Failed to delete AI agent.');
-    } finally {
-      setBusyKey(null);
-    }
-  };
-
-  const startDuplicate = (agentId: string): void => {
-    const agent = data?.registeredAgents.find((entry) => entry.id === agentId);
-    if (!agent) return;
-    setDuplicateSourceId(agent.id);
-    setAgentDraft({
-      name: `${agent.name} (copy)`,
-      providerId: agent.providerId,
-      modelId: agent.modelId,
-      modelDisplayName: agent.modelDisplayName,
-      setAsDefault: false,
-    });
-  };
+    return formatVerificationStatus(status.verificationStatus);
+  }, [claudeModeDraft, selectedClaudeStored, settings, status]);
 
   if (loading) {
     return <section className="page-state">Loading AI agents…</section>;
   }
 
-  if (!data) {
+  if (!data || !settings || !status) {
     return <section className="page-state">AI agents are unavailable.</section>;
   }
 
@@ -402,7 +499,7 @@ export function AiAgentsPage({
       <header className="page-header">
         <div>
           <h1>AI Agents</h1>
-          <p>Register provider credentials, create reusable agents, and choose the default for new talks.</p>
+          <p>Set up your default Claude agent and any additional provider keys you want available in talks.</p>
         </div>
         {returnTo ? (
           <button
@@ -429,70 +526,246 @@ export function AiAgentsPage({
       <section className="talk-llm-section">
         <div className="talk-llm-section-header">
           <div>
-            <h3>Default Agent</h3>
+            <h3>Default Claude Agent</h3>
             <p className="talk-llm-meta">
-              {data.defaultRegisteredAgentId
-                ? 'This agent seeds new talks.'
-                : 'No default agent is configured yet.'}
+              Every new talk starts with Claude as the default agent. You can add other agents and roles inside the talk itself.
             </p>
           </div>
         </div>
-        {data.registeredAgents.length > 0 ? (
-          <label className="talk-llm-field-span">
-            <span>Default for new talks</span>
-            <select
-              value={data.defaultRegisteredAgentId || ''}
-              onChange={(event) => void handleSetDefaultAgent(event.target.value)}
-              disabled={!canManage}
-            >
-              {data.registeredAgents
-                .filter((agent) => agent.enabled)
-                .map((agent) => (
-                  <option key={agent.id} value={agent.id}>
-                    {agent.name} · {agent.providerName} · {agent.modelDisplayName}
-                  </option>
-                ))}
-            </select>
-          </label>
-        ) : (
-          <p className="talk-llm-meta">Set up your first provider credential and agent below.</p>
-        )}
-      </section>
 
-      {data.onboardingRequired ? (
-        <section className="talk-llm-section">
-          <div className="talk-llm-section-header">
+        <article className="talk-llm-card">
+          <div className="talk-llm-card-header">
             <div>
-              <h3>First Agent Setup</h3>
+              <h4>Claude</h4>
               <p className="talk-llm-meta">
-                Configure Anthropic first, then create the initial agent that new talks will use by default.
+                Configure the Claude capability every new talk starts with.
               </p>
             </div>
+            <span className="talk-agent-chip">{selectedClaudeStatus}</span>
           </div>
-          <button
-            type="button"
-            className="secondary-btn"
-            onClick={() =>
-              updateProviderDraft('provider.anthropic', { expanded: true })
-            }
-          >
-            Configure Anthropic
-          </button>
-        </section>
-      ) : null}
+
+          <div className="talk-llm-grid">
+            <label className="talk-llm-field-span">
+              <span>Billing model</span>
+              <select
+                value={claudeModeDraft}
+                onChange={(event) =>
+                  setClaudeModeDraft(event.target.value as ClaudeAuthMode)
+                }
+                disabled={!canManage || busyKey === 'claude-save'}
+              >
+                <option value="subscription">Subscription (Claude Pro/Max)</option>
+                <option value="api_key">API</option>
+              </select>
+            </label>
+
+            <label className="talk-llm-field-span">
+              <span>Default Claude model</span>
+              <select
+                value={claudeModelDraft}
+                onChange={(event) => setClaudeModelDraft(event.target.value)}
+                disabled={!canManage || busyKey === 'claude-save'}
+              >
+                {data.claudeModelSuggestions.map((model) => (
+                  <option key={model.modelId} value={model.modelId}>
+                    {model.displayName}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          {claudeModeDraft === 'subscription' ? (
+            <div className="talk-llm-grid">
+              <div className="talk-llm-field-span">
+                <span>Subscription credential</span>
+                {selectedClaudeStored ? (
+                  <div className="talk-llm-stored-key">
+                    <div>
+                      <strong>{selectedClaudeHint || 'Stored in settings'}</strong>
+                      <p className="talk-llm-meta">
+                        Last verified {formatDateTime(status.lastVerifiedAt)}
+                      </p>
+                    </div>
+                    <span className="talk-agent-chip">
+                      {formatVerificationStatus(status.verificationStatus)}
+                    </span>
+                  </div>
+                ) : (
+                  <p className="talk-llm-meta">
+                    No Claude subscription credential is stored yet.
+                  </p>
+                )}
+                <p className="talk-llm-meta">
+                  Use Claude Code on the same machine and OS user as ClawRocket. Run:
+                  <code> claude config set -g forceLoginMethod claudeai </code>
+                  then
+                  <code> claude login</code>.
+                </p>
+                <p className="talk-llm-meta">
+                  If host import is unavailable, you can run <code>claude setup-token</code> and paste the token manually below.
+                </p>
+                <div className="talk-llm-inline-actions">
+                  <button
+                    type="button"
+                    className="secondary-btn"
+                    onClick={() => void handleCheckSubscriptionHost()}
+                    disabled={!canManage || subscriptionHostBusy === 'checking'}
+                  >
+                    {subscriptionHostBusy === 'checking'
+                      ? 'Checking…'
+                      : 'Check host Claude login'}
+                  </button>
+                  {subscriptionHostStatus?.importAvailable ? (
+                    <button
+                      type="button"
+                      className="secondary-btn"
+                      onClick={() => void handleImportSubscription()}
+                      disabled={!canManage || subscriptionHostBusy === 'importing'}
+                    >
+                      {subscriptionHostBusy === 'importing'
+                        ? 'Importing…'
+                        : 'Import from host'}
+                    </button>
+                  ) : null}
+                  <button
+                    type="button"
+                    className="secondary-btn"
+                    onClick={() => setShowSubscriptionAdvanced((current) => !current)}
+                  >
+                    {showSubscriptionAdvanced
+                      ? 'Hide manual token entry'
+                      : 'Paste Claude Code OAuth token manually'}
+                  </button>
+                </div>
+                {subscriptionHostStatus ? (
+                  <div className="talk-llm-host-status">
+                    <p className="talk-llm-meta">
+                      Checked as user {subscriptionHostStatus.serviceUser || 'unknown'} · Home{' '}
+                      {subscriptionHostStatus.serviceHomePath}
+                    </p>
+                    <p className="talk-llm-meta">{subscriptionHostStatus.message}</p>
+                    {subscriptionHostStatus.recommendedCommands.length > 0 ? (
+                      <div className="talk-llm-command-list">
+                        {subscriptionHostStatus.recommendedCommands.map((command) => (
+                          <code key={command}>{command}</code>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+                {showSubscriptionAdvanced ? (
+                  <label className="talk-llm-field-span">
+                    <span>Claude Code OAuth token</span>
+                    <input
+                      type="password"
+                      value={claudeOauthDraft}
+                      onChange={(event) => {
+                        setClaudeOauthDraft(event.target.value);
+                        setClearClaudeOauth(false);
+                      }}
+                      placeholder="Paste token from claude setup-token"
+                      disabled={!canManage || busyKey === 'claude-save'}
+                    />
+                  </label>
+                ) : null}
+              </div>
+            </div>
+          ) : (
+            <div className="talk-llm-grid">
+              <div className="talk-llm-field-span">
+                <span>Anthropic API credential</span>
+                {selectedClaudeStored ? (
+                  <div className="talk-llm-stored-key">
+                    <div>
+                      <strong>{selectedClaudeHint || 'Stored in settings'}</strong>
+                      <p className="talk-llm-meta">
+                        Get a key from{' '}
+                        <a href="https://console.anthropic.com/settings/keys" target="_blank" rel="noreferrer">
+                          Anthropic Console
+                        </a>
+                        .
+                      </p>
+                    </div>
+                    <span className="talk-agent-chip">
+                      {formatVerificationStatus(status.verificationStatus)}
+                    </span>
+                  </div>
+                ) : (
+                  <p className="talk-llm-meta">
+                    Use an Anthropic Console API key for Claude in talks.
+                  </p>
+                )}
+                <label className="talk-llm-field-span">
+                  <span>Anthropic API key</span>
+                  <input
+                    type="password"
+                    value={claudeApiKeyDraft}
+                    onChange={(event) => {
+                      setClaudeApiKeyDraft(event.target.value);
+                      setClearClaudeApiKey(false);
+                    }}
+                    placeholder="sk-ant-..."
+                    disabled={!canManage || busyKey === 'claude-save'}
+                  />
+                </label>
+              </div>
+            </div>
+          )}
+
+          <div className="talk-llm-inline-actions">
+            {claudeModeDraft === 'subscription' && settings.hasOauthToken ? (
+              <button
+                type="button"
+                className="secondary-btn"
+                onClick={() => setClearClaudeOauth(true)}
+                disabled={!canManage || busyKey === 'claude-save'}
+              >
+                Clear stored subscription token
+              </button>
+            ) : null}
+            {claudeModeDraft === 'api_key' && settings.hasApiKey ? (
+              <button
+                type="button"
+                className="secondary-btn"
+                onClick={() => setClearClaudeApiKey(true)}
+                disabled={!canManage || busyKey === 'claude-save'}
+              >
+                Clear stored API key
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="secondary-btn"
+              onClick={() => void handleVerifyClaude()}
+              disabled={!canManage || busyKey === 'claude-verify'}
+            >
+              {busyKey === 'claude-verify' ? 'Verifying…' : 'Re-verify'}
+            </button>
+            <button
+              type="button"
+              className="primary-btn"
+              onClick={() => void handleSaveClaude()}
+              disabled={!canManage || busyKey === 'claude-save'}
+            >
+              {busyKey === 'claude-save' ? 'Saving…' : 'Save Claude Settings'}
+            </button>
+          </div>
+        </article>
+      </section>
 
       <section className="talk-llm-section">
         <div className="talk-llm-section-header">
           <div>
-            <h3>Provider Credentials</h3>
+            <h3>Additional Providers</h3>
             <p className="talk-llm-meta">
-              Provider credentials are stored once per provider account and reused by registered agents.
+              Add any other provider keys you want available when inviting extra agents into a talk.
             </p>
           </div>
         </div>
 
         <div className="talk-llm-card-list">
-          {data.providers.map((provider) => {
+          {additionalProviders.map((provider) => {
             const draft = providerDrafts[provider.id] || buildProviderDraft(provider);
             const busySave = busyKey === `provider-save:${provider.id}`;
             const busyVerify = busyKey === `provider-verify:${provider.id}`;
@@ -502,42 +775,57 @@ export function AiAgentsPage({
                   <div>
                     <h4>{provider.name}</h4>
                     <p className="talk-llm-meta">
-                      {provider.hasCredential
-                        ? `${provider.credentialHint || 'Configured'} · ${formatVerificationStatus(
-                            provider.verificationStatus,
-                          )}`
-                        : 'Not configured'}
+                      {PROVIDER_DOCS_URL[provider.id] ? (
+                        <a
+                          href={PROVIDER_DOCS_URL[provider.id]}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          Get key from {provider.name}
+                        </a>
+                      ) : (
+                        'Configure this provider for additional talk agents.'
+                      )}
                     </p>
                   </div>
-                  <div className="talk-llm-inline-actions">
-                    <button
-                      type="button"
-                      className="secondary-btn"
-                      onClick={() =>
-                        updateProviderDraft(provider.id, {
-                          expanded: !draft.expanded,
-                        })
-                      }
-                    >
-                      {draft.expanded ? 'Collapse' : provider.hasCredential ? 'Update' : 'Configure'}
-                    </button>
-                    {provider.hasCredential ? (
-                      <button
-                        type="button"
-                        className="secondary-btn"
-                        onClick={() => void handleVerifyProvider(provider.id)}
-                        disabled={!canManage || busyVerify}
-                      >
-                        {busyVerify ? 'Verifying…' : 'Re-verify'}
-                      </button>
-                    ) : null}
-                  </div>
+                  <span className="talk-agent-chip">
+                    {formatProviderVerificationSummary(provider)}
+                  </span>
                 </div>
 
-                {draft.expanded ? (
+                {provider.hasCredential ? (
+                  <div className="talk-llm-stored-key">
+                    <div>
+                      <strong>{provider.credentialHint || 'Stored in settings'}</strong>
+                      <p className="talk-llm-meta">
+                        Last verified {formatDateTime(provider.lastVerifiedAt)}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      className="icon-btn danger-btn"
+                      onClick={() => void handleClearProvider(provider.id)}
+                      disabled={!canManage || busySave}
+                      aria-label={`Delete ${provider.name} credential`}
+                    >
+                      ×
+                    </button>
+                  </div>
+                ) : null}
+
+                <details
+                  className="talk-llm-update-disclosure"
+                  open={draft.expanded}
+                  onToggle={(event) =>
+                    updateProviderDraft(provider.id, {
+                      expanded: (event.currentTarget as HTMLDetailsElement).open,
+                    })
+                  }
+                >
+                  <summary>{provider.hasCredential ? 'Update key' : 'Configure'}</summary>
                   <div className="talk-llm-grid">
                     <label className="talk-llm-field-span">
-                      <span>{provider.authScheme === 'x_api_key' ? 'API key' : 'Token'}</span>
+                      <span>API key</span>
                       <input
                         type="password"
                         value={draft.apiKey}
@@ -546,57 +834,10 @@ export function AiAgentsPage({
                             apiKey: event.target.value,
                           })
                         }
-                        placeholder={
-                          provider.authScheme === 'x_api_key' ? 'sk-ant-…' : 'Bearer token'
-                        }
+                        placeholder="sk-..."
                         disabled={!canManage || busySave}
                       />
                     </label>
-                    {provider.id === 'provider.openai' ? (
-                      <label>
-                        <span>Organization ID</span>
-                        <input
-                          type="text"
-                          value={draft.organizationId}
-                          onChange={(event) =>
-                            updateProviderDraft(provider.id, {
-                              organizationId: event.target.value,
-                            })
-                          }
-                          disabled={!canManage || busySave}
-                        />
-                      </label>
-                    ) : null}
-                    <label className="talk-llm-field-span">
-                      <span>Base URL</span>
-                      <input
-                        type="text"
-                        value={draft.baseUrl}
-                        onChange={(event) =>
-                          updateProviderDraft(provider.id, {
-                            baseUrl: event.target.value,
-                          })
-                        }
-                        disabled={!canManage || busySave}
-                      />
-                    </label>
-                    {provider.id === 'provider.custom' ? (
-                      <label>
-                        <span>Auth Scheme</span>
-                        <select
-                          value={draft.authScheme}
-                          onChange={(event) =>
-                            updateProviderDraft(provider.id, {
-                              authScheme: event.target.value as 'x_api_key' | 'bearer',
-                            })
-                          }
-                          disabled={!canManage || busySave}
-                        >
-                          <option value="bearer">Bearer</option>
-                          <option value="x_api_key">X-API-Key</option>
-                        </select>
-                      </label>
-                    ) : null}
                     <div className="talk-llm-inline-actions">
                       <button
                         type="button"
@@ -604,210 +845,42 @@ export function AiAgentsPage({
                         onClick={() => void handleSaveProvider(provider.id)}
                         disabled={!canManage || busySave}
                       >
-                        {busySave ? 'Saving…' : 'Save'}
+                        {busySave ? 'Saving…' : provider.hasCredential ? 'Update' : 'Save'}
                       </button>
+                      {provider.hasCredential ? (
+                        <button
+                          type="button"
+                          className="secondary-btn"
+                          onClick={() => void handleVerifyProvider(provider.id)}
+                          disabled={!canManage || busyVerify}
+                        >
+                          {busyVerify ? 'Verifying…' : 'Re-verify'}
+                        </button>
+                      ) : null}
                     </div>
                   </div>
-                ) : null}
+                </details>
               </article>
             );
           })}
         </div>
       </section>
 
-      <section className="talk-llm-section">
-        <div className="talk-llm-section-header">
-          <div>
-            <h3>Registered Agents</h3>
-            <p className="talk-llm-meta">
-              Registered agents are reusable identities backed by one provider and model. Role stays talk-local.
-            </p>
-          </div>
-        </div>
-
-        <form className="talk-llm-card" onSubmit={handleCreateAgent}>
-          <div className="talk-llm-card-header">
+      {returnTo ? (
+        <section className="talk-llm-section">
+          <div className="talk-llm-section-header">
             <div>
-              <h4>{duplicateSourceId ? 'Duplicate as new' : 'Create AI Agent'}</h4>
+              <h3>Back to Talk</h3>
               <p className="talk-llm-meta">
-                {duplicateSourceId
-                  ? 'Create a new agent with a different provider or model.'
-                  : 'Create a global agent identity to invite into talks.'}
+                After updating Claude or provider keys, return to your talk and invite additional agents there.
               </p>
             </div>
           </div>
-          <div className="talk-llm-grid">
-            <label>
-              <span>Name</span>
-              <input
-                type="text"
-                value={agentDraft.name}
-                onChange={(event) =>
-                  setAgentDraft((current) => ({ ...current, name: event.target.value }))
-                }
-                disabled={!canManage || busyKey === 'agent-create'}
-              />
-            </label>
-            <label>
-              <span>Provider</span>
-              <select
-                value={agentDraft.providerId}
-                onChange={(event) =>
-                  setAgentDraft((current) => ({
-                    ...current,
-                    providerId: event.target.value,
-                    modelId: '',
-                    modelDisplayName: '',
-                  }))
-                }
-                disabled={!canManage || busyKey === 'agent-create'}
-              >
-                {configuredProviders.map((provider) => (
-                  <option key={provider.id} value={provider.id}>
-                    {provider.name}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label>
-              <span>Model</span>
-              <input
-                list="registered-agent-model-suggestions"
-                value={agentDraft.modelId}
-                onChange={(event) =>
-                  setAgentDraft((current) => ({
-                    ...current,
-                    modelId: event.target.value,
-                    modelDisplayName: event.target.value,
-                  }))
-                }
-                disabled={!canManage || busyKey === 'agent-create'}
-              />
-            </label>
-            <label>
-              <span>Display name</span>
-              <input
-                type="text"
-                value={agentDraft.modelDisplayName}
-                onChange={(event) =>
-                  setAgentDraft((current) => ({
-                    ...current,
-                    modelDisplayName: event.target.value,
-                  }))
-                }
-                disabled={!canManage || busyKey === 'agent-create'}
-              />
-            </label>
-            <label className="talk-llm-checkbox">
-              <input
-                type="checkbox"
-                checked={agentDraft.setAsDefault}
-                onChange={(event) =>
-                  setAgentDraft((current) => ({
-                    ...current,
-                    setAsDefault: event.target.checked,
-                  }))
-                }
-                disabled={!canManage || busyKey === 'agent-create'}
-              />
-              <span>Default for new talks</span>
-            </label>
-          </div>
-
-          <datalist id="registered-agent-model-suggestions">
-            {modelSuggestions.map((model) => (
-              <option key={model.modelId} value={model.modelId}>
-                {model.displayName}
-              </option>
-            ))}
-          </datalist>
-
-          <div className="talk-llm-inline-actions">
-            <button
-              type="submit"
-              className="primary-btn"
-              disabled={!canManage || configuredProviders.length === 0 || busyKey === 'agent-create'}
-            >
-              {busyKey === 'agent-create'
-                ? 'Saving…'
-                : duplicateSourceId
-                  ? 'Duplicate agent'
-                  : 'Create agent'}
-            </button>
-            {duplicateSourceId ? (
-              <button
-                type="button"
-                className="secondary-btn"
-                onClick={() => {
-                  setDuplicateSourceId(null);
-                  setAgentDraft((current) => ({ ...current, name: '' }));
-                }}
-              >
-                Cancel duplicate
-              </button>
-            ) : null}
-          </div>
-        </form>
-
-        {data.registeredAgents.length === 0 ? (
-          <p className="talk-llm-meta">Create your first agent once a provider credential is configured.</p>
-        ) : (
-          <div className="talk-llm-card-list">
-            {data.registeredAgents.map((agent) => (
-              <article key={agent.id} className="talk-llm-card">
-                <div className="talk-llm-card-header">
-                  <div>
-                    <h4>{agent.name}</h4>
-                    <p className="talk-llm-meta">
-                      {agent.providerName} · {agent.modelDisplayName} · Used in {agent.usageCount}{' '}
-                      talk{agent.usageCount === 1 ? '' : 's'}
-                      {!agent.enabled ? ' · Archived' : ''}
-                    </p>
-                  </div>
-                  <div className="talk-llm-inline-actions">
-                    {data.defaultRegisteredAgentId === agent.id ? (
-                      <span className="talk-agent-chip">Default</span>
-                    ) : null}
-                    <button
-                      type="button"
-                      className="secondary-btn"
-                      onClick={() => startDuplicate(agent.id)}
-                      disabled={!canManage}
-                    >
-                      Duplicate as new
-                    </button>
-                    <button
-                      type="button"
-                      className="secondary-btn"
-                      onClick={() => void handleToggleAgent(agent.id, !agent.enabled)}
-                      disabled={!canManage || busyKey === `toggle:${agent.id}`}
-                    >
-                      {agent.enabled ? 'Archive' : 'Restore'}
-                    </button>
-                    {agent.usageCount === 0 ? (
-                      <button
-                        type="button"
-                        className="secondary-btn"
-                        onClick={() => void handleDeleteAgent(agent.id)}
-                        disabled={!canManage || busyKey === `delete:${agent.id}`}
-                      >
-                        Delete
-                      </button>
-                    ) : null}
-                  </div>
-                </div>
-              </article>
-            ))}
-          </div>
-        )}
-      </section>
+          <Link to={returnTo} className="primary-btn">
+            Return to talk
+          </Link>
+        </section>
+      ) : null}
     </section>
   );
-}
-
-function currentProviderMissing(
-  providers: AgentProviderCard[],
-  providerId: string,
-): boolean {
-  return !providers.some((provider) => provider.id === providerId);
 }

--- a/webapp/src/pages/SettingsPage.test.tsx
+++ b/webapp/src/pages/SettingsPage.test.tsx
@@ -1,5 +1,4 @@
 import { cleanup, render, screen, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { SettingsPage } from './SettingsPage';
@@ -189,8 +188,7 @@ describe('SettingsPage', () => {
     expect(link.getAttribute('href')).toBe('/app/agents');
   });
 
-  it('shows pending subscription activation clearly before save', async () => {
-    const user = userEvent.setup();
+  it('shows Claude setup status as a read-only handoff to AI Agents', async () => {
     mockFetch([
       jsonResponse(200, {
         ok: true,
@@ -198,12 +196,12 @@ describe('SettingsPage', () => {
           configuredAliasMap: {},
           effectiveAliasMap: { Mock: 'default' },
           defaultAlias: 'Mock',
-          executorAuthMode: 'none',
+          executorAuthMode: 'subscription',
           hasApiKey: true,
           hasOauthToken: true,
           hasAuthToken: false,
-          activeCredentialConfigured: false,
-          verificationStatus: 'missing',
+          activeCredentialConfigured: true,
+          verificationStatus: 'not_verified',
           lastVerifiedAt: null,
           lastVerificationError: null,
           anthropicBaseUrl: '',
@@ -221,12 +219,12 @@ describe('SettingsPage', () => {
           restartSupported: false,
           pendingRestartReasons: [],
           activeRunCount: 0,
-          executorAuthMode: 'none',
-          activeCredentialConfigured: false,
-          verificationStatus: 'missing',
+          executorAuthMode: 'subscription',
+          activeCredentialConfigured: true,
+          verificationStatus: 'not_verified',
           lastVerifiedAt: null,
           lastVerificationError: null,
-          hasProviderAuth: false,
+          hasProviderAuth: true,
           hasValidAliasMap: true,
           configVersion: 2,
           isConfigured: true,
@@ -239,26 +237,22 @@ describe('SettingsPage', () => {
     render(<SettingsPage onUnauthorized={vi.fn()} userRole="owner" />);
 
     await screen.findByRole('heading', { name: 'Executor Settings' });
-    await user.selectOptions(
-      screen.getByLabelText('Active auth mode'),
-      'subscription',
-    );
-
-    expect(await screen.findByText('Ready to save')).toBeTruthy();
+    const agentsSection = await screen.findByRole('heading', { name: 'AI Agents' });
+    const agentsCard = agentsSection.closest('section');
+    expect(agentsCard).not.toBeNull();
+    const card = within(agentsCard as HTMLElement);
+    expect(agentsSection).toBeTruthy();
+    expect(await card.findByText('Current Claude mode')).toBeTruthy();
+    expect(await card.findByText('Subscription (Claude Pro/Max)')).toBeTruthy();
+    expect(await card.findByText('Not verified')).toBeTruthy();
     expect(
-      await screen.findByText(
-        /saving will switch the active Anthropic auth mode from/i,
-      ),
-    ).toBeTruthy();
-    expect(
-      await screen.findByText(/A credential is already stored in settings\./i),
-    ).toBeTruthy();
+      screen.queryByRole('button', { name: /Save Credential Settings/i }),
+    ).toBeNull();
+    expect(screen.queryByLabelText('Active auth mode')).toBeNull();
   });
 
-  it('preserves explicit credential clears when switching auth modes before save', async () => {
-    const user = userEvent.setup();
-    const fetchMock = vi.fn();
-    const responses = [
+  it('keeps Anthropic credential editing off the settings page', async () => {
+    mockFetch([
       jsonResponse(200, {
         ok: true,
         data: {
@@ -267,7 +261,7 @@ describe('SettingsPage', () => {
           defaultAlias: 'Mock',
           executorAuthMode: 'api_key',
           hasApiKey: true,
-          hasOauthToken: true,
+          hasOauthToken: false,
           hasAuthToken: false,
           activeCredentialConfigured: true,
           verificationStatus: 'verified',
@@ -301,236 +295,77 @@ describe('SettingsPage', () => {
           configErrors: [],
         },
       }),
+    ]);
+
+    render(<SettingsPage onUnauthorized={vi.fn()} userRole="owner" />);
+
+    await screen.findByRole('heading', { name: 'Executor Settings' });
+    const agentsSection = await screen.findByRole('heading', { name: 'AI Agents' });
+    const agentsCard = agentsSection.closest('section');
+    expect(agentsCard).not.toBeNull();
+    const card = within(agentsCard as HTMLElement);
+    expect(await card.findByText('API Key (Anthropic Console)')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Clear API Key/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Check host Claude login/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Import from host/i })).toBeNull();
+    expect(await screen.findByRole('link', { name: 'Open AI Agents' })).toBeTruthy();
+  });
+
+  it('uses AI Agents as the place for subscription setup guidance', async () => {
+    mockFetch([
       jsonResponse(200, {
         ok: true,
         data: {
           configuredAliasMap: {},
           effectiveAliasMap: { Mock: 'default' },
           defaultAlias: 'Mock',
-          executorAuthMode: 'subscription',
+          executorAuthMode: 'none',
           hasApiKey: false,
-          hasOauthToken: true,
+          hasOauthToken: false,
           hasAuthToken: false,
-          activeCredentialConfigured: true,
-          verificationStatus: 'verified',
-          lastVerifiedAt: '2026-03-05T12:00:00.000Z',
+          activeCredentialConfigured: false,
+          verificationStatus: 'missing',
+          lastVerifiedAt: null,
           lastVerificationError: null,
           anthropicBaseUrl: '',
-          isConfigured: true,
-          configVersion: 4,
-          lastUpdatedAt: '2026-03-06T12:00:00.000Z',
-          lastUpdatedBy: { id: 'owner-1', displayName: 'Owner' },
+          isConfigured: false,
+          configVersion: 0,
+          lastUpdatedAt: null,
+          lastUpdatedBy: null,
           configErrors: [],
         },
       }),
       jsonResponse(200, {
         ok: true,
         data: {
-          mode: 'real',
-          restartSupported: true,
+          mode: 'mock',
+          restartSupported: false,
           pendingRestartReasons: [],
           activeRunCount: 0,
-          executorAuthMode: 'subscription',
-          activeCredentialConfigured: true,
-          verificationStatus: 'verified',
-          lastVerifiedAt: '2026-03-05T12:00:00.000Z',
+          executorAuthMode: 'none',
+          activeCredentialConfigured: false,
+          verificationStatus: 'missing',
+          lastVerifiedAt: null,
           lastVerificationError: null,
-          hasProviderAuth: true,
+          hasProviderAuth: false,
           hasValidAliasMap: true,
-          configVersion: 4,
-          isConfigured: true,
-          bootId: 'boot-5',
+          configVersion: 0,
+          isConfigured: false,
+          bootId: 'boot-initial',
           configErrors: [],
         },
       }),
-    ];
-
-    fetchMock.mockImplementation(async (_input, init) => {
-      const next = responses.shift();
-      if (!next) {
-        throw new Error('No mocked response left for fetch()');
-      }
-      return next;
-    });
-    vi.stubGlobal('fetch', fetchMock);
+    ]);
 
     render(<SettingsPage onUnauthorized={vi.fn()} userRole="owner" />);
 
     await screen.findByRole('heading', { name: 'Executor Settings' });
-    await user.click(screen.getByRole('button', { name: 'Clear API Key' }));
-    await user.selectOptions(
-      screen.getByLabelText('Active auth mode'),
-      'subscription',
-    );
-    await user.click(
-      screen.getByRole('button', { name: 'Save Credential Settings' }),
-    );
-
-    await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(4);
-    });
-
-    const saveCall = fetchMock.mock.calls[2];
-    const body = JSON.parse(String(saveCall?.[1]?.body ?? '{}')) as Record<
-      string,
-      string | null
-    >;
-
-    expect(body.executorAuthMode).toBe('subscription');
-    expect(body.anthropicApiKey).toBeNull();
-  });
-
-  it('guides subscription users through host check and import', async () => {
-    const user = userEvent.setup();
-    let imported = false;
-
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (input, init) => {
-        const url = String(input);
-        const method = init?.method || 'GET';
-
-        if (url.endsWith('/api/v1/settings/executor') && method === 'GET') {
-          return jsonResponse(200, {
-            ok: true,
-            data: {
-              configuredAliasMap: {},
-              effectiveAliasMap: { Mock: 'default' },
-              defaultAlias: 'Mock',
-              executorAuthMode: imported ? 'subscription' : 'none',
-              hasApiKey: false,
-              hasOauthToken: imported,
-              hasAuthToken: false,
-              activeCredentialConfigured: imported,
-              verificationStatus: imported ? 'not_verified' : 'missing',
-              lastVerifiedAt: null,
-              lastVerificationError: null,
-              anthropicBaseUrl: '',
-              isConfigured: imported,
-              configVersion: imported ? 2 : 1,
-              lastUpdatedAt: null,
-              lastUpdatedBy: null,
-              configErrors: [],
-            },
-          });
-        }
-
-        if (url.endsWith('/api/v1/settings/executor-status') && method === 'GET') {
-          return jsonResponse(200, {
-            ok: true,
-            data: {
-              mode: imported ? 'real' : 'mock',
-              restartSupported: false,
-              pendingRestartReasons: [],
-              activeRunCount: 0,
-              executorAuthMode: imported ? 'subscription' : 'none',
-              activeCredentialConfigured: imported,
-              verificationStatus: imported ? 'not_verified' : 'missing',
-              lastVerifiedAt: null,
-              lastVerificationError: null,
-              hasProviderAuth: imported,
-              hasValidAliasMap: true,
-              configVersion: imported ? 2 : 1,
-              isConfigured: imported,
-              bootId: imported ? 'boot-imported' : 'boot-initial',
-              configErrors: [],
-            },
-          });
-        }
-
-        if (
-          url.endsWith('/api/v1/settings/executor/subscription-host-status') &&
-          method === 'GET'
-        ) {
-          return jsonResponse(200, {
-            ok: true,
-            data: {
-              serviceUser: 'clawrocket',
-              serviceUid: 1001,
-              serviceHomePath: '/srv/clawrocket',
-              runtimeContext: 'systemd',
-              claudeCliInstalled: true,
-              hostLoginDetected: true,
-              serviceEnvOauthPresent: true,
-              importAvailable: true,
-              hostCredentialFingerprint: 'fingerprint-1',
-              message:
-                'A Claude Code OAuth token is already present in the ClawRocket service environment and can be imported into settings.',
-              recommendedCommands: ['sudo -u clawrocket -H claude login'],
-            },
-          });
-        }
-
-        if (
-          url.endsWith('/api/v1/settings/executor/subscription/import') &&
-          method === 'POST'
-        ) {
-          imported = true;
-          return jsonResponse(200, {
-            ok: true,
-            data: {
-              status: 'imported',
-              settings: {
-                configuredAliasMap: {},
-                effectiveAliasMap: { Mock: 'default' },
-                defaultAlias: 'Mock',
-                executorAuthMode: 'subscription',
-                hasApiKey: false,
-                hasOauthToken: true,
-                hasAuthToken: false,
-                activeCredentialConfigured: true,
-                verificationStatus: 'not_verified',
-                lastVerifiedAt: null,
-                lastVerificationError: null,
-                anthropicBaseUrl: '',
-                isConfigured: true,
-                configVersion: 2,
-                lastUpdatedAt: null,
-                lastUpdatedBy: null,
-                configErrors: [],
-              },
-            },
-          });
-        }
-
-        throw new Error(`Unexpected fetch: ${method} ${url}`);
-      }),
-    );
-
-    render(<SettingsPage onUnauthorized={vi.fn()} userRole="owner" />);
-
-    await screen.findByRole('heading', { name: 'Executor Settings' });
-    await user.selectOptions(
-      screen.getByLabelText('Active auth mode'),
-      'subscription',
-    );
-    await user.click(
-      screen.getByRole('button', { name: 'Check host Claude login' }),
-    );
-
-    expect(await screen.findByText('Checked as user')).toBeTruthy();
-    expect(await screen.findByText('clawrocket')).toBeTruthy();
-    expect(
-      (
-        await screen.findAllByText(
-          /already present in the ClawRocket service environment/i,
-        )
-      ).length,
-    ).toBeGreaterThan(0);
-
-    await user.click(screen.getByRole('button', { name: 'Import from host' }));
-
     expect(
       await screen.findByText(
-        /Subscription credential imported from the service host/i,
+        /Configure the default Claude agent and any additional provider keys on the AI Agents page/i,
       ),
     ).toBeTruthy();
-    const selectedModeLabel = (await screen.findAllByText('Active auth mode'))[0];
-    expect(
-      within(selectedModeLabel.parentElement as HTMLElement).getByText(
-        'Subscription (Claude Pro/Max)',
-      ),
-    ).toBeTruthy();
+    expect(await screen.findByRole('link', { name: 'Open AI Agents' })).toBeTruthy();
   });
 });
 

--- a/webapp/src/pages/SettingsPage.tsx
+++ b/webapp/src/pages/SettingsPage.tsx
@@ -722,382 +722,47 @@ export function SettingsPage({ onUnauthorized, userRole }: Props) {
         ) : null}
       </section>
 
-      <section className="settings-card">
-        <h2>Anthropic Credentials</h2>
-        <p className="settings-copy">
-          Choose the active auth mode for the core executor. Stored standby
-          credentials remain visible but are not exported unless their mode is
-          selected.
-        </p>
-
-        <label className="settings-field-span">
-          <span>Active auth mode</span>
-          <select
-            value={authModeDraft}
-            onChange={(event) => setAuthModeDraft(event.target.value as AuthMode)}
-          >
-            <option value="subscription">Subscription (Claude Pro/Max)</option>
-            <option value="api_key">API Key (Anthropic Console)</option>
-            <option value="advanced_bearer">Advanced bearer / gateway</option>
-            <option value="none">None</option>
-          </select>
-        </label>
-
-        {authModeDraft === 'subscription' ? (
-          <>
-            <p className="settings-copy">
-              Use the Claude Code / Claude.ai subscription path for Claude Pro or
-              Max. Run Claude login on the machine running ClawRocket, as the
-              same OS user that runs the ClawRocket process. API-key mode takes
-              precedence over subscription usage when it is selected.
-            </p>
-            <div className="settings-grid settings-status-grid">
-              <div>
-                <span className="settings-label">Checked as user</span>
-                <strong>
-                  {subscriptionHostStatus?.serviceUser || 'Unknown service user'}
-                </strong>
-              </div>
-              <div>
-                <span className="settings-label">Home</span>
-                <strong>
-                  {subscriptionHostStatus?.serviceHomePath || 'Unknown'}
-                </strong>
-              </div>
-              <div>
-                <span className="settings-label">Host CLI</span>
-                <strong>
-                  {subscriptionHostStatus
-                    ? subscriptionHostStatus.claudeCliInstalled === true
-                      ? 'Installed'
-                      : subscriptionHostStatus.claudeCliInstalled === false
-                        ? 'Not found'
-                        : 'Unavailable'
-                    : 'Not checked'}
-                </strong>
-              </div>
-              <div>
-                <span className="settings-label">Host login</span>
-                <strong>
-                  {subscriptionHostStatus
-                    ? subscriptionHostStatus.hostLoginDetected
-                      ? 'Detected'
-                      : 'Not detected'
-                    : 'Not checked'}
-                </strong>
-              </div>
-            </div>
-
-            <div className="settings-button-row">
-              <button
-                type="button"
-                className="secondary-btn"
-                disabled={subscriptionHostBusy === 'checking'}
-                onClick={() => void checkSubscriptionHostLogin()}
-              >
-                {subscriptionHostBusy === 'checking'
-                  ? 'Checking…'
-                  : 'Check host Claude login'}
-              </button>
-              {showSubscriptionImportButton ? (
-                <button
-                  type="button"
-                  className="secondary-btn"
-                  disabled={subscriptionHostBusy === 'importing'}
-                  onClick={() => void importSubscriptionFromHost()}
-                >
-                  {subscriptionHostBusy === 'importing'
-                    ? 'Importing…'
-                    : 'Import from host'}
-                </button>
-              ) : null}
-              <button
-                type="button"
-                className="secondary-btn"
-                onClick={() =>
-                  setShowSubscriptionAdvanced((current) => !current)
-                }
-              >
-                {showSubscriptionAdvanced
-                  ? 'Hide manual token entry'
-                  : 'Paste Claude Code OAuth token manually'}
-              </button>
-            </div>
-
-            {subscriptionHostStatus ? (
-              <div className="settings-host-status">
-                <p className="settings-copy">{subscriptionHostStatus.message}</p>
-                {subscriptionHostStatus.recommendedCommands.length > 0 ? (
-                  <div className="settings-command-list">
-                    <strong>Recommended commands</strong>
-                    <ul>
-                      {subscriptionHostStatus.recommendedCommands.map((command) => (
-                        <li key={command}>
-                          <code>{command}</code>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ) : null}
-              </div>
-            ) : null}
-
-            {showSubscriptionAdvanced ? (
-              <div className="settings-advanced-box">
-                <p className="settings-copy">
-                  Manual fallback is intended for headless or unsupported host
-                  setups. You can generate a long-lived token with{' '}
-                  <code>claude setup-token</code>, then paste it here.
-                </p>
-                <p className="settings-copy">
-                  {
-                    fieldDraftState({
-                      stored: settings.hasOauthToken,
-                      cleared: clearOauth,
-                      draftValue: oauthDraft,
-                    }).message
-                  }
-                </p>
-                <div className="settings-form-grid">
-                  <label>
-                    <span>Claude Code OAuth Token</span>
-                    <input
-                      type="password"
-                      value={oauthDraft}
-                      onChange={(event) => {
-                        setOauthDraft(event.target.value);
-                        setClearOauth(false);
-                      }}
-                      placeholder={
-                        settings.hasOauthToken ? 'Configured' : 'Not configured'
-                      }
-                    />
-                  </label>
-                  <button
-                    type="button"
-                    className="secondary-btn"
-                    onClick={() => {
-                      setOauthDraft('');
-                      setClearOauth(true);
-                    }}
-                  >
-                    Clear OAuth Token
-                  </button>
-                </div>
-              </div>
-            ) : null}
-          </>
-        ) : null}
-
-        {authModeDraft === 'api_key' ? (
-          <>
-            <p className="settings-copy">
-              Use an Anthropic Console API key for normal API billing. Saving this
-              mode auto-starts verification in the background.
-            </p>
-            <p className="settings-copy">
-              {
-                fieldDraftState({
-                  stored: settings.hasApiKey,
-                  cleared: clearApiKey,
-                  draftValue: apiKeyDraft,
-                }).message
-              }
-            </p>
-            <div className="settings-form-grid">
-              <label>
-                <span>API Key</span>
-                <input
-                  type="password"
-                  value={apiKeyDraft}
-                  onChange={(event) => {
-                    setApiKeyDraft(event.target.value);
-                    setClearApiKey(false);
-                  }}
-                  placeholder={
-                    settings.hasApiKey ? 'Configured' : 'Not configured'
-                  }
-                />
-              </label>
-              <button
-                type="button"
-                className="secondary-btn"
-                onClick={() => {
-                  setApiKeyDraft('');
-                  setClearApiKey(true);
-                }}
-              >
-                Clear API Key
-              </button>
-            </div>
-          </>
-        ) : null}
-
-        {authModeDraft === 'advanced_bearer' ? (
-          <>
-            <p className="settings-copy">
-              Advanced bearer mode is intended for custom bearer-token or gateway
-              deployments. Saving this mode auto-starts verification in the
-              background.
-            </p>
-            <p className="settings-copy">
-              {
-                fieldDraftState({
-                  stored: settings.hasAuthToken,
-                  cleared: clearAuthToken,
-                  draftValue: authTokenDraft,
-                }).message
-              }
-            </p>
-            <div className="settings-form-grid">
-              <label>
-                <span>Auth Token</span>
-                <input
-                  type="password"
-                  value={authTokenDraft}
-                  onChange={(event) => {
-                    setAuthTokenDraft(event.target.value);
-                    setClearAuthToken(false);
-                  }}
-                  placeholder={
-                    settings.hasAuthToken ? 'Configured' : 'Not configured'
-                  }
-                />
-              </label>
-              <button
-                type="button"
-                className="secondary-btn"
-                onClick={() => {
-                  setAuthTokenDraft('');
-                  setClearAuthToken(true);
-                }}
-              >
-                Clear Auth Token
-              </button>
-            </div>
-          </>
-        ) : null}
-
-        {authModeDraft === 'none' ? (
+      {userRole === 'owner' || userRole === 'admin' ? (
+        <section className="settings-card">
+          <h2>AI Agents</h2>
           <p className="settings-copy">
-            The core executor will not export Anthropic credentials while None is
-            selected. Real core runs will fail fast until you choose a mode and
-            configure its credential.
+            Configure the default Claude agent and any additional provider keys
+            on the AI Agents page. Roles and primary-agent behavior are managed
+            inside each talk.
           </p>
-        ) : null}
-
-        {showBaseUrl ? (
-          <>
-            <p className="settings-copy">
-              Anthropic/Gateway Base URL applies to API Key and Advanced bearer
-              modes only.
-            </p>
-            <div className="settings-form-grid">
-              <label>
-                <span>Anthropic/Gateway Base URL</span>
-                <input
-                  type="text"
-                  value={baseUrlDraft}
-                  onChange={(event) => {
-                    setBaseUrlDraft(event.target.value);
-                    setClearBaseUrl(false);
-                  }}
-                  placeholder="https://api.anthropic.com"
-                />
-              </label>
-              <button
-                type="button"
-                className="secondary-btn"
-                onClick={() => {
-                  setBaseUrlDraft('');
-                  setClearBaseUrl(true);
-                }}
-              >
-                Clear Base URL
-              </button>
+          <div className="settings-grid settings-status-grid">
+            <div>
+              <span className="settings-label">Current Claude mode</span>
+              <strong>{formatAuthMode(status.executorAuthMode)}</strong>
             </div>
-          </>
-        ) : null}
-
-        <div className="settings-grid settings-status-grid">
-          <div>
-            <span className="settings-label">Mode to save</span>
-            <strong>{formatAuthMode(authModeDraft)}</strong>
+            <div>
+              <span className="settings-label">Credential</span>
+              <strong>
+                {status.activeCredentialConfigured ? 'Configured' : 'Missing'}
+              </strong>
+            </div>
+            <div>
+              <span className="settings-label">Verification</span>
+              <strong>{formatVerificationStatus(status.verificationStatus)}</strong>
+            </div>
+            <div>
+              <span className="settings-label">Last verified</span>
+              <strong>{formatDateTime(status.lastVerifiedAt)}</strong>
+            </div>
           </div>
-          <div>
-            <span className="settings-label">Configured</span>
-            <strong>{displayedConfiguredLabel}</strong>
-          </div>
-          <div>
-            <span className="settings-label">Status</span>
-            <strong>{displayedVerificationLabel}</strong>
-          </div>
-          <div>
-            <span className="settings-label">Last verified</span>
-            <strong>{displayedLastVerifiedLabel}</strong>
-          </div>
-        </div>
-
-        {hasUnsavedModeChange ? (
-          <p className="settings-copy">
-            <strong>Unsaved change:</strong> saving will switch the active
-            Anthropic auth mode from{' '}
-            <strong>{formatAuthMode(settings.executorAuthMode)}</strong> to{' '}
-            <strong>{formatAuthMode(authModeDraft)}</strong>.
-          </p>
-        ) : null}
-
-        <p className="settings-copy">
-          <strong>Selected mode credential:</strong>{' '}
-          {selectedModeCredentialState.message}
-        </p>
-
-        {standby.length > 0 ? (
-          <div className="settings-standby-list">
-            <strong>Stored standby credentials</strong>
-            <ul>
-              {standby.map((item) => (
-                <li key={item}>{item}</li>
-              ))}
-            </ul>
-          </div>
-        ) : null}
-
-        {status.lastVerificationError ? (
-          <p className="settings-copy">
-            <strong>Current verification note:</strong>{' '}
-            {status.lastVerificationError}
-          </p>
-        ) : null}
-
-        <div className="settings-button-row">
-          <button
-            type="button"
-            className="primary-btn"
-            disabled={busySection === 'credentials'}
-            onClick={() => void saveCredentials()}
-          >
-            {busySection === 'credentials'
-              ? 'Saving…'
-              : 'Save Credential Settings'}
-          </button>
-          {authModeDraft !== 'none' ? (
-            <button
-              type="button"
-              className="secondary-btn"
-              disabled={
-                busySection === 'verification' ||
-                status.verificationStatus === 'verifying'
-              }
-              onClick={() => void handleVerify()}
-            >
-              {busySection === 'verification'
-                ? 'Starting…'
-                : verifyButtonLabel}
-            </button>
+          {status.lastVerificationError ? (
+            <p className="settings-copy">
+              <strong>Current verification note:</strong>{' '}
+              {status.lastVerificationError}
+            </p>
           ) : null}
-        </div>
-      </section>
+          <div className="settings-section-actions">
+            <a className="secondary-btn settings-nav-link" href="/app/agents">
+              Open AI Agents
+            </a>
+          </div>
+        </section>
+      ) : null}
 
       <section className="settings-card">
         <h2>Model Alias Map</h2>
@@ -1243,20 +908,6 @@ export function SettingsPage({ onUnauthorized, userRole }: Props) {
         </p>
       </section>
 
-      {userRole === 'owner' || userRole === 'admin' ? (
-        <section className="settings-card">
-          <h2>AI Agents</h2>
-          <p className="settings-copy">
-            Provider credentials, registered agents, and the default agent for
-            new talks now live on the AI Agents page.
-          </p>
-          <div className="settings-section-actions">
-            <a className="secondary-btn settings-nav-link" href="/app/agents">
-              Open AI Agents
-            </a>
-          </div>
-        </section>
-      ) : null}
     </section>
   );
 }

--- a/webapp/src/pages/TalkDetailPage.test.tsx
+++ b/webapp/src/pages/TalkDetailPage.test.tsx
@@ -22,7 +22,9 @@ type StreamCallbacks = Parameters<typeof openTalkStream>[0];
 type SavedAgentRequest = {
   agents: Array<{
     id: string;
-    registeredAgentId: string | null;
+    sourceKind: 'claude_default' | 'provider';
+    providerId: string | null;
+    modelId: string;
     role: string;
     isLead: boolean;
     displayOrder: number;
@@ -60,7 +62,7 @@ describe('TalkDetailPage', () => {
       talk: buildTalk({ accessRole: 'viewer' }),
     });
 
-    const { unmount } = renderDetailPage({ accessRole: 'viewer' });
+    const { unmount } = renderDetailPage();
     await screen.findByRole('heading', { name: /Smoke Talk/i });
     expect(screen.queryByRole('button', { name: 'Cancel Runs' })).toBeNull();
     expect(
@@ -71,18 +73,18 @@ describe('TalkDetailPage', () => {
     installTalkDetailFetch({
       talk: buildTalk({ accessRole: 'editor' }),
     });
-    renderDetailPage({ accessRole: 'editor' });
+    renderDetailPage();
     await screen.findByRole('heading', { name: /Smoke Talk/i });
     expect(screen.getByRole('button', { name: 'Cancel Runs' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Save Agents' })).toBeTruthy();
-    expect(screen.getByLabelText('Add registered agent')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Add Agent' })).toBeTruthy();
   });
 
   it('renders effective agent badges from the talk payload', async () => {
     installTalkDetailFetch({
       talk: buildTalk({
         accessRole: 'owner',
-        agents: ['Gemini Fast', 'Claude Opus', 'Claude Sonnet'],
+        agents: ['Claude', 'Gemini 2.5 Flash', 'OpenAI GPT-5 Mini'],
       }),
     });
 
@@ -92,12 +94,12 @@ describe('TalkDetailPage', () => {
     const effectiveAgents = screen.getByRole('list', {
       name: 'Effective agents',
     });
-    expect(within(effectiveAgents).getByText('Gemini Fast')).toBeTruthy();
-    expect(within(effectiveAgents).getByText('Claude Opus')).toBeTruthy();
-    expect(within(effectiveAgents).getByText('Claude Sonnet')).toBeTruthy();
+    expect(within(effectiveAgents).getByText('Claude')).toBeTruthy();
+    expect(within(effectiveAgents).getByText('Gemini 2.5 Flash')).toBeTruthy();
+    expect(within(effectiveAgents).getByText('OpenAI GPT-5 Mini')).toBeTruthy();
   });
 
-  it('updates talk agents from the registered-agent editor', async () => {
+  it('updates talk agents from the source, model, and role editor', async () => {
     const user = userEvent.setup();
     let savedRequestBody: SavedAgentRequest | undefined;
 
@@ -109,8 +111,8 @@ describe('TalkDetailPage', () => {
           agents: [
             buildTalkAgent({
               id: body.agents[0].id,
-              registeredAgentId: 'ragent-gemini',
-              name: 'Gemini Fast',
+              name: 'Gemini',
+              sourceKind: 'provider',
               role: 'analyst',
               isLead: false,
               displayOrder: 0,
@@ -121,15 +123,15 @@ describe('TalkDetailPage', () => {
             }),
             buildTalkAgent({
               id: body.agents[1].id,
-              registeredAgentId: 'ragent-opus',
-              name: 'Claude Opus',
+              name: 'Claude',
+              sourceKind: 'claude_default',
               role: 'assistant',
               isLead: true,
               displayOrder: 1,
               providerId: 'provider.anthropic',
               providerName: 'Anthropic',
-              modelId: 'claude-opus-4-1',
-              modelDisplayName: 'Claude Opus 4.1',
+              modelId: 'claude-sonnet-4-5',
+              modelDisplayName: 'Claude Sonnet 4.5',
             }),
           ],
         };
@@ -140,89 +142,53 @@ describe('TalkDetailPage', () => {
     await screen.findByRole('heading', { name: /Smoke Talk/i });
 
     await user.selectOptions(screen.getAllByLabelText('Role')[0], 'analyst');
+
+    const controls = screen
+      .getByRole('button', { name: 'Add Agent' })
+      .closest('.policy-editor-controls') as HTMLElement | null;
+    if (!controls) {
+      throw new Error('Expected talk agent controls');
+    }
+
+    await user.selectOptions(within(controls).getByLabelText('Source'), 'claude_default');
     await user.selectOptions(
-      screen.getByLabelText('Add registered agent'),
-      'ragent-opus',
+      within(controls).getByLabelText('Model'),
+      'claude-sonnet-4-5',
     );
-    await user.click(screen.getByRole('button', { name: 'Add Agent' }));
-    await user.click(screen.getAllByLabelText('Lead Agent')[1]);
+    await user.click(within(controls).getByRole('button', { name: 'Add Agent' }));
+    await user.click(screen.getAllByLabelText('Primary Agent')[1]);
     await user.click(screen.getByRole('button', { name: 'Save Agents' }));
 
     expect(await screen.findByText('Talk agents updated.')).toBeTruthy();
     if (!savedRequestBody) {
       throw new Error('Expected talk agent update request payload');
     }
-    const requestBody = savedRequestBody;
-    expect(requestBody.agents).toHaveLength(2);
-    expect(requestBody.agents[0]).toMatchObject({
-      registeredAgentId: 'ragent-gemini',
+
+    expect(savedRequestBody.agents).toHaveLength(2);
+    expect(savedRequestBody.agents[0]).toMatchObject({
+      sourceKind: 'provider',
+      providerId: 'provider.gemini',
+      modelId: 'gemini-2.5-flash',
       role: 'analyst',
       isLead: false,
       displayOrder: 0,
     });
-    expect(requestBody.agents[1]).toMatchObject({
-      registeredAgentId: 'ragent-opus',
+    expect(savedRequestBody.agents[1]).toMatchObject({
+      sourceKind: 'claude_default',
+      providerId: null,
+      modelId: 'claude-sonnet-4-5',
       role: 'assistant',
       isLead: true,
       displayOrder: 1,
     });
 
-    const policyPanel = screen.getByLabelText('Talk policy');
-    expect(within(policyPanel).getByText('Gemini Fast · Analyst')).toBeTruthy();
-    expect(within(policyPanel).getByText('Claude Opus · Assistant · Lead')).toBeTruthy();
-  });
-
-  it('renders legacy talk agents without forcing a registered-agent selection', async () => {
-    installTalkDetailFetch({
-      talkAgents: [
-        {
-          id: 'legacy-1',
-          registeredAgentId: null,
-          name: 'Imported Legacy',
-          personaRole: 'critic',
-          isPrimary: true,
-          sortOrder: 0,
-          status: 'legacy',
-          providerId: null,
-          providerName: null,
-          modelId: null,
-          modelDisplayName: null,
-        } as unknown as TalkAgent,
-      ],
-    });
-
-    renderDetailPage();
-    await screen.findByRole('heading', { name: /Smoke Talk/i });
-
-    expect(screen.getByDisplayValue('Imported Legacy')).toBeTruthy();
-    expect(screen.getByText('Legacy agent')).toBeTruthy();
-  });
-
-  it('creates a new AI agent inline and makes it available to add to the talk', async () => {
-    const user = userEvent.setup();
-
-    installTalkDetailFetch();
-
-    renderDetailPage();
-    await screen.findByRole('heading', { name: /Smoke Talk/i });
-
-    await user.click(
-      screen.getByRole('button', { name: 'Create new AI Agent…' }),
-    );
-
-    await user.type(screen.getByLabelText('Name'), 'Claude Sonnet');
-    await user.clear(screen.getByLabelText('Model'));
-    await user.type(screen.getByLabelText('Model'), 'claude-sonnet-4-5');
-    await user.clear(screen.getByLabelText('Display name'));
-    await user.type(screen.getByLabelText('Display name'), 'Claude Sonnet 4.5');
-    await user.click(screen.getByRole('button', { name: 'Create AI Agent' }));
-
+    const talkAgentsPanel = screen.getByLabelText('Talk agents');
     expect(
-      await screen.findByText('AI agent created. You can add it to this talk now.'),
+      within(talkAgentsPanel).getByText('Gemini 2.5 Flash · Analyst'),
     ).toBeTruthy();
-
-    const addSelect = screen.getByLabelText('Add registered agent');
-    expect(within(addSelect).getByRole('option', { name: /Claude Sonnet/i })).toBeTruthy();
+    expect(
+      within(talkAgentsPanel).getByText('Claude Sonnet 4.5 · General · Primary'),
+    ).toBeTruthy();
   });
 
   it('shows send and cancel inline error states and clears send error on typing', async () => {
@@ -480,21 +446,13 @@ describe('TalkDetailPage', () => {
   });
 });
 
-function renderDetailPage(options?: {
-  accessRole?: 'owner' | 'admin' | 'editor' | 'viewer';
-  userRole?: 'owner' | 'admin' | 'member';
-}): ReturnType<typeof render> {
+function renderDetailPage(): ReturnType<typeof render> {
   return render(
     <MemoryRouter initialEntries={['/app/talks/talk-1']}>
       <Routes>
         <Route
           path="/app/talks/:talkId"
-          element={
-            <TalkDetailPage
-              onUnauthorized={vi.fn()}
-              userRole={options?.userRole || 'owner'}
-            />
-          }
+          element={<TalkDetailPage onUnauthorized={vi.fn()} />}
         />
       </Routes>
     </MemoryRouter>,
@@ -509,7 +467,7 @@ function buildTalk(input: {
     id: 'talk-1',
     ownerId: 'owner-1',
     title: 'Smoke Talk',
-    agents: input.agents || ['Gemini Fast'],
+    agents: input.agents || ['Claude'],
     status: 'active',
     version: 1,
     createdAt: '2026-03-04T00:00:00.000Z',
@@ -518,11 +476,13 @@ function buildTalk(input: {
   };
 }
 
-function buildTalkAgent(input: Partial<TalkAgent> & Pick<TalkAgent, 'id' | 'name'>): TalkAgent {
+function buildTalkAgent(
+  input: Partial<TalkAgent> & Pick<TalkAgent, 'id' | 'name'>,
+): TalkAgent {
   return {
     id: input.id,
-    registeredAgentId: input.registeredAgentId ?? null,
     name: input.name,
+    sourceKind: input.sourceKind ?? 'provider',
     role: input.role ?? 'assistant',
     isLead: input.isLead ?? false,
     displayOrder: input.displayOrder ?? 0,
@@ -534,7 +494,9 @@ function buildTalkAgent(input: Partial<TalkAgent> & Pick<TalkAgent, 'id' | 'name
   };
 }
 
-function buildMessage(input: Partial<TalkMessage> & Pick<TalkMessage, 'id' | 'role' | 'content' | 'createdAt'>): TalkMessage {
+function buildMessage(
+  input: Partial<TalkMessage> & Pick<TalkMessage, 'id' | 'role' | 'content' | 'createdAt'>,
+): TalkMessage {
   return {
     id: input.id,
     role: input.role,
@@ -549,31 +511,22 @@ function buildMessage(input: Partial<TalkMessage> & Pick<TalkMessage, 'id' | 'ro
 
 function buildAiAgentsData(): AiAgentsPageData {
   return {
-    defaultRegisteredAgentId: 'ragent-gemini',
-    onboardingRequired: false,
-    providers: [
+    defaultClaudeModelId: 'claude-sonnet-4-5',
+    claudeModelSuggestions: [
       {
-        id: 'provider.anthropic',
-        name: 'Anthropic',
-        providerKind: 'anthropic',
-        apiFormat: 'anthropic_messages',
-        baseUrl: 'https://api.anthropic.com',
-        authScheme: 'x_api_key',
-        enabled: true,
-        hasCredential: true,
-        credentialHint: '••••OPUS',
-        verificationStatus: 'verified',
-        lastVerifiedAt: '2026-03-05T12:00:00.000Z',
-        lastVerificationError: null,
-        modelSuggestions: [
-          {
-            modelId: 'claude-opus-4-1',
-            displayName: 'Claude Opus 4.1',
-            contextWindowTokens: 200000,
-            defaultMaxOutputTokens: 4096,
-          },
-        ],
+        modelId: 'claude-sonnet-4-5',
+        displayName: 'Claude Sonnet 4.5',
+        contextWindowTokens: 200000,
+        defaultMaxOutputTokens: 4096,
       },
+      {
+        modelId: 'claude-opus-4-1',
+        displayName: 'Claude Opus 4.1',
+        contextWindowTokens: 200000,
+        defaultMaxOutputTokens: 4096,
+      },
+    ],
+    additionalProviders: [
       {
         id: 'provider.gemini',
         name: 'Google / Gemini',
@@ -596,31 +549,27 @@ function buildAiAgentsData(): AiAgentsPageData {
           },
         ],
       },
-    ],
-    registeredAgents: [
       {
-        id: 'ragent-gemini',
-        name: 'Gemini Fast',
-        providerId: 'provider.gemini',
-        providerName: 'Google / Gemini',
-        providerKind: 'gemini',
-        modelId: 'gemini-2.5-flash',
-        modelDisplayName: 'Gemini 2.5 Flash',
-        routeId: 'route.agent.ragent-gemini',
+        id: 'provider.openai',
+        name: 'OpenAI',
+        providerKind: 'openai',
+        apiFormat: 'openai_chat_completions',
+        baseUrl: 'https://api.openai.com/v1',
+        authScheme: 'bearer',
         enabled: true,
-        usageCount: 1,
-      },
-      {
-        id: 'ragent-opus',
-        name: 'Claude Opus',
-        providerId: 'provider.anthropic',
-        providerName: 'Anthropic',
-        providerKind: 'anthropic',
-        modelId: 'claude-opus-4-1',
-        modelDisplayName: 'Claude Opus 4.1',
-        routeId: 'route.agent.ragent-opus',
-        enabled: true,
-        usageCount: 0,
+        hasCredential: true,
+        credentialHint: '••••MINI',
+        verificationStatus: 'verified',
+        lastVerifiedAt: '2026-03-05T12:00:00.000Z',
+        lastVerificationError: null,
+        modelSuggestions: [
+          {
+            modelId: 'gpt-5-mini',
+            displayName: 'GPT-5 Mini',
+            contextWindowTokens: 128000,
+            defaultMaxOutputTokens: 4096,
+          },
+        ],
       },
     ],
   };
@@ -633,38 +582,9 @@ function installTalkDetailFetch(input?: {
     messages: TalkMessage[];
     page: { limit: number; count: number; beforeCreatedAt: string | null };
   }>;
-  talkAgents?: Array<Partial<TalkAgent>>;
-  aiAgents?: ReturnType<typeof buildAiAgentsData>;
-  onCreateRegisteredAgent?: (body: {
-    name: string;
-    providerId: string;
-    modelId: string;
-    modelDisplayName?: string | null;
-    setAsDefault?: boolean;
-  }) => {
-    agent: {
-      id: string;
-      name: string;
-      providerId: string;
-      providerName: string;
-      providerKind: 'anthropic' | 'openai' | 'gemini' | 'deepseek' | 'kimi' | 'custom';
-      modelId: string;
-      modelDisplayName: string;
-      routeId: string;
-      enabled: boolean;
-      usageCount: number;
-    };
-    defaultRegisteredAgentId: string | null;
-  };
-  onPutAgents?: (body: {
-    agents: Array<{
-      id: string;
-      registeredAgentId: string | null;
-      role: string;
-      isLead: boolean;
-      displayOrder: number;
-    }>;
-  }) => { talkId: string; agents: TalkAgent[] };
+  talkAgents?: TalkAgent[];
+  aiAgents?: AiAgentsPageData;
+  onPutAgents?: (body: SavedAgentRequest) => { talkId: string; agents: TalkAgent[] };
   onSendMessage?: () => { status: number; body: unknown };
   onCancelRuns?: () => { status: number; body: unknown };
 }) {
@@ -678,14 +598,14 @@ function installTalkDetailFetch(input?: {
       },
     ]),
   ];
-  let aiAgents = input?.aiAgents || buildAiAgentsData();
+  const aiAgents = input?.aiAgents || buildAiAgentsData();
   const initialAgents =
     input?.talkAgents ||
     [
       buildTalkAgent({
         id: 'talk-agent-1',
-        registeredAgentId: 'ragent-gemini',
-        name: 'Gemini Fast',
+        name: 'Gemini',
+        sourceKind: 'provider',
         role: 'assistant',
         isLead: true,
         displayOrder: 0,
@@ -732,71 +652,51 @@ function installTalkDetailFetch(input?: {
         return jsonResponse(200, { ok: true, data: aiAgents });
       }
 
-      if (url.endsWith('/api/v1/agents/registered') && method === 'POST') {
-        const parsed = JSON.parse(String(init?.body || '{}')) as {
-          name: string;
-          providerId: string;
-          modelId: string;
-          modelDisplayName?: string | null;
-          setAsDefault?: boolean;
-        };
-        const created = input?.onCreateRegisteredAgent
-          ? input.onCreateRegisteredAgent(parsed)
-          : {
-              agent: {
-                id: 'ragent-sonnet',
-                name: parsed.name,
-                providerId: parsed.providerId,
-                providerName:
-                  aiAgents.providers.find((provider) => provider.id === parsed.providerId)
-                    ?.name || parsed.providerId,
-                providerKind:
-                  aiAgents.providers.find((provider) => provider.id === parsed.providerId)
-                    ?.providerKind || 'custom',
-                modelId: parsed.modelId,
-                modelDisplayName: parsed.modelDisplayName || parsed.modelId,
-                routeId: 'route.agent.ragent-sonnet',
-                enabled: true,
-                usageCount: 0,
-              },
-              defaultRegisteredAgentId: aiAgents.defaultRegisteredAgentId,
-            };
-        aiAgents = {
-          ...aiAgents,
-          defaultRegisteredAgentId: created.defaultRegisteredAgentId,
-          registeredAgents: [...aiAgents.registeredAgents, created.agent],
-        };
-        return jsonResponse(201, { ok: true, data: created });
-      }
-
       if (url.endsWith('/api/v1/talks/talk-1/agents') && method === 'PUT') {
-        const parsed = JSON.parse(String(init?.body || '{}')) as {
-          agents: Array<{
-            id: string;
-            registeredAgentId: string | null;
-            role: string;
-            isLead: boolean;
-            displayOrder: number;
-          }>;
-        };
+        const parsed = JSON.parse(String(init?.body || '{}')) as SavedAgentRequest;
         const payload = input?.onPutAgents
           ? input.onPutAgents(parsed)
           : {
               talkId: 'talk-1',
-              agents: parsed.agents.map((agent) =>
-                buildTalkAgent({
+              agents: parsed.agents.map((agent) => {
+                if (agent.sourceKind === 'claude_default') {
+                  const model =
+                    aiAgents.claudeModelSuggestions.find(
+                      (entry) => entry.modelId === agent.modelId,
+                    ) || null;
+                  return buildTalkAgent({
+                    id: agent.id,
+                    name: 'Claude',
+                    sourceKind: 'claude_default',
+                    role: agent.role as TalkAgent['role'],
+                    isLead: agent.isLead,
+                    displayOrder: agent.displayOrder,
+                    providerId: 'provider.anthropic',
+                    providerName: 'Anthropic',
+                    modelId: agent.modelId,
+                    modelDisplayName: model?.displayName || agent.modelId,
+                  });
+                }
+
+                const provider = aiAgents.additionalProviders.find(
+                  (entry) => entry.id === agent.providerId,
+                );
+                const model = provider?.modelSuggestions.find(
+                  (entry) => entry.modelId === agent.modelId,
+                );
+                return buildTalkAgent({
                   id: agent.id,
-                  registeredAgentId: agent.registeredAgentId,
-                  name:
-                    aiAgents.registeredAgents.find(
-                      (entry) => entry.id === agent.registeredAgentId,
-                    )?.name || 'Legacy Agent',
+                  name: provider?.name || 'Provider',
+                  sourceKind: 'provider',
                   role: agent.role as TalkAgent['role'],
                   isLead: agent.isLead,
                   displayOrder: agent.displayOrder,
-                  status: 'active',
-                }),
-              ),
+                  providerId: agent.providerId,
+                  providerName: provider?.name || null,
+                  modelId: agent.modelId,
+                  modelDisplayName: model?.displayName || agent.modelId,
+                });
+              }),
             };
         return jsonResponse(200, { ok: true, data: payload });
       }

--- a/webapp/src/pages/TalkDetailPage.tsx
+++ b/webapp/src/pages/TalkDetailPage.tsx
@@ -11,14 +11,13 @@ import { Link, useParams } from 'react-router-dom';
 
 import {
   AgentProviderCard,
+  AiAgentsPageData,
   ApiError,
   cancelTalkRuns,
-  createRegisteredAgent,
   getAiAgents,
   getTalk,
   getTalkAgents,
   listTalkMessages,
-  RegisteredAgent,
   sendTalkMessage,
   Talk,
   TalkAgent,
@@ -454,10 +453,17 @@ const SCROLL_STICK_THRESHOLD_PX = 120;
 const TALK_MESSAGE_MAX_CHARS = 20_000;
 
 type AgentCreationDraft = {
-  name: string;
-  providerId: string;
+  sourceKind: 'claude_default' | 'provider';
+  providerId: string | null;
   modelId: string;
-  modelDisplayName: string;
+  role: TalkAgent['role'];
+};
+
+type TalkAgentSourceOption = {
+  id: string;
+  label: string;
+  sourceKind: 'claude_default' | 'provider';
+  providerId: string | null;
 };
 
 const TALK_AGENT_ROLE_OPTIONS: TalkAgent['role'][] = [
@@ -473,7 +479,7 @@ const TALK_AGENT_ROLE_OPTIONS: TalkAgent['role'][] = [
 function formatTalkRole(role: TalkAgent['role']): string {
   switch (role) {
     case 'assistant':
-      return 'Assistant';
+      return 'General';
     case 'analyst':
       return 'Analyst';
     case 'critic':
@@ -491,18 +497,34 @@ function formatTalkRole(role: TalkAgent['role']): string {
   }
 }
 
+function buildAgentDisplayName(agent: Pick<
+  TalkAgent,
+  'sourceKind' | 'providerName' | 'modelId' | 'modelDisplayName' | 'name'
+>): string {
+  if (agent.modelDisplayName?.trim()) {
+    return agent.modelDisplayName.trim();
+  }
+  if (agent.modelId?.trim()) {
+    return agent.modelId.trim();
+  }
+  if (agent.sourceKind === 'claude_default') {
+    return 'Claude';
+  }
+  return agent.providerName?.trim() || agent.name || 'Provider';
+}
+
 function buildTalkAgentLabels(agents: TalkAgent[]): Record<string, string> {
   const counts = new Map<string, number>();
   const nextIndex = new Map<string, number>();
 
   for (const agent of agents) {
-    const base = `${agent.name} · ${formatTalkRole(agent.role)}`;
+    const base = `${buildAgentDisplayName(agent)} · ${formatTalkRole(agent.role)}`;
     counts.set(base, (counts.get(base) || 0) + 1);
   }
 
   const labels: Record<string, string> = {};
   for (const agent of agents) {
-    const base = `${agent.name} · ${formatTalkRole(agent.role)}`;
+    const base = `${buildAgentDisplayName(agent)} · ${formatTalkRole(agent.role)}`;
     if ((counts.get(base) || 0) > 1) {
       const index = (nextIndex.get(base) || 0) + 1;
       nextIndex.set(base, index);
@@ -515,18 +537,115 @@ function buildTalkAgentLabels(agents: TalkAgent[]): Record<string, string> {
   return labels;
 }
 
-function buildAgentCreationDraft(
-  providers: AgentProviderCard[],
-  providerId?: string,
-): AgentCreationDraft {
-  const selectedProvider =
-    providers.find((provider) => provider.id === providerId) || providers[0];
-  const firstSuggestion = selectedProvider?.modelSuggestions[0] || null;
+function buildAgentCreationDraft(input: {
+  claudeModelSuggestions: AiAgentsPageData['claudeModelSuggestions'];
+  providers: AgentProviderCard[];
+  sourceKind?: 'claude_default' | 'provider';
+  providerId?: string | null;
+}): AgentCreationDraft {
+  if (input.sourceKind === 'provider') {
+    const selectedProvider =
+      input.providers.find((provider) => provider.id === input.providerId) ||
+      input.providers[0] ||
+      null;
+    const firstSuggestion = selectedProvider?.modelSuggestions[0] || null;
+    return {
+      sourceKind: 'provider',
+      providerId: selectedProvider?.id || null,
+      modelId: firstSuggestion?.modelId || '',
+      role: 'assistant',
+    };
+  }
+
+  const firstClaudeModel = input.claudeModelSuggestions[0] || null;
   return {
-    name: '',
-    providerId: selectedProvider?.id || 'provider.anthropic',
-    modelId: firstSuggestion?.modelId || '',
-    modelDisplayName: firstSuggestion?.displayName || '',
+    sourceKind: 'claude_default',
+    providerId: null,
+    modelId: firstClaudeModel?.modelId || '',
+    role: 'assistant',
+  };
+}
+
+function buildTalkAgentSourceOptions(input: {
+  providers: AgentProviderCard[];
+}): TalkAgentSourceOption[] {
+  return [
+    {
+      id: 'claude_default',
+      label: 'Claude',
+      sourceKind: 'claude_default',
+      providerId: null,
+    },
+    ...input.providers.map((provider) => ({
+      id: provider.id,
+      label: provider.name,
+      sourceKind: 'provider' as const,
+      providerId: provider.id,
+    })),
+  ];
+}
+
+function getModelSuggestionsForSource(input: {
+  sourceKind: 'claude_default' | 'provider';
+  providerId: string | null;
+  aiAgents: AiAgentsPageData | null;
+}): Array<{
+  modelId: string;
+  displayName: string;
+}> {
+  if (!input.aiAgents) return [];
+  if (input.sourceKind === 'claude_default') {
+    return input.aiAgents.claudeModelSuggestions.map((model) => ({
+      modelId: model.modelId,
+      displayName: model.displayName,
+    }));
+  }
+
+  const provider = input.aiAgents.additionalProviders.find(
+    (entry) => entry.id === input.providerId,
+  );
+  return (provider?.modelSuggestions || []).map((model) => ({
+    modelId: model.modelId,
+    displayName: model.displayName,
+  }));
+}
+
+function normalizeAgentSelection(input: {
+  agent: TalkAgent;
+  sourceKind: 'claude_default' | 'provider';
+  providerId: string | null;
+  modelId: string;
+  aiAgents: AiAgentsPageData | null;
+}): Partial<TalkAgent> {
+  const suggestions = getModelSuggestionsForSource({
+    sourceKind: input.sourceKind,
+    providerId: input.providerId,
+    aiAgents: input.aiAgents,
+  });
+  const selectedModel =
+    suggestions.find((entry) => entry.modelId === input.modelId) ||
+    suggestions[0] ||
+    null;
+  const providerName =
+    input.sourceKind === 'provider'
+      ? input.aiAgents?.additionalProviders.find(
+          (provider) => provider.id === input.providerId,
+        )?.name || null
+      : 'Anthropic';
+
+  return {
+    sourceKind: input.sourceKind,
+    providerId: input.sourceKind === 'provider' ? input.providerId : null,
+    providerName,
+    modelId: selectedModel?.modelId || input.modelId || null,
+    modelDisplayName:
+      selectedModel?.displayName ||
+      (input.modelId ? input.modelId : input.agent.modelDisplayName),
+    status: input.agent.status,
+    name:
+      input.sourceKind === 'claude_default'
+        ? 'Claude'
+        : providerName || input.agent.name,
   };
 }
 
@@ -545,19 +664,22 @@ function normalizeTalkAgent(
   },
   index: number,
 ): TalkAgent {
+  const sourceKind =
+    input.sourceKind === 'claude_default' || input.sourceKind === 'provider'
+      ? input.sourceKind
+      : 'claude_default';
   return {
     id:
       typeof input.id === 'string' && input.id.trim()
         ? input.id
-        : `legacy-agent-${index}`,
-    registeredAgentId:
-      typeof input.registeredAgentId === 'string' && input.registeredAgentId.trim()
-        ? input.registeredAgentId
-        : null,
+        : `agent-${index}`,
     name:
       typeof input.name === 'string' && input.name.trim()
         ? input.name
-        : 'Legacy Agent',
+        : sourceKind === 'claude_default'
+          ? 'Claude'
+          : 'Provider',
+    sourceKind,
     role: isTalkAgentRole(input.role)
       ? input.role
       : isTalkAgentRole(input.personaRole)
@@ -574,11 +696,9 @@ function normalizeTalkAgent(
           ? input.sortOrder
           : index,
     status:
-      input.status === 'active' ||
-      input.status === 'archived' ||
-      input.status === 'legacy'
+      input.status === 'active' || input.status === 'archived'
         ? input.status
-        : 'legacy',
+        : 'active',
     providerId: typeof input.providerId === 'string' ? input.providerId : null,
     providerName:
       typeof input.providerName === 'string' ? input.providerName : null,
@@ -596,27 +716,23 @@ function normalizeTalkAgents(input: TalkAgent[]): TalkAgent[] {
 
 export function TalkDetailPage({
   onUnauthorized,
-  userRole,
 }: {
   onUnauthorized: () => void;
-  userRole: string;
 }): JSX.Element {
   const { talkId = '' } = useParams<{ talkId: string }>();
   const [state, dispatch] = useReducer(detailReducer, undefined, createInitialDetailState);
   const [draft, setDraft] = useState('');
   const [agents, setAgents] = useState<TalkAgent[]>([]);
   const [agentDrafts, setAgentDrafts] = useState<TalkAgent[]>([]);
+  const [aiAgentsData, setAiAgentsData] = useState<AiAgentsPageData | null>(null);
   const [agentProviders, setAgentProviders] = useState<AgentProviderCard[]>([]);
   const [targetAgentId, setTargetAgentId] = useState<string | null>(null);
-  const [registeredAgents, setRegisteredAgents] = useState<RegisteredAgent[]>([]);
-  const [registeredAgentsError, setRegisteredAgentsError] = useState<string | null>(null);
-  const [newAgentRegisteredId, setNewAgentRegisteredId] = useState('');
-  const [showCreateAgentInline, setShowCreateAgentInline] = useState(false);
-  const [createAgentDraft, setCreateAgentDraft] = useState<AgentCreationDraft>({
-    name: '',
-    providerId: 'provider.anthropic',
+  const [agentsCatalogError, setAgentsCatalogError] = useState<string | null>(null);
+  const [newAgentDraft, setNewAgentDraft] = useState<AgentCreationDraft>({
+    sourceKind: 'claude_default',
+    providerId: null,
     modelId: '',
-    modelDisplayName: '',
+    role: 'assistant',
   });
   const [agentState, setAgentState] = useState<{
     status: 'idle' | 'saving' | 'error' | 'success';
@@ -651,8 +767,6 @@ export function TalkDetailPage({
   const canCancelRuns =
     accessRole === 'owner' || accessRole === 'admin' || accessRole === 'editor';
   const canEditAgents = canCancelRuns;
-  const canManageRegisteredAgents =
-    userRole === 'owner' || userRole === 'admin';
 
   const isNearBottom = useCallback((): boolean => {
     const container = timelineRef.current;
@@ -852,17 +966,15 @@ export function TalkDetailPage({
     messageElementRefs.current.clear();
     setAgents([]);
     setAgentDrafts([]);
+    setAiAgentsData(null);
     setAgentProviders([]);
-    setRegisteredAgents([]);
-    setRegisteredAgentsError(null);
+    setAgentsCatalogError(null);
     setTargetAgentId(null);
-    setNewAgentRegisteredId('');
-    setShowCreateAgentInline(false);
-    setCreateAgentDraft({
-      name: '',
-      providerId: 'provider.anthropic',
+    setNewAgentDraft({
+      sourceKind: 'claude_default',
+      providerId: null,
       modelId: '',
-      modelDisplayName: '',
+      role: 'assistant',
     });
     setAgentState({ status: 'idle' });
 
@@ -877,9 +989,7 @@ export function TalkDetailPage({
           const nextAgents = normalizeTalkAgents(rawAgents);
           setAgents(nextAgents);
           setAgentDrafts(nextAgents);
-          setTargetAgentId(
-            nextAgents.find((agent) => agent.isLead)?.id || nextAgents[0]?.id || null,
-          );
+          setTargetAgentId(null);
           setAgentState({ status: 'idle' });
           dispatch({ type: 'BOOTSTRAP_READY', talk, messages });
         }
@@ -918,24 +1028,25 @@ export function TalkDetailPage({
   useEffect(() => {
     let cancelled = false;
 
-    const loadRegisteredAgents = async () => {
+    const loadAiAgents = async () => {
       try {
         const next = await getAiAgents();
         if (cancelled) return;
-        const nextProviders = next.providers.filter((provider) => provider.hasCredential);
-        const activeAgents = next.registeredAgents.filter((agent) => agent.enabled);
-        setAgentProviders(nextProviders);
-        setRegisteredAgents(activeAgents);
-        setRegisteredAgentsError(null);
-        setNewAgentRegisteredId((current) =>
-          current && activeAgents.some((agent) => agent.id === current)
-            ? current
-            : activeAgents[0]?.id || '',
+        const nextProviders = next.additionalProviders.filter(
+          (provider) => provider.hasCredential,
         );
-        setCreateAgentDraft((current) =>
-          current.name || current.modelId
+        setAiAgentsData(next);
+        setAgentProviders(nextProviders);
+        setAgentsCatalogError(null);
+        setNewAgentDraft((current) =>
+          current.modelId
             ? current
-            : buildAgentCreationDraft(nextProviders, current.providerId),
+            : buildAgentCreationDraft({
+                claudeModelSuggestions: next.claudeModelSuggestions,
+                providers: nextProviders,
+                sourceKind: current.sourceKind,
+                providerId: current.providerId,
+              }),
         );
       } catch (err) {
         if (err instanceof UnauthorizedError) {
@@ -943,15 +1054,16 @@ export function TalkDetailPage({
           return;
         }
         if (!cancelled) {
-          setRegisteredAgents([]);
-          setRegisteredAgentsError(
+          setAiAgentsData(null);
+          setAgentProviders([]);
+          setAgentsCatalogError(
             err instanceof Error ? err.message : 'Failed to load AI agents.',
           );
         }
       }
     };
 
-    void loadRegisteredAgents();
+    void loadAiAgents();
 
     return () => {
       cancelled = true;
@@ -1138,24 +1250,73 @@ export function TalkDetailPage({
     }
   };
 
+  const applyAgentSourceSelection = (
+    agentId: string,
+    input: {
+      sourceKind: 'claude_default' | 'provider';
+      providerId: string | null;
+      modelId: string;
+    },
+  ) => {
+    setAgentDrafts((current) =>
+      current.map((agent) =>
+        agent.id === agentId
+          ? {
+              ...agent,
+              ...normalizeAgentSelection({
+                agent,
+                sourceKind: input.sourceKind,
+                providerId: input.providerId,
+                modelId: input.modelId,
+                aiAgents: aiAgentsData,
+              }),
+            }
+          : agent,
+      ),
+    );
+    if (agentState.status === 'error' || agentState.status === 'success') {
+      setAgentState({ status: 'idle' });
+    }
+  };
+
   const handleAddAgent = () => {
-    const source = registeredAgents.find((agent) => agent.id === newAgentRegisteredId);
-    if (!source) return;
-    const nextAgent: TalkAgent = {
-      id: globalThis.crypto?.randomUUID?.() || `agent-${Date.now()}`,
-      registeredAgentId: source.id,
-      name: source.name,
-      role: 'assistant',
-      isLead: false,
-      displayOrder: agentDrafts.length,
-      status: 'active',
-      providerId: source.providerId,
-      providerName: source.providerName,
-      modelId: source.modelId,
-      modelDisplayName: source.modelDisplayName,
-    };
+    const nextAgent: TalkAgent = normalizeTalkAgent(
+      {
+        id: globalThis.crypto?.randomUUID?.() || `agent-${Date.now()}`,
+        name: newAgentDraft.sourceKind === 'claude_default' ? 'Claude' : 'Provider',
+        sourceKind: newAgentDraft.sourceKind,
+        providerId: newAgentDraft.providerId,
+        modelId: newAgentDraft.modelId,
+        role: newAgentDraft.role,
+        isLead: false,
+        displayOrder: agentDrafts.length,
+        status: 'active',
+        ...normalizeAgentSelection({
+          agent: {
+            id: '',
+            name: '',
+            sourceKind: newAgentDraft.sourceKind,
+            role: newAgentDraft.role,
+            isLead: false,
+            displayOrder: agentDrafts.length,
+            status: 'active',
+            providerId: newAgentDraft.providerId,
+            providerName: null,
+            modelId: newAgentDraft.modelId,
+            modelDisplayName: null,
+          },
+          sourceKind: newAgentDraft.sourceKind,
+          providerId: newAgentDraft.providerId,
+          modelId: newAgentDraft.modelId,
+          aiAgents: aiAgentsData,
+        }),
+      },
+      agentDrafts.length,
+    );
+    if (!nextAgent.modelId) return;
     setAgentDrafts((current) => [...current, nextAgent]);
-    setTargetAgentId((current) => current || nextAgent.id);
+    setTargetAgentId(null);
+    setAgentState({ status: 'idle' });
   };
 
   const handleRemoveAgent = (agentId: string) => {
@@ -1180,79 +1341,7 @@ export function TalkDetailPage({
         isLead: agent.id === agentId,
       })),
     );
-    setTargetAgentId(agentId);
-  };
-
-  const handleRegisteredAgentSelection = (
-    agentId: string,
-    registeredAgentId: string,
-  ) => {
-    const source = registeredAgents.find((agent) => agent.id === registeredAgentId);
-    if (!source) return;
-    handleAgentDraftChange(agentId, {
-      registeredAgentId: source.id,
-      name: source.name,
-      status: 'active',
-      providerId: source.providerId,
-      providerName: source.providerName,
-      modelId: source.modelId,
-      modelDisplayName: source.modelDisplayName,
-    });
-  };
-
-  const refreshRegisteredAgents = useCallback(async () => {
-    const next = await getAiAgents();
-    const nextProviders = next.providers.filter((provider) => provider.hasCredential);
-    const activeAgents = next.registeredAgents.filter((agent) => agent.enabled);
-    setAgentProviders(nextProviders);
-    setRegisteredAgents(activeAgents);
-    setRegisteredAgentsError(null);
-    setNewAgentRegisteredId((current) =>
-      current && activeAgents.some((agent) => agent.id === current)
-        ? current
-        : activeAgents[0]?.id || '',
-    );
-    return activeAgents;
-  }, []);
-
-  const handleCreateRegisteredAgentInline = async (event: FormEvent) => {
-    event.preventDefault();
-    if (!canManageRegisteredAgents) return;
-
-    setAgentState({ status: 'saving' });
-    try {
-      if (
-        !createAgentDraft.name.trim() ||
-        !createAgentDraft.providerId ||
-        !createAgentDraft.modelId.trim()
-      ) {
-        throw new Error('Agent name, provider, and model are required.');
-      }
-      const result = await createRegisteredAgent({
-        name: createAgentDraft.name.trim(),
-        providerId: createAgentDraft.providerId,
-        modelId: createAgentDraft.modelId.trim(),
-        modelDisplayName: createAgentDraft.modelDisplayName.trim() || null,
-      });
-      await refreshRegisteredAgents();
-      setShowCreateAgentInline(false);
-      setCreateAgentDraft(buildAgentCreationDraft(agentProviders));
-      setNewAgentRegisteredId(result.agent.id);
-      setAgentState({
-        status: 'success',
-        message: 'AI agent created. You can add it to this talk now.',
-      });
-    } catch (err) {
-      if (err instanceof UnauthorizedError) {
-        handleUnauthorized();
-        return;
-      }
-      setAgentState({
-        status: 'error',
-        message:
-          err instanceof Error ? err.message : 'Failed to create AI agent.',
-      });
-    }
+    setTargetAgentId(null);
   };
 
   const handleSaveAgents = async () => {
@@ -1262,22 +1351,25 @@ export function TalkDetailPage({
     try {
       const normalized = agentDrafts.map((agent, index) => ({
         id: agent.id,
-        registeredAgentId: agent.registeredAgentId,
+        sourceKind:
+          agent.sourceKind === 'claude_default' || agent.sourceKind === 'provider'
+            ? agent.sourceKind
+            : 'claude_default',
+        providerId: agent.sourceKind === 'provider' ? agent.providerId : null,
+        modelId: agent.modelId,
         role: agent.role,
         isLead: agent.isLead,
         displayOrder: index,
       }));
       const saved = normalizeTalkAgents(
         await updateTalkAgents({
-        talkId: state.talk!.id,
-        agents: normalized as TalkAgent[],
-      }),
+          talkId: state.talk!.id,
+          agents: normalized as TalkAgent[],
+        }),
       );
       setAgents(saved);
       setAgentDrafts(saved);
-      setTargetAgentId(
-        saved.find((agent) => agent.isLead)?.id || saved[0]?.id || null,
-      );
+      setTargetAgentId(null);
       setAgentState({
         status: 'success',
         message: 'Talk agents updated.',
@@ -1316,15 +1408,18 @@ export function TalkDetailPage({
     () => buildTalkAgentLabels(agentDrafts),
     [agentDrafts],
   );
-  const configuredProviderChoices = useMemo(
-    () => agentProviders.map((provider) => ({ id: provider.id, name: provider.name })),
+  const sourceOptions = useMemo(
+    () => buildTalkAgentSourceOptions({ providers: agentProviders }),
     [agentProviders],
   );
-  const selectedCreateProvider = useMemo(
+  const newAgentModelOptions = useMemo(
     () =>
-      agentProviders.find((provider) => provider.id === createAgentDraft.providerId) ||
-      null,
-    [agentProviders, createAgentDraft.providerId],
+      getModelSuggestionsForSource({
+        sourceKind: newAgentDraft.sourceKind,
+        providerId: newAgentDraft.providerId,
+        aiAgents: aiAgentsData,
+      }),
+    [aiAgentsData, newAgentDraft.modelId, newAgentDraft.providerId, newAgentDraft.sourceKind],
   );
   const manageAgentsHref = `/app/agents?returnTo=${encodeURIComponent(
     `/app/talks/${talkId}`,
@@ -1404,14 +1499,14 @@ export function TalkDetailPage({
         <Link to="/app/talks">Back</Link>
       </header>
 
-      <section className="policy-panel" aria-label="Talk policy">
+      <section className="policy-panel" aria-label="Talk agents">
         <h2>Talk Agents</h2>
         {agents.length > 0 ? (
           <div className="talk-agent-row">
             {agents.map((agent) => (
               <span key={agent.id} className="talk-agent-chip">
                 {savedAgentLabels[agent.id] || agent.name}
-                {agent.isLead ? ' · Lead' : ''}
+                {agent.isLead ? ' · Primary' : ''}
                 {agent.status !== 'active' ? ` · ${agent.status}` : ''}
               </span>
             ))}
@@ -1420,35 +1515,87 @@ export function TalkDetailPage({
         {canEditAgents ? (
           <div className="policy-editor">
             <p className="policy-muted">
-              Roles are talk-specific. Global AI agents are configured on the AI
-              Agents page.
+              The primary agent responds to normal user messages. Any other
+              agents are only used when you explicitly call them.
             </p>
             {agentDrafts.map((agent) => (
               <div key={agent.id} className="policy-agent-grid">
-                {agent.status === 'legacy' ? (
+                <>
                   <label>
-                    <span>Legacy agent</span>
-                    <input type="text" value={agent.name} disabled />
-                  </label>
-                ) : (
-                  <label>
-                    <span>AI Agent</span>
+                    <span>Agent source</span>
                     <select
-                      value={agent.registeredAgentId || ''}
-                      onChange={(event) =>
-                        handleRegisteredAgentSelection(agent.id, event.target.value)
+                      value={
+                        agent.sourceKind === 'claude_default'
+                          ? 'claude_default'
+                          : agent.providerId || ''
                       }
+                      onChange={(event) => {
+                        const selected = sourceOptions.find(
+                          (option) => option.id === event.target.value,
+                        );
+                        if (!selected) return;
+                        const suggestions = getModelSuggestionsForSource({
+                          sourceKind: selected.sourceKind,
+                          providerId: selected.providerId,
+                          aiAgents: aiAgentsData,
+                        });
+                        applyAgentSourceSelection(agent.id, {
+                          sourceKind: selected.sourceKind,
+                          providerId: selected.providerId,
+                          modelId:
+                            suggestions.find(
+                              (entry) => entry.modelId === agent.modelId,
+                            )?.modelId ||
+                            suggestions[0]?.modelId ||
+                            '',
+                        });
+                      }}
                       disabled={agentState.status === 'saving'}
                     >
-                      {registeredAgents.map((registeredAgent) => (
-                        <option key={registeredAgent.id} value={registeredAgent.id}>
-                          {registeredAgent.name} · {registeredAgent.providerName} ·{' '}
-                          {registeredAgent.modelDisplayName}
+                      {sourceOptions.map((option) => (
+                        <option key={option.id} value={option.id}>
+                          {option.label}
                         </option>
                       ))}
                     </select>
                   </label>
-                )}
+                  <label>
+                    <span>Model</span>
+                    <select
+                      value={agent.modelId || ''}
+                      onChange={(event) =>
+                        applyAgentSourceSelection(agent.id, {
+                          sourceKind:
+                            agent.sourceKind === 'provider'
+                              ? 'provider'
+                              : 'claude_default',
+                          providerId:
+                            agent.sourceKind === 'provider'
+                              ? agent.providerId
+                              : null,
+                          modelId: event.target.value,
+                        })
+                      }
+                      disabled={agentState.status === 'saving'}
+                    >
+                      {getModelSuggestionsForSource({
+                        sourceKind:
+                          agent.sourceKind === 'provider'
+                            ? 'provider'
+                            : 'claude_default',
+                        providerId:
+                          agent.sourceKind === 'provider'
+                            ? agent.providerId
+                            : null,
+                        aiAgents: aiAgentsData,
+                      }).map((model) => (
+                        <option key={model.modelId} value={model.modelId}>
+                          {model.displayName}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </>
                 <label>
                   <span>Role</span>
                   <select
@@ -1478,12 +1625,12 @@ export function TalkDetailPage({
                 <label className="policy-primary-toggle">
                   <input
                     type="radio"
-                    name="lead-talk-agent"
+                    name="primary-talk-agent"
                     checked={agent.isLead}
                     onChange={() => handleSetLeadAgent(agent.id)}
                     disabled={agentState.status === 'saving'}
                   />
-                  <span>Lead Agent</span>
+                  <span>Primary Agent</span>
                 </label>
                 <button
                   type="button"
@@ -1497,17 +1644,71 @@ export function TalkDetailPage({
             ))}
             <div className="policy-editor-controls">
               <label className="policy-add-agent">
-                <span>Add registered agent</span>
+                <span>Source</span>
                 <select
-                  value={newAgentRegisteredId}
-                  onChange={(event) => setNewAgentRegisteredId(event.target.value)}
-                  disabled={
-                    agentState.status === 'saving' || registeredAgents.length === 0
+                  value={
+                    newAgentDraft.sourceKind === 'claude_default'
+                      ? 'claude_default'
+                      : newAgentDraft.providerId || ''
                   }
+                  onChange={(event) => {
+                    const selected = sourceOptions.find(
+                      (option) => option.id === event.target.value,
+                    );
+                    if (!selected) return;
+                    setNewAgentDraft(
+                      buildAgentCreationDraft({
+                        claudeModelSuggestions:
+                          aiAgentsData?.claudeModelSuggestions || [],
+                        providers: agentProviders,
+                        sourceKind: selected.sourceKind,
+                        providerId: selected.providerId,
+                      }),
+                    );
+                  }}
+                  disabled={agentState.status === 'saving'}
                 >
-                  {registeredAgents.map((agent) => (
-                    <option key={agent.id} value={agent.id}>
-                      {agent.name} · {agent.providerName} · {agent.modelDisplayName}
+                  {sourceOptions.map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="policy-add-agent">
+                <span>Model</span>
+                <select
+                  value={newAgentDraft.modelId}
+                  onChange={(event) =>
+                    setNewAgentDraft((current) => ({
+                      ...current,
+                      modelId: event.target.value,
+                    }))
+                  }
+                  disabled={agentState.status === 'saving'}
+                >
+                  {newAgentModelOptions.map((model) => (
+                    <option key={model.modelId} value={model.modelId}>
+                      {model.displayName}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="policy-add-agent">
+                <span>Role</span>
+                <select
+                  value={newAgentDraft.role}
+                  onChange={(event) =>
+                    setNewAgentDraft((current) => ({
+                      ...current,
+                      role: event.target.value as TalkAgent['role'],
+                    }))
+                  }
+                  disabled={agentState.status === 'saving'}
+                >
+                  {TALK_AGENT_ROLE_OPTIONS.map((role) => (
+                    <option key={role} value={role}>
+                      {formatTalkRole(role)}
                     </option>
                   ))}
                 </select>
@@ -1517,35 +1718,11 @@ export function TalkDetailPage({
                 className="secondary-btn"
                 onClick={handleAddAgent}
                 disabled={
-                  agentState.status === 'saving' || registeredAgents.length === 0
+                  agentState.status === 'saving' || !newAgentDraft.modelId
                 }
               >
                 Add Agent
               </button>
-              {canManageRegisteredAgents ? (
-                <button
-                  type="button"
-                  className="secondary-btn"
-                  onClick={() => {
-                    setShowCreateAgentInline((current) => !current);
-                    setCreateAgentDraft(
-                      buildAgentCreationDraft(
-                        agentProviders,
-                        createAgentDraft.providerId,
-                      ),
-                    );
-                  }}
-                  disabled={
-                    agentState.status === 'saving' || agentProviders.length === 0
-                  }
-                >
-                  Create new AI Agent…
-                </button>
-              ) : (
-                <Link className="secondary-btn" to={manageAgentsHref}>
-                  Open AI Agents
-                </Link>
-              )}
               <button
                 type="button"
                 className="secondary-btn"
@@ -1554,129 +1731,23 @@ export function TalkDetailPage({
               >
                 {agentState.status === 'saving' ? 'Saving…' : 'Save Agents'}
               </button>
+              <Link className="secondary-btn" to={manageAgentsHref}>
+                Manage AI Agents
+              </Link>
             </div>
-            {registeredAgentsError ? (
+            {agentsCatalogError ? (
               <div className="inline-banner inline-banner-error" role="alert">
-                {registeredAgentsError}
+                {agentsCatalogError}
               </div>
             ) : null}
-            {registeredAgents.length === 0 ? (
+            {sourceOptions.length <= 1 ? (
               <div className="inline-banner inline-banner-warning" role="status">
-                <span>No active AI agents are configured yet.</span>
-                <Link to={manageAgentsHref}>Set up AI Agents</Link>
+                <span>
+                  Claude is ready, but no additional provider keys are
+                  configured yet.
+                </span>
+                <Link to={manageAgentsHref}>Open AI Agents</Link>
               </div>
-            ) : null}
-            {showCreateAgentInline && canManageRegisteredAgents ? (
-              <form
-                className="policy-inline-create"
-                onSubmit={handleCreateRegisteredAgentInline}
-              >
-                <h3>Create new AI Agent</h3>
-                <p className="policy-muted">
-                  Create a global agent identity, then add it to this talk.
-                </p>
-                <div className="policy-agent-grid">
-                  <label>
-                    <span>Name</span>
-                    <input
-                      type="text"
-                      value={createAgentDraft.name}
-                      onChange={(event) =>
-                        setCreateAgentDraft((current) => ({
-                          ...current,
-                          name: event.target.value,
-                        }))
-                      }
-                      disabled={agentState.status === 'saving'}
-                    />
-                  </label>
-                  <label>
-                    <span>Provider</span>
-                    <select
-                      value={createAgentDraft.providerId}
-                      onChange={(event) => {
-                        const providerId = event.target.value;
-                        const nextDraft = buildAgentCreationDraft(
-                          agentProviders,
-                          providerId,
-                        );
-                        setCreateAgentDraft((current) => ({
-                          ...current,
-                          providerId,
-                          modelId: nextDraft.modelId,
-                          modelDisplayName: nextDraft.modelDisplayName,
-                        }));
-                      }}
-                      disabled={agentState.status === 'saving'}
-                    >
-                      {configuredProviderChoices.map((provider) => (
-                        <option key={provider.id} value={provider.id}>
-                          {provider.name}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <label>
-                    <span>Model</span>
-                    <input
-                      list="talk-create-agent-models"
-                      value={createAgentDraft.modelId}
-                      onChange={(event) =>
-                        setCreateAgentDraft((current) => ({
-                          ...current,
-                          modelId: event.target.value,
-                          modelDisplayName: event.target.value,
-                        }))
-                      }
-                      disabled={agentState.status === 'saving'}
-                    />
-                  </label>
-                  <label>
-                    <span>Display name</span>
-                    <input
-                      type="text"
-                      value={createAgentDraft.modelDisplayName}
-                      onChange={(event) =>
-                        setCreateAgentDraft((current) => ({
-                          ...current,
-                          modelDisplayName: event.target.value,
-                        }))
-                      }
-                      disabled={agentState.status === 'saving'}
-                    />
-                  </label>
-                </div>
-                <datalist id="talk-create-agent-models">
-                  {(selectedCreateProvider?.modelSuggestions || []).map((model) => (
-                    <option
-                      key={`${createAgentDraft.providerId}:${model.modelId}`}
-                      value={model.modelId}
-                    >
-                      {model.displayName}
-                    </option>
-                  ))}
-                </datalist>
-                <div className="policy-editor-controls">
-                  <button
-                    type="submit"
-                    className="primary-btn"
-                    disabled={
-                      agentState.status === 'saving' ||
-                      configuredProviderChoices.length === 0
-                    }
-                  >
-                    {agentState.status === 'saving' ? 'Creating…' : 'Create AI Agent'}
-                  </button>
-                  <button
-                    type="button"
-                    className="secondary-btn"
-                    onClick={() => setShowCreateAgentInline(false)}
-                    disabled={agentState.status === 'saving'}
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </form>
             ) : null}
             {agentState.status === 'error' ? (
               <div className="inline-banner inline-banner-error" role="alert">
@@ -1824,16 +1895,17 @@ export function TalkDetailPage({
 
       <form className="composer" onSubmit={handleSend}>
         <label className="composer-target">
-          <span>Reply agent</span>
+          <span>Called agent</span>
           <select
             value={targetAgentId || ''}
             onChange={(event) => setTargetAgentId(event.target.value || null)}
             disabled={state.sendState.status === 'posting' || agents.length === 0}
           >
+            <option value="">Primary Agent (default)</option>
             {agents.map((agent) => (
               <option key={agent.id} value={agent.id}>
                 {savedAgentLabels[agent.id] || agent.name}
-                {agent.isLead ? ' (Lead)' : ''}
+                {agent.isLead ? ' (Primary)' : ''}
               </option>
             ))}
           </select>


### PR DESCRIPTION
## Summary
- simplify the product model down to `Default Claude Agent` plus `Additional Providers`
- remove the user-facing registered-agent concept and keep talk roles fully talk-local
- move Anthropic/Claude setup into `AI Agents` and keep `Settings` focused on runtime/admin concerns
- simplify talk agent editing to source/model/role selection with a single primary responder
- remove the dead registered-agent HTTP/frontend surface and legacy user-facing talk-agent paths

## What Changed

### AI Agents
- rework `AI Agents` around:
  - `Default Claude Agent`
  - `Additional Providers`
- remove `First Agent Setup`
- remove user-facing `Registered Agents`
- keep Anthropic/Claude setup in `AI Agents`, including the `Subscription` vs `API` path
- keep additional provider cards as the main place for non-Claude keys

### Talks
- new talks are seeded with the default Claude agent
- default role is `General`
- talk agents are now selected by:
  - source
  - model
  - role
- one talk agent is marked as the primary responder
- remove raw `routeId` editing and the old comma-separated agent UX

### Settings
- remove provider/model/agent setup from `Settings`
- keep `Settings` focused on executor/runtime/admin configuration

### Cleanup
- remove dead registered-agent CRUD HTTP endpoints
- remove stale frontend registered-agent types/helpers
- remove remaining legacy user-facing talk-agent UI branches
- change old fallback talk badges from `Mock` to `Claude`

## Validation
- `npm -C ClawRocket run typecheck`
- `npm -C ClawRocket run test`
- `npm --prefix ClawRocket/webapp run typecheck`
- `npm --prefix ClawRocket/webapp run test`

## Notes
- `routeId` remains internal only
- role/persona is talk-local only
- the only remaining `
