### PR TITLE
fix(agents): persist provider keys and expose pasted values

### DIFF
--- a/src/clawrocket/agents/provider-credentials-verifier.ts
+++ b/src/clawrocket/agents/provider-credentials-verifier.ts
@@ -40,18 +40,23 @@ type VerificationRequest = {
   headers?: Record<string, string>;
 };
 
-function buildVerificationRequest(provider: LlmProviderRecord): VerificationRequest {
+function buildVerificationRequest(
+  provider: LlmProviderRecord,
+): VerificationRequest {
   if (provider.provider_kind === 'nvidia') {
     return {
       url: joinUrl(provider.base_url, '/chat/completions'),
       method: 'POST',
       headers: {
+        accept: 'application/json',
         'content-type': 'application/json',
       },
       body: JSON.stringify({
         model: 'moonshotai/kimi-k2.5',
         messages: [{ role: 'user', content: 'ping' }],
-        max_tokens: 1,
+        max_tokens: 16,
+        temperature: 1.0,
+        top_p: 1.0,
         stream: false,
       }),
     };

--- a/src/clawrocket/web/routes/agents.test.ts
+++ b/src/clawrocket/web/routes/agents.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import {
+  _initTestDatabase,
+  listKnownProviderCredentialCards,
+} from '../../db/index.js';
+import { upsertUser } from '../../db/accessors.js';
+import { saveAiProviderCredentialRoute } from './agents.js';
+import type { AuthContext } from '../types.js';
+
+const OWNER_AUTH: AuthContext = {
+  sessionId: 'session-1',
+  userId: 'owner-1',
+  role: 'owner',
+  authType: 'cookie',
+};
+
+describe('agents routes', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    upsertUser({
+      id: 'owner-1',
+      email: 'owner@example.com',
+      displayName: 'Owner',
+      role: 'owner',
+    });
+  });
+
+  it('persists provider credentials before background verification finishes', async () => {
+    const verify = vi.fn().mockRejectedValue(new Error('provider unavailable'));
+
+    const result = await saveAiProviderCredentialRoute({
+      auth: OWNER_AUTH,
+      providerId: 'provider.nvidia',
+      apiKey: 'nvapi-test-key',
+      verifier: { verify } as never,
+    });
+
+    expect(result.statusCode).toBe(200);
+    expect(result.body.ok).toBe(true);
+    if (!result.body.ok) {
+      throw new Error('expected success response');
+    }
+    expect(result.body.data.provider.id).toBe('provider.nvidia');
+    expect(result.body.data.provider.hasCredential).toBe(true);
+    expect(result.body.data.provider.verificationStatus).toBe('not_verified');
+
+    expect(verify).toHaveBeenCalledWith('provider.nvidia');
+
+    const stored = listKnownProviderCredentialCards().find(
+      (provider) => provider.id === 'provider.nvidia',
+    );
+    expect(stored?.hasCredential).toBe(true);
+    expect(stored?.verificationStatus).toBe('not_verified');
+  });
+});

--- a/src/clawrocket/web/routes/agents.ts
+++ b/src/clawrocket/web/routes/agents.ts
@@ -135,16 +135,18 @@ export function saveAiProviderCredentialRoute(input: {
       updatedBy: input.auth.userId,
     });
 
-    const verified = credential
-      ? await input.verifier.verify(provider.id)
-      : provider;
+    if (credential) {
+      // Persist first, then verify in the background so a slow provider probe
+      // does not make the save itself look broken in the UI.
+      void input.verifier.verify(provider.id).catch(() => undefined);
+    }
 
     return {
       statusCode: 200,
       body: {
         ok: true,
         data: {
-          provider: verified,
+          provider,
         },
       },
     };

