### PR TITLE
feat(agents): refine claude card and add nvidia provider

### DIFF
--- a/src/clawrocket/db/init.ts
+++ b/src/clawrocket/db/init.ts
@@ -283,7 +283,7 @@ function createClawrocketSchema(database: Database.Database): void {
       id TEXT PRIMARY KEY,
       name TEXT NOT NULL,
       provider_kind TEXT NOT NULL
-        CHECK(provider_kind IN ('anthropic', 'openai', 'gemini', 'deepseek', 'kimi', 'custom')),
+        CHECK(provider_kind IN ('anthropic', 'openai', 'gemini', 'deepseek', 'kimi', 'nvidia', 'custom')),
       api_format TEXT NOT NULL
         CHECK(api_format IN ('anthropic_messages', 'openai_chat_completions')),
       base_url TEXT NOT NULL,

--- a/src/clawrocket/db/llm-accessors.ts
+++ b/src/clawrocket/db/llm-accessors.ts
@@ -266,8 +266,20 @@ const KNOWN_PROVIDER_CATALOG: Array<{
     baseUrl: 'https://api.anthropic.com',
     modelSuggestions: [
       {
+        modelId: 'claude-opus-4-6',
+        displayName: 'Claude Opus 4.6',
+        contextWindowTokens: 200000,
+        defaultMaxOutputTokens: 4096,
+      },
+      {
         modelId: 'claude-opus-4-1',
         displayName: 'Claude Opus 4.1',
+        contextWindowTokens: 200000,
+        defaultMaxOutputTokens: 4096,
+      },
+      {
+        modelId: 'claude-sonnet-4-6',
+        displayName: 'Claude Sonnet 4.6',
         contextWindowTokens: 200000,
         defaultMaxOutputTokens: 4096,
       },
@@ -359,12 +371,35 @@ const KNOWN_PROVIDER_CATALOG: Array<{
   },
   {
     id: 'provider.kimi',
-    name: 'Kimi',
+    name: 'Moonshot / Kimi',
     providerKind: 'kimi',
     apiFormat: 'openai_chat_completions',
     authScheme: 'bearer',
     baseUrl: 'https://api.moonshot.cn/v1',
-    modelSuggestions: [],
+    modelSuggestions: [
+      {
+        modelId: 'kimi-k2-0711-preview',
+        displayName: 'Kimi K2 Preview',
+        contextWindowTokens: 128000,
+        defaultMaxOutputTokens: 4096,
+      },
+    ],
+  },
+  {
+    id: 'provider.nvidia',
+    name: 'NVIDIA',
+    providerKind: 'nvidia',
+    apiFormat: 'openai_chat_completions',
+    authScheme: 'bearer',
+    baseUrl: 'https://integrate.api.nvidia.com/v1',
+    modelSuggestions: [
+      {
+        modelId: 'moonshotai/kimi-k2.5',
+        displayName: 'Kimi 2.5 (NVIDIA)',
+        contextWindowTokens: 262144,
+        defaultMaxOutputTokens: 16384,
+      },
+    ],
   },
   {
     id: 'provider.custom',
@@ -1636,7 +1671,8 @@ export function listTalkAgentInstances(
 ): TalkAgentInstanceSnapshot[] {
   const existing = ensureTalkHasDefaultAgent(talkId);
   return existing.map((agent) => {
-    const sourceKind = agent.source_kind as TalkAgentInstanceSnapshot['sourceKind'];
+    const sourceKind =
+      agent.source_kind as TalkAgentInstanceSnapshot['sourceKind'];
     const providerId =
       sourceKind === 'claude_default'
         ? 'provider.anthropic'

--- a/src/clawrocket/llm/types.ts
+++ b/src/clawrocket/llm/types.ts
@@ -10,6 +10,7 @@ export type LlmProviderKind =
   | 'gemini'
   | 'deepseek'
   | 'kimi'
+  | 'nvidia'
   | 'custom';
 
 export interface LlmProviderRecord {

--- a/src/clawrocket/talks/direct-executor.test.ts
+++ b/src/clawrocket/talks/direct-executor.test.ts
@@ -46,6 +46,7 @@ function configureTalkRuntime(input: {
       | 'gemini'
       | 'deepseek'
       | 'kimi'
+      | 'nvidia'
       | 'custom';
     apiFormat: 'anthropic_messages' | 'openai_chat_completions';
     baseUrl: string;

--- a/src/clawrocket/talks/direct-executor.ts
+++ b/src/clawrocket/talks/direct-executor.ts
@@ -1,7 +1,10 @@
 import { ChildProcess } from 'child_process';
 import { setTimeout as sleep } from 'timers/promises';
 
-import { runContainerAgent, type ContainerOutput } from '../../container-runner.js';
+import {
+  runContainerAgent,
+  type ContainerOutput,
+} from '../../container-runner.js';
 import { logger } from '../../logger.js';
 import type { RegisteredGroup } from '../../types.js';
 import {
@@ -444,9 +447,7 @@ function classifyHttpFailure(response: {
   };
 }
 
-function renderPromptTranscript(
-  promptMessages: PromptMessage[],
-): string {
+function renderPromptTranscript(promptMessages: PromptMessage[]): string {
   return promptMessages
     .map((message) => {
       const label =
@@ -528,7 +529,9 @@ function classifyClaudeDefaultFailure(error: unknown): ClassifiedTalkError {
   return {
     code: 'execution_failed',
     message:
-      error instanceof Error ? error.message : 'Unknown Claude execution failure',
+      error instanceof Error
+        ? error.message
+        : 'Unknown Claude execution failure',
     failureClass: 'unknown',
     retryable: false,
   };
@@ -1079,7 +1082,10 @@ export class DirectTalkExecutor implements TalkExecutor {
           });
         }
 
-        const content = chunks.join('').trim() || result.result?.trim() || 'No response generated.';
+        const content =
+          chunks.join('').trim() ||
+          result.result?.trim() ||
+          'No response generated.';
         createLlmAttempt({
           runId: context.input.runId,
           talkId: context.input.talkId,

--- a/src/clawrocket/web/routes/agents.ts
+++ b/src/clawrocket/web/routes/agents.ts
@@ -60,7 +60,8 @@ export function updateDefaultClaudeModelRoute(input: {
         ok: false,
         error: {
           code: 'forbidden',
-          message: 'You do not have permission to update the default Claude model.',
+          message:
+            'You do not have permission to update the default Claude model.',
         },
       },
     };

--- a/src/clawrocket/web/routes/talks.ts
+++ b/src/clawrocket/web/routes/talks.ts
@@ -643,10 +643,7 @@ export function updateTalkPolicyRoute(input: {
       currentAgents[index]?.provider_id ||
       primary.provider_id ||
       'provider.anthropic',
-    modelId:
-      currentAgents[index]?.model_id ||
-      primary.model_id ||
-      null,
+    modelId: currentAgents[index]?.model_id || primary.model_id || null,
     isPrimary: index === 0,
     sortOrder: index,
   }));

--- a/src/clawrocket/web/server.ts
+++ b/src/clawrocket/web/server.ts
@@ -1298,7 +1298,8 @@ function buildApp(opts: WebServerOptions): Hono {
 
     const result = updateDefaultClaudeModelRoute({
       auth,
-      modelId: typeof payload.data.modelId === 'string' ? payload.data.modelId : '',
+      modelId:
+        typeof payload.data.modelId === 'string' ? payload.data.modelId : '',
     });
     return new Response(JSON.stringify(result.body), {
       status: result.statusCode,

--- a/webapp/src/components/TalkLlmSettingsCard.tsx
+++ b/webapp/src/components/TalkLlmSettingsCard.tsx
@@ -67,6 +67,7 @@ const PROVIDER_KIND_OPTIONS: Array<TalkLlmProvider['providerKind']> = [
   'gemini',
   'deepseek',
   'kimi',
+  'nvidia',
   'custom',
 ];
 

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -94,6 +94,7 @@ export type AgentProviderCard = {
     | 'gemini'
     | 'deepseek'
     | 'kimi'
+    | 'nvidia'
     | 'custom';
   apiFormat: 'anthropic_messages' | 'openai_chat_completions';
   baseUrl: string;
@@ -137,6 +138,7 @@ export type TalkLlmProvider = {
     | 'gemini'
     | 'deepseek'
     | 'kimi'
+    | 'nvidia'
     | 'custom';
   apiFormat: 'anthropic_messages' | 'openai_chat_completions';
   baseUrl: string;

--- a/webapp/src/pages/AiAgentsPage.test.tsx
+++ b/webapp/src/pages/AiAgentsPage.test.tsx
@@ -33,11 +33,20 @@ describe('AiAgentsPage', () => {
     expect(
       screen.getByRole('heading', { name: 'Additional Providers' }),
     ).toBeTruthy();
-    expect(screen.getByText('Subscription (Claude Pro/Max)')).toBeTruthy();
     expect(
       screen.getByText(
         /Every new talk starts with Claude as the default agent/i,
       ),
+    ).toBeTruthy();
+    expect(screen.getByLabelText('Subscription')).toBeChecked();
+    expect(screen.getByLabelText('API')).not.toBeChecked();
+    expect(screen.getByText('Model for new talks')).toBeTruthy();
+    expect(
+      screen.queryByRole('button', { name: /Check host Claude login/i }),
+    ).toBeNull();
+    expect(screen.getByLabelText('Claude Code OAuth token')).toBeTruthy();
+    expect(
+      await screen.findByText(/Checked as user k1min8r/i),
     ).toBeTruthy();
 
     const openAiCard = screen.getByRole('heading', { name: 'OpenAI' }).closest('article');
@@ -105,6 +114,32 @@ function installAiAgentsFetch() {
         return jsonResponse(200, { ok: true, data: status });
       }
 
+      if (
+        url.endsWith('/api/v1/settings/executor/subscription-host-status') &&
+        method === 'GET'
+      ) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            serviceUser: 'k1min8r',
+            serviceUid: 1000,
+            serviceHomePath: '/home/k1min8r',
+            runtimeContext: 'host',
+            claudeCliInstalled: true,
+            hostLoginDetected: true,
+            serviceEnvOauthPresent: false,
+            importAvailable: false,
+            hostCredentialFingerprint: null,
+            message:
+              'Claude Code login was detected for this service user, but the current authenticated state could not be imported automatically. Use the advanced manual token flow with `claude setup-token`.',
+            recommendedCommands: [
+              'claude config set -g forceLoginMethod claudeai',
+              'claude login',
+            ],
+          },
+        });
+      }
+
       if (url.endsWith('/api/v1/agents/providers/provider.openai') && method === 'PUT') {
         snapshot = {
           ...snapshot,
@@ -135,6 +170,18 @@ function buildAiAgentsData(): AiAgentsPageData {
   return {
     defaultClaudeModelId: 'claude-sonnet-4-5',
     claudeModelSuggestions: [
+      {
+        modelId: 'claude-opus-4-6',
+        displayName: 'Claude Opus 4.6',
+        contextWindowTokens: 200000,
+        defaultMaxOutputTokens: 4096,
+      },
+      {
+        modelId: 'claude-sonnet-4-6',
+        displayName: 'Claude Sonnet 4.6',
+        contextWindowTokens: 200000,
+        defaultMaxOutputTokens: 4096,
+      },
       {
         modelId: 'claude-sonnet-4-5',
         displayName: 'Claude Sonnet 4.5',

--- a/webapp/src/pages/AiAgentsPage.tsx
+++ b/webapp/src/pages/AiAgentsPage.tsx
@@ -38,6 +38,7 @@ const PROVIDER_DOCS_URL: Record<string, string> = {
   'provider.gemini': 'https://aistudio.google.com/app/apikey',
   'provider.deepseek': 'https://platform.deepseek.com/api_keys',
   'provider.kimi': 'https://platform.moonshot.ai/console/api-keys',
+  'provider.nvidia': 'https://build.nvidia.com/',
 };
 
 function canManageAgents(userRole: string): boolean {
@@ -82,6 +83,21 @@ function formatVerificationStatus(
       return 'Unavailable';
     default:
       return status;
+  }
+}
+
+function verificationStatusClass(
+  status: ExecutorStatus['verificationStatus'] | AgentProviderCard['verificationStatus'],
+): string {
+  switch (status) {
+    case 'verified':
+      return 'talk-agent-chip talk-agent-chip-success';
+    case 'invalid':
+      return 'talk-agent-chip talk-agent-chip-error';
+    case 'unavailable':
+      return 'talk-agent-chip talk-agent-chip-warning';
+    default:
+      return 'talk-agent-chip';
   }
 }
 
@@ -163,9 +179,6 @@ export function AiAgentsPage({
   const [claudeModelDraft, setClaudeModelDraft] = useState('');
   const [claudeApiKeyDraft, setClaudeApiKeyDraft] = useState('');
   const [claudeOauthDraft, setClaudeOauthDraft] = useState('');
-  const [clearClaudeApiKey, setClearClaudeApiKey] = useState(false);
-  const [clearClaudeOauth, setClearClaudeOauth] = useState(false);
-  const [showSubscriptionAdvanced, setShowSubscriptionAdvanced] = useState(false);
   const [subscriptionHostStatus, setSubscriptionHostStatus] =
     useState<ExecutorSubscriptionHostStatus | null>(null);
   const [subscriptionHostBusy, setSubscriptionHostBusy] = useState<
@@ -188,8 +201,6 @@ export function AiAgentsPage({
     setClaudeModelDraft(nextData.defaultClaudeModelId);
     setClaudeApiKeyDraft('');
     setClaudeOauthDraft('');
-    setClearClaudeApiKey(false);
-    setClearClaudeOauth(false);
     setProviderDrafts((current) => {
       const nextDrafts: Record<string, ProviderDraft> = {};
       for (const provider of nextData.additionalProviders) {
@@ -271,6 +282,34 @@ export function AiAgentsPage({
     };
   }, [status?.verificationStatus, onUnauthorized]);
 
+  useEffect(() => {
+    if (claudeModeDraft !== 'subscription') {
+      setSubscriptionHostStatus(null);
+      return;
+    }
+
+    let cancelled = false;
+    setSubscriptionHostBusy('checking');
+    void getExecutorSubscriptionHostStatus()
+      .then((nextHostStatus) => {
+        if (cancelled) return;
+        setSubscriptionHostStatus(nextHostStatus);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        handleApiFailure(err, 'Failed to check Claude host login.');
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setSubscriptionHostBusy(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [claudeModeDraft, onUnauthorized]);
+
   const updateProviderDraft = (
     providerId: string,
     patch: Partial<ProviderDraft>,
@@ -320,13 +359,9 @@ export function AiAgentsPage({
         executorAuthMode: claudeModeDraft,
       };
       if (claudeModeDraft === 'subscription') {
-        if (clearClaudeOauth) {
-          update.claudeOauthToken = null;
-        } else if (claudeOauthDraft.trim()) {
+        if (claudeOauthDraft.trim()) {
           update.claudeOauthToken = claudeOauthDraft.trim();
         }
-      } else if (clearClaudeApiKey) {
-        update.anthropicApiKey = null;
       } else if (claudeApiKeyDraft.trim()) {
         update.anthropicApiKey = claudeApiKeyDraft.trim();
       }
@@ -365,27 +400,6 @@ export function AiAgentsPage({
       handleApiFailure(err, 'Failed to verify Claude credentials.');
     } finally {
       setBusyKey(null);
-    }
-  };
-
-  const handleCheckSubscriptionHost = async (): Promise<void> => {
-    setSubscriptionHostBusy('checking');
-    setNotice(null);
-    setError(null);
-    try {
-      const nextHostStatus = await getExecutorSubscriptionHostStatus();
-      setSubscriptionHostStatus(nextHostStatus);
-      if (
-        !nextHostStatus.importAvailable &&
-        !nextHostStatus.serviceEnvOauthPresent &&
-        (!nextHostStatus.claudeCliInstalled || nextHostStatus.hostLoginDetected)
-      ) {
-        setShowSubscriptionAdvanced(true);
-      }
-    } catch (err) {
-      handleApiFailure(err, 'Failed to check Claude host login.');
-    } finally {
-      setSubscriptionHostBusy(null);
     }
   };
 
@@ -541,26 +555,48 @@ export function AiAgentsPage({
                 Configure the Claude capability every new talk starts with.
               </p>
             </div>
-            <span className="talk-agent-chip">{selectedClaudeStatus}</span>
+            <span
+              className={verificationStatusClass(
+                status.executorAuthMode !== claudeModeDraft || !selectedClaudeStored
+                  ? 'not_verified'
+                  : status.verificationStatus,
+              )}
+            >
+              {selectedClaudeStatus}
+            </span>
           </div>
 
           <div className="talk-llm-grid">
-            <label className="talk-llm-field-span">
+            <fieldset className="talk-llm-field-span talk-llm-radio-group">
               <span>Billing model</span>
-              <select
-                value={claudeModeDraft}
-                onChange={(event) =>
-                  setClaudeModeDraft(event.target.value as ClaudeAuthMode)
-                }
-                disabled={!canManage || busyKey === 'claude-save'}
-              >
-                <option value="subscription">Subscription (Claude Pro/Max)</option>
-                <option value="api_key">API</option>
-              </select>
-            </label>
+              <div className="talk-llm-radio-options">
+                <label className="talk-llm-radio-option">
+                  <input
+                    type="radio"
+                    name="claude-billing-model"
+                    value="subscription"
+                    checked={claudeModeDraft === 'subscription'}
+                    onChange={() => setClaudeModeDraft('subscription')}
+                    disabled={!canManage || busyKey === 'claude-save'}
+                  />
+                  <span>Subscription</span>
+                </label>
+                <label className="talk-llm-radio-option">
+                  <input
+                    type="radio"
+                    name="claude-billing-model"
+                    value="api_key"
+                    checked={claudeModeDraft === 'api_key'}
+                    onChange={() => setClaudeModeDraft('api_key')}
+                    disabled={!canManage || busyKey === 'claude-save'}
+                  />
+                  <span>API</span>
+                </label>
+              </div>
+            </fieldset>
 
             <label className="talk-llm-field-span">
-              <span>Default Claude model</span>
+              <span>Model for new talks</span>
               <select
                 value={claudeModelDraft}
                 onChange={(event) => setClaudeModelDraft(event.target.value)}
@@ -587,9 +623,6 @@ export function AiAgentsPage({
                         Last verified {formatDateTime(status.lastVerifiedAt)}
                       </p>
                     </div>
-                    <span className="talk-agent-chip">
-                      {formatVerificationStatus(status.verificationStatus)}
-                    </span>
                   </div>
                 ) : (
                   <p className="talk-llm-meta">
@@ -605,17 +638,10 @@ export function AiAgentsPage({
                 <p className="talk-llm-meta">
                   If host import is unavailable, you can run <code>claude setup-token</code> and paste the token manually below.
                 </p>
+                <p className="talk-llm-meta">
+                  Re-verify uses the stored subscription login/token. Paste a new token only if the stored one is expired, revoked, or incorrect.
+                </p>
                 <div className="talk-llm-inline-actions">
-                  <button
-                    type="button"
-                    className="secondary-btn"
-                    onClick={() => void handleCheckSubscriptionHost()}
-                    disabled={!canManage || subscriptionHostBusy === 'checking'}
-                  >
-                    {subscriptionHostBusy === 'checking'
-                      ? 'Checking…'
-                      : 'Check host Claude login'}
-                  </button>
                   {subscriptionHostStatus?.importAvailable ? (
                     <button
                       type="button"
@@ -628,16 +654,10 @@ export function AiAgentsPage({
                         : 'Import from host'}
                     </button>
                   ) : null}
-                  <button
-                    type="button"
-                    className="secondary-btn"
-                    onClick={() => setShowSubscriptionAdvanced((current) => !current)}
-                  >
-                    {showSubscriptionAdvanced
-                      ? 'Hide manual token entry'
-                      : 'Paste Claude Code OAuth token manually'}
-                  </button>
                 </div>
+                {subscriptionHostBusy === 'checking' ? (
+                  <p className="talk-llm-meta">Checking Claude login on this host…</p>
+                ) : null}
                 {subscriptionHostStatus ? (
                   <div className="talk-llm-host-status">
                     <p className="talk-llm-meta">
@@ -654,21 +674,18 @@ export function AiAgentsPage({
                     ) : null}
                   </div>
                 ) : null}
-                {showSubscriptionAdvanced ? (
-                  <label className="talk-llm-field-span">
-                    <span>Claude Code OAuth token</span>
-                    <input
-                      type="password"
-                      value={claudeOauthDraft}
-                      onChange={(event) => {
-                        setClaudeOauthDraft(event.target.value);
-                        setClearClaudeOauth(false);
-                      }}
-                      placeholder="Paste token from claude setup-token"
-                      disabled={!canManage || busyKey === 'claude-save'}
-                    />
-                  </label>
-                ) : null}
+                <label className="talk-llm-field-span">
+                  <span>Claude Code OAuth token</span>
+                  <input
+                    type="password"
+                    value={claudeOauthDraft}
+                    onChange={(event) => {
+                      setClaudeOauthDraft(event.target.value);
+                    }}
+                    placeholder="Paste token from claude setup-token"
+                    disabled={!canManage || busyKey === 'claude-save'}
+                  />
+                </label>
               </div>
             </div>
           ) : (
@@ -687,9 +704,6 @@ export function AiAgentsPage({
                         .
                       </p>
                     </div>
-                    <span className="talk-agent-chip">
-                      {formatVerificationStatus(status.verificationStatus)}
-                    </span>
                   </div>
                 ) : (
                   <p className="talk-llm-meta">
@@ -703,7 +717,6 @@ export function AiAgentsPage({
                     value={claudeApiKeyDraft}
                     onChange={(event) => {
                       setClaudeApiKeyDraft(event.target.value);
-                      setClearClaudeApiKey(false);
                     }}
                     placeholder="sk-ant-..."
                     disabled={!canManage || busyKey === 'claude-save'}
@@ -714,26 +727,6 @@ export function AiAgentsPage({
           )}
 
           <div className="talk-llm-inline-actions">
-            {claudeModeDraft === 'subscription' && settings.hasOauthToken ? (
-              <button
-                type="button"
-                className="secondary-btn"
-                onClick={() => setClearClaudeOauth(true)}
-                disabled={!canManage || busyKey === 'claude-save'}
-              >
-                Clear stored subscription token
-              </button>
-            ) : null}
-            {claudeModeDraft === 'api_key' && settings.hasApiKey ? (
-              <button
-                type="button"
-                className="secondary-btn"
-                onClick={() => setClearClaudeApiKey(true)}
-                disabled={!canManage || busyKey === 'claude-save'}
-              >
-                Clear stored API key
-              </button>
-            ) : null}
             <button
               type="button"
               className="secondary-btn"
@@ -788,9 +781,9 @@ export function AiAgentsPage({
                       )}
                     </p>
                   </div>
-                  <span className="talk-agent-chip">
-                    {formatProviderVerificationSummary(provider)}
-                  </span>
+                    <span className={verificationStatusClass(provider.verificationStatus)}>
+                      {formatProviderVerificationSummary(provider)}
+                    </span>
                 </div>
 
                 {provider.hasCredential ? (

--- a/webapp/src/pages/TalkDetailPage.test.tsx
+++ b/webapp/src/pages/TalkDetailPage.test.tsx
@@ -514,6 +514,18 @@ function buildAiAgentsData(): AiAgentsPageData {
     defaultClaudeModelId: 'claude-sonnet-4-5',
     claudeModelSuggestions: [
       {
+        modelId: 'claude-opus-4-6',
+        displayName: 'Claude Opus 4.6',
+        contextWindowTokens: 200000,
+        defaultMaxOutputTokens: 4096,
+      },
+      {
+        modelId: 'claude-sonnet-4-6',
+        displayName: 'Claude Sonnet 4.6',
+        contextWindowTokens: 200000,
+        defaultMaxOutputTokens: 4096,
+      },
+      {
         modelId: 'claude-sonnet-4-5',
         displayName: 'Claude Sonnet 4.5',
         contextWindowTokens: 200000,

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -448,6 +448,35 @@ a {
   grid-column: 1 / -1;
 }
 
+.talk-llm-radio-group {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.talk-llm-radio-options {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.talk-llm-radio-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #c8d3e9;
+  border-radius: 999px;
+  background: #fff;
+  color: #31415f;
+  font-size: 0.95rem;
+}
+
+.talk-llm-radio-option input {
+  margin: 0;
+}
+
 .talk-llm-grid input,
 .talk-llm-grid select {
   border: 1px solid #c8d3e9;
@@ -695,6 +724,24 @@ a {
   color: #1d4487;
   font-size: 0.75rem;
   padding: 0.1rem 0.55rem;
+}
+
+.talk-agent-chip-success {
+  border-color: #b9dfc7;
+  background: #edfdf2;
+  color: #1f6e3e;
+}
+
+.talk-agent-chip-warning {
+  border-color: #f0d4a6;
+  background: #fff8ec;
+  color: #85581a;
+}
+
+.talk-agent-chip-error {
+  border-color: #e8b5b5;
+  background: #fff3f3;
+  color: #8d1f1f;
 }
 
 .talk-list li a span {


### PR DESCRIPTION
## Summary
- simplify `AI Agents` around a single `Default Claude Agent` card plus `Additional Providers`
- streamline the Claude card UX with a subscription/API toggle, clearer copy, and fewer redundant controls
- add the latest Claude model suggestions, including Opus 4.6 and Sonnet 4.6
- split Moonshot Kimi and NVIDIA-hosted Kimi into separate provider cards
- keep talk roles fully talk-local and preserve the simplified talk-agent flow

## What Changed

### Default Claude Agent UX
- replace the billing-model dropdown with a radio toggle:
  - `Subscription`
  - `API`
- rename `Default Claude model` to `Model for new talks`
- remove the duplicate lower `Configured` chip and keep a single top-right status badge
- auto-run subscription host detection when `Subscription` is selected
- remove:
  - `Check host Claude login`
  - `Hide manual token entry`
  - `Clear stored subscription token`
- keep:
  - `Save Claude Settings`
  - `Re-verify`
- clarify that re-verification uses the stored subscription token and only requires a new token if the stored one is expired, revoked, or incorrect

### Claude model updates
- add:
  - `Claude Opus 4.6`
  - `Claude Sonnet 4.6`

### Provider cards
- rename the current Kimi provider to:
  - `Moonshot / Kimi`
- add a separate `NVIDIA` provider card for NVIDIA-hosted Kimi
- wire NVIDIA to the fixed OpenAI-compatible endpoint:
  - `https://integrate.api.nvidia.com/v1`
- add NVIDIA model suggestion:
  - `moonshotai/kimi-k2.5`
- keep the normal UI free of extra base-URL fields

## Files
- `src/clawrocket/db/init.ts`
- `src/clawrocket/db/llm-accessors.ts`
- `src/clawrocket/llm/types.ts`
- `src/clawrocket/talks/direct-executor.ts`
- `src/clawrocket/talks/direct-executor.test.ts`
- `src/clawrocket/web/routes/agents.ts`
- `src/clawrocket/web/routes/talks.ts`
- `src/clawrocket/web/server.ts`
- `webapp/src/components/TalkLlmSettingsCard.tsx`
- `webapp/src/lib/api.ts`
- `webapp/src/pages/AiAgentsPage.tsx`
- `webapp/src/pages/AiAgentsPage.test.tsx`
- `webapp/src/pages/TalkDetailPage.test.tsx`
- `webapp/src/styles.css`

## Validation
- `npm --prefix webapp run typecheck`
- `npm --prefix webapp run test`
- `npm -C ClawRocket run typecheck`
- focused backend sanity check:
  - `npx vitest run src/clawrocket/db/llm-accessors.test.ts`

## Notes
- the full backend test suite still has existing unrelated timeout failures in:
  - `src/index.test.ts`
  - `skills-engine/__tests__/merge.test.ts`
  - `skills-engine/__tests__/rebase.test.ts`
- those failures are not introduced by this Claude/NVIDIA follow-up
