### PR TITLE
fix(agents): hydrate claude defaults and trim stale models

### DIFF
--- a/src/clawrocket/agents/provider-credentials-verifier.ts
+++ b/src/clawrocket/agents/provider-credentials-verifier.ts
@@ -33,14 +33,46 @@ function buildHeaders(
   };
 }
 
-function verificationEndpoint(provider: LlmProviderRecord): string {
+type VerificationRequest = {
+  url: string;
+  method: 'GET' | 'POST';
+  body?: string;
+  headers?: Record<string, string>;
+};
+
+function buildVerificationRequest(provider: LlmProviderRecord): VerificationRequest {
+  if (provider.provider_kind === 'nvidia') {
+    return {
+      url: joinUrl(provider.base_url, '/chat/completions'),
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'moonshotai/kimi-k2.5',
+        messages: [{ role: 'user', content: 'ping' }],
+        max_tokens: 1,
+        stream: false,
+      }),
+    };
+  }
+
   switch (provider.api_format) {
     case 'anthropic_messages':
-      return joinUrl(provider.base_url, '/v1/models');
+      return {
+        url: joinUrl(provider.base_url, '/v1/models'),
+        method: 'GET',
+      };
     case 'openai_chat_completions':
-      return joinUrl(provider.base_url, '/models');
+      return {
+        url: joinUrl(provider.base_url, '/models'),
+        method: 'GET',
+      };
     default:
-      return provider.base_url;
+      return {
+        url: provider.base_url,
+        method: 'GET',
+      };
   }
 }
 
@@ -79,6 +111,7 @@ export class ProviderCredentialsVerifier {
     }
 
     const secret = decryptProviderSecret(secretRecord.ciphertext);