--- a/webapp/src/pages/AiAgentsPage.test.tsx
+++ b/webapp/src/pages/AiAgentsPage.test.tsx
@@ -18,6 +18,7 @@ describe('AiAgentsPage', () => {
   });
 
   it('renders the simplified Claude plus additional providers layout', async () => {
+    const user = userEvent.setup();
     installAiAgentsFetch();
 
     render(
@@ -67,6 +68,14 @@ describe('AiAgentsPage', () => {
       within(nvidiaCard).getByRole('link', { name: 'Get key from NVIDIA' }),
     ).toHaveAttribute('href', 'https://build.nvidia.com/');
     expect(within(nvidiaCard).getByPlaceholderText('nvapi-...')).toBeTruthy();
+    const nvidiaKeyInput = within(nvidiaCard).getByLabelText('API key');
+    expect(nvidiaKeyInput).toHaveAttribute('type', 'password');
+    await user.click(
+      within(nvidiaCard).getByRole('button', {
+        name: 'Show NVIDIA Kimi2.5 API key',
+      }),
+    );
+    expect(nvidiaKeyInput).toHaveAttribute('type', 'text');
   });
 
   it('reports saved provider credentials honestly when verification does not pass', async () => {
@@ -92,6 +101,39 @@ describe('AiAgentsPage', () => {
     expect(
       await screen.findByText('OpenAI credential saved. Verification status: invalid.'),
     ).toBeTruthy();
+  });
+
+  it('shows NVIDIA as saved immediately while background verification runs', async () => {
+    const user = userEvent.setup();
+    installAiAgentsFetch();
+
+    render(
+      <MemoryRouter initialEntries={['/app/agents']}>
+        <AiAgentsPage onUnauthorized={vi.fn()} userRole="owner" />
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole('heading', { name: 'AI Agents' });
+
+    const nvidiaCard = screen
+      .getByRole('heading', { name: 'NVIDIA Kimi2.5' })
+      .closest('article');
+    if (!nvidiaCard) {
+      throw new Error('Expected NVIDIA provider card');
+    }
+
+    await user.type(
+      within(nvidiaCard).getByLabelText('API key'),
+      'nvapi-test-key',
+    );
+    await user.click(within(nvidiaCard).getByRole('button', { name: 'Save' }));
+
+    expect(
+      await screen.findByText(
+        'NVIDIA Kimi2.5 credential saved. Verification is running in the background.',
+      ),
+    ).toBeTruthy();
+    expect(within(nvidiaCard).getByText('Needs verification')).toBeTruthy();
   });
 });
 
@@ -168,6 +210,27 @@ function installAiAgentsFetch() {
         };
         const provider = snapshot.additionalProviders.find(
           (entry) => entry.id === 'provider.openai',
+        );
+        return jsonResponse(200, { ok: true, data: { provider } });
+      }
+
+      if (url.endsWith('/api/v1/agents/providers/provider.nvidia') && method === 'PUT') {
+        snapshot = {
+          ...snapshot,
+          additionalProviders: snapshot.additionalProviders.map((provider) =>
+            provider.id === 'provider.nvidia'
+              ? {
+                  ...provider,
+                  hasCredential: true,
+                  credentialHint: '••••X6za',
+                  verificationStatus: 'not_verified',
+                  lastVerificationError: null,
+                }
+              : provider,
+          ),
+        };
+        const provider = snapshot.additionalProviders.find(
+          (entry) => entry.id === 'provider.nvidia',
         );
         return jsonResponse(200, { ok: true, data: { provider } });
       }

--- a/webapp/src/pages/AiAgentsPage.tsx
+++ b/webapp/src/pages/AiAgentsPage.tsx
@@ -31,6 +31,7 @@ type ClaudeAuthMode = 'subscription' | 'api_key';
 type ProviderDraft = {
   apiKey: string;
   expanded: boolean;
+  showApiKey: boolean;
 };
 
 const PROVIDER_DOCS_URL: Record<string, string> = {
@@ -120,6 +121,7 @@ function buildProviderDraft(provider: AgentProviderCard): ProviderDraft {
   return {
     apiKey: '',
     expanded: !provider.hasCredential,
+    showApiKey: false,
   };
 }
 
@@ -159,6 +161,8 @@ function formatProviderSaveNotice(provider: AgentProviderCard): string {
   switch (provider.verificationStatus) {
     case 'verified':
       return `${provider.name} credential saved and verified.`;
+    case 'not_verified':
+      return `${provider.name} credential saved. Verification is running in the background.`;
     case 'invalid':
     case 'unavailable':
       return `${provider.name} credential saved. Verification status: ${provider.verificationStatus}.`;
@@ -187,6 +191,8 @@ export function AiAgentsPage({
   const [claudeModelDraft, setClaudeModelDraft] = useState('');
   const [claudeApiKeyDraft, setClaudeApiKeyDraft] = useState('');
   const [claudeOauthDraft, setClaudeOauthDraft] = useState('');
+  const [showClaudeApiKey, setShowClaudeApiKey] = useState(false);
+  const [showClaudeOauthToken, setShowClaudeOauthToken] = useState(false);
   const [subscriptionHostStatus, setSubscriptionHostStatus] =
     useState<ExecutorSubscriptionHostStatus | null>(null);
   const [subscriptionHostBusy, setSubscriptionHostBusy] = useState<
@@ -209,12 +215,15 @@ export function AiAgentsPage({
     setClaudeModelDraft(nextData.defaultClaudeModelId);
     setClaudeApiKeyDraft('');
     setClaudeOauthDraft('');
+    setShowClaudeApiKey(false);
+    setShowClaudeOauthToken(false);
     setProviderDrafts((current) => {
       const nextDrafts: Record<string, ProviderDraft> = {};
       for (const provider of nextData.additionalProviders) {
         nextDrafts[provider.id] = {
           ...buildProviderDraft(provider),
           expanded: current[provider.id]?.expanded || !provider.hasCredential,
+          showApiKey: current[provider.id]?.showApiKey || false,
         };
       }
       return nextDrafts;
@@ -684,15 +693,30 @@ export function AiAgentsPage({
                 ) : null}
                 <label className="talk-llm-field-span">
                   <span>Claude Code OAuth token</span>
-                  <input
-                    type="password"
-                    value={claudeOauthDraft}
-                    onChange={(event) => {
-                      setClaudeOauthDraft(event.target.value);
-                    }}
-                    placeholder="Paste token from claude setup-token"
-                    disabled={!canManage || busyKey === 'claude-save'}
-                  />
+                  <div className="talk-llm-secret-input">
+                    <input
+                      type={showClaudeOauthToken ? 'text' : 'password'}
+                      value={claudeOauthDraft}
+                      onChange={(event) => {
+                        setClaudeOauthDraft(event.target.value);
+                      }}
+                      placeholder="Paste token from claude setup-token"
+                      disabled={!canManage || busyKey === 'claude-save'}
+                    />
+                    <button
+                      type="button"
+                      className="talk-llm-eye-toggle"
+                      onClick={() => setShowClaudeOauthToken((current) => !current)}
+                      disabled={!canManage || busyKey === 'claude-save'}
+                      aria-label={
+                        showClaudeOauthToken
+                          ? 'Hide Claude Code OAuth token'
+                          : 'Show Claude Code OAuth token'
+                      }
+                    >
+                      {showClaudeOauthToken ? 'Hide' : 'Show'}
+                    </button>
+                  </div>
                 </label>
               </div>
             </div>
@@ -720,15 +744,30 @@ export function AiAgentsPage({
                 )}
                 <label className="talk-llm-field-span">
                   <span>Anthropic API key</span>
-                  <input
-                    type="password"
-                    value={claudeApiKeyDraft}
-                    onChange={(event) => {
-                      setClaudeApiKeyDraft(event.target.value);
-                    }}
-                    placeholder="sk-ant-..."
-                    disabled={!canManage || busyKey === 'claude-save'}
-                  />
+                  <div className="talk-llm-secret-input">
+                    <input
+                      type={showClaudeApiKey ? 'text' : 'password'}
+                      value={claudeApiKeyDraft}
+                      onChange={(event) => {
+                        setClaudeApiKeyDraft(event.target.value);
+                      }}
+                      placeholder="sk-ant-..."
+                      disabled={!canManage || busyKey === 'claude-save'}
+                    />
+                    <button
+                      type="button"
+                      className="talk-llm-eye-toggle"
+                      onClick={() => setShowClaudeApiKey((current) => !current)}
+                      disabled={!canManage || busyKey === 'claude-save'}
+                      aria-label={
+                        showClaudeApiKey
+                          ? 'Hide Anthropic API key'
+                          : 'Show Anthropic API key'
+                      }
+                    >
+                      {showClaudeApiKey ? 'Hide' : 'Show'}
+                    </button>
+                  </div>
                 </label>
               </div>
             </div>
@@ -827,17 +866,36 @@ export function AiAgentsPage({
                   <div className="talk-llm-grid">
                     <label className="talk-llm-field-span">
                       <span>API key</span>
-                      <input
-                        type="password"
-                        value={draft.apiKey}
-                        onChange={(event) =>
-                          updateProviderDraft(provider.id, {
-                            apiKey: event.target.value,
-                          })
-                        }
-                        placeholder={PROVIDER_KEY_PLACEHOLDER[provider.id] || 'sk-...'}
-                        disabled={!canManage || busySave}
-                      />
+                      <div className="talk-llm-secret-input">
+                        <input
+                          type={draft.showApiKey ? 'text' : 'password'}
+                          value={draft.apiKey}
+                          onChange={(event) =>
+                            updateProviderDraft(provider.id, {
+                              apiKey: event.target.value,
+                            })
+                          }
+                          placeholder={PROVIDER_KEY_PLACEHOLDER[provider.id] || 'sk-...'}
+                          disabled={!canManage || busySave}
+                        />
+                        <button
+                          type="button"
+                          className="talk-llm-eye-toggle"
+                          onClick={() =>
+                            updateProviderDraft(provider.id, {
+                              showApiKey: !draft.showApiKey,
+                            })
+                          }
+                          disabled={!canManage || busySave}
+                          aria-label={
+                            draft.showApiKey
+                              ? `Hide ${provider.name} API key`
+                              : `Show ${provider.name} API key`
+                          }
+                        >
+                          {draft.showApiKey ? 'Hide' : 'Show'}
+                        </button>
+                      </div>
                     </label>
                     <div className="talk-llm-inline-actions">
                       <button

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -485,6 +485,30 @@ a {
   font-size: 0.95rem;
 }
 
+.talk-llm-secret-input {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.talk-llm-secret-input input {
+  flex: 1;
+}
+
+.talk-llm-eye-toggle {
+  border: 1px solid #c8d3e9;
+  border-radius: 9px;
+  background: #fff;
+  color: #2a467f;
+  padding: 0.62rem 0.85rem;
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.talk-llm-eye-toggle:disabled {
+  opacity: 0.65;
+}
+
 .talk-llm-subsection {
   display: grid;
   gap: 0.75rem;


### PR DESCRIPTION
## Summary
- make provider credential saves persist immediately and verify asynchronously in the background
- add show/hide controls for Claude and provider API key fields so pasted values can be inspected before saving
- keep NVIDIA Kimi2.5 saves from looking broken when verification is slow or brittle

## What Changed
- update the provider save route so credentials are stored first and returned immediately:
  - `src/clawrocket/web/routes/agents.ts`
- add a backend regression test proving provider credentials persist even if background verification fails:
  - `src/clawrocket/web/routes/agents.test.ts`
- update the AI Agents page notice copy to reflect background verification:
  - `webapp/src/pages/AiAgentsPage.tsx`
- add show/hide toggles for:
  - Claude subscription token
  - Claude API key
  - additional provider API keys, including NVIDIA
- add matching styling for the secret input + toggle controls:
  - `webapp/src/styles.css`
- extend the AI Agents page test to cover the NVIDIA key visibility toggle:
  - `webapp/src/pages/AiAgentsPage.test.tsx`

## User Impact
- saving an NVIDIA Kimi2.5 key now immediately shows the provider as having a stored credential instead of appearing to fail just because verification is still running
- users can confirm exactly what they pasted into API key/token inputs before saving
- verification still remains available via re-verify, but it is no longer on the critical path for the save UX

## Validation
- `npm -C ClawRocket run typecheck`
- `npm --prefix ClawRocket/webapp run typecheck`
- `npm -C ClawRocket run test -- --run src/clawrocket/web/routes/agents.test.ts`
- `npm --prefix ClawRocket/webapp run test -- --run src/pages/AiAgentsPage.test.tsx`

## Notes
- this change is intentionally focused on save behavior and input clarity; it does not expand the normal UI with extra base-url controls
- background verification is especially important for NVIDIA Kimi2.5 because provider probing can be more brittle than a simple key save