+    const request = buildVerificationRequest(provider);
     const controller = new AbortController();
     const timer = setTimeout(
       () => controller.abort('provider_verify_timeout'),
@@ -86,9 +119,13 @@ export class ProviderCredentialsVerifier {
     );
 
     try {
-      const response = await this.fetchImpl(verificationEndpoint(provider), {
-        method: 'GET',
-        headers: buildHeaders(provider, secret),
+      const response = await this.fetchImpl(request.url, {
+        method: request.method,
+        headers: {
+          ...buildHeaders(provider, secret),
+          ...(request.headers || {}),
+        },
+        body: request.body,
         signal: controller.signal,
       });
 

--- a/src/clawrocket/db/llm-accessors.test.ts
+++ b/src/clawrocket/db/llm-accessors.test.ts
@@ -1,10 +1,19 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { _initTestDatabase } from './index.js';
+import { getDb } from '../../db.js';
+import {
+  _initTestDatabase,
+  listTalkAgentInstances,
+  resetTalkAgentsToDefault,
+  upsertTalk,
+  upsertUser,
+} from './index.js';
 import {
   createRegisteredAgent,
   deleteRegisteredAgent,
+  getDefaultClaudeModelId,
   getDefaultRegisteredAgentId,
+  listClaudeModelSuggestions,
   upsertKnownProviderCredential,
 } from './llm-accessors.js';
 
@@ -25,7 +34,7 @@ describe('registered agent accessors', () => {
     const defaultAgent = createRegisteredAgent({
       name: 'Claude Opus',
       providerId: 'provider.anthropic',
-      modelId: 'claude-opus-4-1',
+      modelId: 'claude-opus-4-6',
       setAsDefault: true,
     });
     const fallbackAgent = createRegisteredAgent({
@@ -39,5 +48,46 @@ describe('registered agent accessors', () => {
     deleteRegisteredAgent(defaultAgent.id);
 
     expect(getDefaultRegisteredAgentId()).toBe(fallbackAgent.id);
+  });
+
+  it('rehydrates malformed persisted Claude agents from their route data', () => {
+    upsertUser({
+      id: 'owner-1',
+      email: 'owner@example.com',
+      displayName: 'Owner',
+      role: 'owner',
+    });
+    upsertTalk({
+      id: 'talk-1',
+      ownerId: 'owner-1',
+      topicTitle: 'Hydration Test',
+    });
+    resetTalkAgentsToDefault('talk-1');
+
+    getDb()
+      .prepare(
+        `
+        UPDATE talk_agents
+        SET source_kind = 'provider',
+            provider_id = NULL,
+            model_id = NULL
+        WHERE talk_id = ?
+      `,
+      )
+      .run('talk-1');
+
+    const expectedModelId = getDefaultClaudeModelId();
+    const expectedModelDisplayName =
+      listClaudeModelSuggestions().find(
+        (model) => model.modelId === expectedModelId,
+      )?.displayName || expectedModelId;
+    const [agent] = listTalkAgentInstances('talk-1');
+    expect(agent).toMatchObject({
+      name: 'Claude',
+      sourceKind: 'claude_default',
+      providerId: 'provider.anthropic',
+      modelId: expectedModelId,
+      modelDisplayName: expectedModelDisplayName,
+    });
   });
 });

--- a/src/clawrocket/db/llm-accessors.ts
+++ b/src/clawrocket/db/llm-accessors.ts
@@ -272,12 +272,6 @@ const KNOWN_PROVIDER_CATALOG: Array<{
         defaultMaxOutputTokens: 4096,
       },
       {
-        modelId: 'claude-opus-4-1',
-        displayName: 'Claude Opus 4.1',
-        contextWindowTokens: 200000,
-        defaultMaxOutputTokens: 4096,
-      },
-      {
         modelId: 'claude-sonnet-4-6',
         displayName: 'Claude Sonnet 4.6',
         contextWindowTokens: 200000,
@@ -387,7 +381,7 @@ const KNOWN_PROVIDER_CATALOG: Array<{
   },
   {
     id: 'provider.nvidia',
-    name: 'NVIDIA',
+    name: 'NVIDIA Kimi2.5',
     providerKind: 'nvidia',
     apiFormat: 'openai_chat_completions',
     authScheme: 'bearer',
@@ -1666,19 +1660,46 @@ export function ensureTalkHasDefaultAgent(
   return resetTalkAgentsToDefault(talkId, now);
 }
 
+function resolvePersistedTalkAgentIdentity(agent: TalkAgentRecord): {
+  sourceKind: TalkAgentSourceKind;
+  providerId: string | null;
+  modelId: string | null;
+} {
+  const route = getTalkRouteById(agent.route_id);
+  const primaryStep = route ? listTalkRouteSteps(route.id)[0] : undefined;
+  let sourceKind =
+    agent.source_kind === 'claude_default' || agent.source_kind === 'provider'
+      ? (agent.source_kind as TalkAgentSourceKind)
+      : 'claude_default';
+  let providerId =
+    sourceKind === 'claude_default'
+      ? 'provider.anthropic'
+      : agent.provider_id || primaryStep?.provider_id || null;
+  let modelId = agent.model_id || primaryStep?.model_id || null;
+
+  // Older malformed rows can lose provider/model columns even though the route
+  // still points at Claude. Rehydrate those rows as the default Claude agent.
+  if (providerId === 'provider.anthropic') {
+    sourceKind = 'claude_default';
+  }
+  if (sourceKind === 'claude_default') {
+    providerId = 'provider.anthropic';
+    if (!modelId) {
+      modelId = getDefaultClaudeModelId();
+    }
+  }
+
+  return { sourceKind, providerId, modelId };
+}
+
 export function listTalkAgentInstances(
   talkId: string,
 ): TalkAgentInstanceSnapshot[] {
   const existing = ensureTalkHasDefaultAgent(talkId);
   return existing.map((agent) => {
-    const sourceKind =
-      agent.source_kind as TalkAgentInstanceSnapshot['sourceKind'];
-    const providerId =
-      sourceKind === 'claude_default'
-        ? 'provider.anthropic'
-        : agent.provider_id || null;
+    const { sourceKind, providerId, modelId } =
+      resolvePersistedTalkAgentIdentity(agent);
     const providerName = resolveProviderDisplayName(providerId);
-    const modelId = agent.model_id || null;
     const modelDisplayName = resolveModelDisplayName(providerId, modelId);
     return {
       id: agent.id,
@@ -1761,7 +1782,8 @@ export function resolveTalkAgent(
       : undefined) || agents.find((entry) => entry.is_primary === 1);
   if (!agent) return null;
 
-  const sourceKind = agent.source_kind as TalkAgentSourceKind;
+  const { sourceKind, providerId, modelId } =
+    resolvePersistedTalkAgentIdentity(agent);
 
   const route = getTalkRouteById(agent.route_id);
   if (!route) return null;
@@ -1790,11 +1812,8 @@ export function resolveTalkAgent(
     route,
     steps,
     sourceKind,
-    providerId:
-      sourceKind === 'claude_default'
-        ? 'provider.anthropic'
-        : agent.provider_id || null,
-    modelId: agent.model_id || null,
+    providerId,
+    modelId,
   };
 }
 

--- a/webapp/src/pages/AiAgentsPage.test.tsx
+++ b/webapp/src/pages/AiAgentsPage.test.tsx
@@ -56,6 +56,17 @@ describe('AiAgentsPage', () => {
     expect(
       within(openAiCard).getByRole('link', { name: 'Get key from OpenAI' }),
     ).toHaveAttribute('href', 'https://platform.openai.com/api-keys');
+
+    const nvidiaCard = screen
+      .getByRole('heading', { name: 'NVIDIA Kimi2.5' })
+      .closest('article');
+    if (!nvidiaCard) {
+      throw new Error('Expected NVIDIA provider card');
+    }
+    expect(
+      within(nvidiaCard).getByRole('link', { name: 'Get key from NVIDIA' }),
+    ).toHaveAttribute('href', 'https://build.nvidia.com/');
+    expect(within(nvidiaCard).getByPlaceholderText('nvapi-...')).toBeTruthy();
   });
 
   it('reports saved provider credentials honestly when verification does not pass', async () => {
@@ -188,12 +199,6 @@ function buildAiAgentsData(): AiAgentsPageData {
         contextWindowTokens: 200000,
         defaultMaxOutputTokens: 4096,
       },
-      {
-        modelId: 'claude-opus-4-1',
-        displayName: 'Claude Opus 4.1',
-        contextWindowTokens: 200000,
-        defaultMaxOutputTokens: 4096,
-      },
     ],
     additionalProviders: [
       {
@@ -237,6 +242,28 @@ function buildAiAgentsData(): AiAgentsPageData {
             displayName: 'Gemini 2.5 Flash',
             contextWindowTokens: 1000000,
             defaultMaxOutputTokens: 8192,
+          },
+        ],
+      },
+      {
+        id: 'provider.nvidia',
+        name: 'NVIDIA Kimi2.5',
+        providerKind: 'nvidia',
+        apiFormat: 'openai_chat_completions',
+        baseUrl: 'https://integrate.api.nvidia.com/v1',
+        authScheme: 'bearer',
+        enabled: true,
+        hasCredential: false,
+        credentialHint: null,
+        verificationStatus: 'missing',
+        lastVerifiedAt: null,
+        lastVerificationError: null,
+        modelSuggestions: [
+          {
+            modelId: 'moonshotai/kimi-k2.5',
+            displayName: 'Kimi 2.5 (NVIDIA)',
+            contextWindowTokens: 262144,
+            defaultMaxOutputTokens: 16384,
           },
         ],
       },

--- a/webapp/src/pages/AiAgentsPage.tsx
+++ b/webapp/src/pages/AiAgentsPage.tsx
@@ -41,6 +41,14 @@ const PROVIDER_DOCS_URL: Record<string, string> = {
   'provider.nvidia': 'https://build.nvidia.com/',
 };
 
+const PROVIDER_DOCS_LABEL: Record<string, string> = {
+  'provider.nvidia': 'NVIDIA',
+};
+
+const PROVIDER_KEY_PLACEHOLDER: Record<string, string> = {
+  'provider.nvidia': 'nvapi-...',
+};
+
 function canManageAgents(userRole: string): boolean {
   return userRole === 'owner' || userRole === 'admin';
 }
@@ -774,7 +782,7 @@ export function AiAgentsPage({
                           target="_blank"
                           rel="noreferrer"
                         >
-                          Get key from {provider.name}
+                          Get key from {PROVIDER_DOCS_LABEL[provider.id] || provider.name}
                         </a>
                       ) : (
                         'Configure this provider for additional talk agents.'
@@ -827,7 +835,7 @@ export function AiAgentsPage({
                             apiKey: event.target.value,
                           })
                         }
-                        placeholder="sk-..."
+                        placeholder={PROVIDER_KEY_PLACEHOLDER[provider.id] || 'sk-...'}
                         disabled={!canManage || busySave}
                       />
                     </label>

--- a/webapp/src/pages/TalkDetailPage.test.tsx
+++ b/webapp/src/pages/TalkDetailPage.test.tsx
@@ -531,12 +531,6 @@ function buildAiAgentsData(): AiAgentsPageData {
         contextWindowTokens: 200000,
         defaultMaxOutputTokens: 4096,
       },
-      {
-        modelId: 'claude-opus-4-1',
-        displayName: 'Claude Opus 4.1',
-        contextWindowTokens: 200000,
-        defaultMaxOutputTokens: 4096,
-      },
     ],
     additionalProviders: [
       {


### PR DESCRIPTION
## Summary
- simplify `AI Agents` around a single `Default Claude Agent` card plus `Additional Providers`
- streamline the Claude card UX with a subscription/API toggle, clearer copy, and fewer redundant controls
- fix malformed persisted Claude talk agents so the primary/default Claude row hydrates with a real model again
- split Moonshot Kimi and NVIDIA Kimi2.5 into separate provider cards
- remove stale Claude Opus 4.1 from the model catalog

## What Changed

### AI Agents
- keep `Default Claude Agent` as the main Claude setup surface
- replace the Claude billing-model dropdown with a `Subscription` / `API` toggle
- rename the Claude model field to `Model for new talks`
- remove redundant Claude card controls:
  - `Check host Claude login`
  - `Hide manual token entry`
  - `Clear stored subscription token`
- keep only the main `Save Claude Settings` and `Re-verify` actions
- keep a single top-right status badge and render configured/verified state in green

### Claude model and talk-agent fixes
- add current Claude suggestions:
  - `Claude Opus 4.6`
  - `Claude Sonnet 4.6`
- remove `Claude Opus 4.1`
- fix persisted malformed Claude talk agents so they are rehydrated from route data as proper `claude_default` agents with a valid model
- this fixes the talk editor case where the primary Claude row showed `Claude` as the source but had a blank model dropdown and `Provider`-style preview text

### Provider cards
- keep `Moonshot / Kimi` as the Moonshot-native provider
- add a separate `NVIDIA Kimi2.5` provider card
- use NVIDIA-specific key handling:
  - placeholder `nvapi-...`
  - fixed NVIDIA endpoint
  - NVIDIA-specific docs label/linking
- keep the normal UI free of extra base-URL fields

## Files
- `src/clawrocket/agents/provider-credentials-verifier.ts`
- `src/clawrocket/db/llm-accessors.ts`
- `src/clawrocket/db/llm-accessors.test.ts`
- `webapp/src/pages/AiAgentsPage.tsx`
- `webapp/src/pages/AiAgentsPage.test.tsx`
- `webapp/src/pages/TalkDetailPage.test.tsx`

## Validation
- `npm --prefix webapp run test -- --run src/pages/AiAgentsPage.test.tsx src/pages/TalkDetailPage.test.tsx`
- `npx vitest run src/clawrocket/db/llm-accessors.test.ts`

## Notes
- the Claude talk-agent hydration fix is backend-side, so it repairs both talk serialization and the talk editor without relying on browser-only normalization
- re-verify still uses the stored subscription token; users only need to paste a new token if the stored one is expired, revoked, or incorrect
