### PR TITLE
fix(db): migrate nvidia provider schema

### DIFF
--- a/src/clawrocket/db/init.test.ts
+++ b/src/clawrocket/db/init.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { _initTestDatabase as _initCoreTestDatabase, getDb } from '../../db.js';
 import { _initClawrocketTestSchema } from './index.js';
+import { upsertKnownProviderCredential } from './llm-accessors.js';
 
 describe('clawrocket schema init', () => {
   it('adds registered_agent_id to legacy talk_agents tables before creating its index', () => {
@@ -39,5 +40,68 @@ describe('clawrocket schema init', () => {
         (index) => index.name === 'idx_talk_agents_registered_agent_id',
       ),
     ).toBe(true);
+  });
+
+  it('migrates legacy llm_providers tables so nvidia providers can be saved', () => {
+    _initCoreTestDatabase();
+
+    const database = getDb();
+    database.exec(`
+      CREATE TABLE llm_providers (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        provider_kind TEXT NOT NULL
+          CHECK(provider_kind IN ('anthropic', 'openai', 'gemini', 'deepseek', 'kimi', 'custom')),
+        api_format TEXT NOT NULL
+          CHECK(api_format IN ('anthropic_messages', 'openai_chat_completions')),
+        base_url TEXT NOT NULL,
+        auth_scheme TEXT NOT NULL
+          CHECK(auth_scheme IN ('x_api_key', 'bearer')),
+        enabled INTEGER NOT NULL DEFAULT 1,
+        core_compatibility TEXT NOT NULL DEFAULT 'none'
+          CHECK(core_compatibility IN ('none', 'claude_sdk_proxy')),
+        response_start_timeout_ms INTEGER,
+        stream_idle_timeout_ms INTEGER,
+        absolute_timeout_ms INTEGER,
+        updated_at TEXT NOT NULL,
+        updated_by TEXT REFERENCES users(id)
+      );
+
+      CREATE TABLE llm_provider_models (
+        provider_id TEXT NOT NULL REFERENCES llm_providers(id) ON DELETE CASCADE,
+        model_id TEXT NOT NULL,
+        display_name TEXT NOT NULL,
+        context_window_tokens INTEGER NOT NULL,
+        default_max_output_tokens INTEGER NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        updated_at TEXT NOT NULL,
+        updated_by TEXT REFERENCES users(id),
+        PRIMARY KEY (provider_id, model_id)
+      );
+
+      CREATE TABLE llm_provider_secrets (
+        provider_id TEXT PRIMARY KEY REFERENCES llm_providers(id) ON DELETE CASCADE,
+        ciphertext TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        updated_by TEXT REFERENCES users(id)
+      );
+
+      CREATE TABLE llm_provider_verifications (
+        provider_id TEXT PRIMARY KEY REFERENCES llm_providers(id) ON DELETE CASCADE,
+        status TEXT NOT NULL
+          CHECK(status IN ('missing', 'not_verified', 'verified', 'invalid', 'unavailable')),
+        last_verified_at TEXT,
+        last_error TEXT,
+        updated_at TEXT NOT NULL
+      );
+    `);
+
+    expect(() => _initClawrocketTestSchema()).not.toThrow();
+    expect(() =>
+      upsertKnownProviderCredential({
+        providerId: 'provider.nvidia',
+        credential: { apiKey: 'nvapi-test-key' },
+      }),
+    ).not.toThrow();
   });
 });

--- a/src/clawrocket/db/init.ts
+++ b/src/clawrocket/db/init.ts
@@ -92,6 +92,83 @@ function seedBuiltinTalkLlmDefaults(database: Database.Database): void {
     .run(now);
 }
 
+function migrateLlmProvidersForNvidia(database: Database.Database): void {
+  const row = database
+    .prepare(
+      `
+      SELECT sql
+      FROM sqlite_master
+      WHERE type = 'table' AND name = 'llm_providers'
+    `,
+    )
+    .get() as { sql?: string | null } | undefined;
+
+  const sql = row?.sql || '';
+  if (!sql || sql.includes("'nvidia'")) {
+    return;
+  }
+
+  database.exec(`
+    PRAGMA foreign_keys = OFF;
+
+    CREATE TABLE llm_providers_new (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      provider_kind TEXT NOT NULL
+        CHECK(provider_kind IN ('anthropic', 'openai', 'gemini', 'deepseek', 'kimi', 'nvidia', 'custom')),
+      api_format TEXT NOT NULL
+        CHECK(api_format IN ('anthropic_messages', 'openai_chat_completions')),
+      base_url TEXT NOT NULL,
+      auth_scheme TEXT NOT NULL
+        CHECK(auth_scheme IN ('x_api_key', 'bearer')),
+      enabled INTEGER NOT NULL DEFAULT 1,
+      core_compatibility TEXT NOT NULL DEFAULT 'none'
+        CHECK(core_compatibility IN ('none', 'claude_sdk_proxy')),
+      response_start_timeout_ms INTEGER,
+      stream_idle_timeout_ms INTEGER,
+      absolute_timeout_ms INTEGER,
+      updated_at TEXT NOT NULL,
+      updated_by TEXT REFERENCES users(id)
+    );
+
+    INSERT INTO llm_providers_new (
+      id,
+      name,
+      provider_kind,
+      api_format,
+      base_url,
+      auth_scheme,
+      enabled,
+      core_compatibility,
+      response_start_timeout_ms,
+      stream_idle_timeout_ms,
+      absolute_timeout_ms,
+      updated_at,
+      updated_by
+    )
+    SELECT
+      id,
+      name,
+      provider_kind,
+      api_format,
+      base_url,
+      auth_scheme,
+      enabled,
+      core_compatibility,
+      response_start_timeout_ms,
+      stream_idle_timeout_ms,
+      absolute_timeout_ms,
+      updated_at,
+      updated_by
+    FROM llm_providers;
+
+    DROP TABLE llm_providers;
+    ALTER TABLE llm_providers_new RENAME TO llm_providers;
+
+    PRAGMA foreign_keys = ON;
+  `);
+}
+
 function createClawrocketSchema(database: Database.Database): void {
   database.exec(`
     CREATE TABLE IF NOT EXISTS users (
@@ -408,6 +485,8 @@ function createClawrocketSchema(database: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_llm_attempts_talk_id_created_at
       ON llm_attempts(talk_id, created_at);
   `);
+
+  migrateLlmProvidersForNvidia(database);
 
   try {
     database.exec(`


### PR DESCRIPTION
## Summary
- simplify `AI Agents` around a single `Default Claude Agent` card plus `Additional Providers`
- streamline the Claude card UX with a subscription/API toggle, clearer copy, and fewer redundant controls
- split Moonshot Kimi and NVIDIA Kimi2.5 into separate provider cards
- persist provider keys immediately, verify in the background, and allow pasted key visibility
- fix old databases so `provider.nvidia` can actually be saved

## What Changed

### AI Agents UX
- `Default Claude Agent` now uses a `Subscription` / `API` toggle
- `Default Claude model` is now `Model for new talks`
- removed redundant Claude controls:
  - `Check host Claude login`
  - `Hide manual token entry`
  - `Clear stored subscription token`
- kept a single status badge and green configured styling
- added show/hide controls for pasted Claude and provider secrets

### Claude models
- added:
  - `Claude Opus 4.6`
  - `Claude Sonnet 4.6`
- removed:
  - `Claude Opus 4.1`

### Providers
- `Moonshot / Kimi` remains the Moonshot-native provider
- added separate `NVIDIA Kimi2.5`
- NVIDIA uses:
  - `nvapi-...` placeholder
  - fixed NVIDIA endpoint
  - background verification after save

### Backend fixes
- provider saves now persist first and verify asynchronously
- malformed stored Claude talk-agent rows are rehydrated as valid Claude-default agents
- old SQLite schemas are migrated so `llm_providers.provider_kind` allows `nvidia`
- added regression coverage for the NVIDIA schema migration and save flow

## Validation
- `npm -C ClawRocket run typecheck`
- `npm -C ClawRocket run test -- --run src/clawrocket/db/init.test.ts src/clawrocket/web/routes/agents.test.ts`
- `npm --prefix ClawRocket/webapp run typecheck`
- `npm --prefix ClawRocket/webapp run test -- --run src/pages/AiAgentsPage.test.tsx src/pages/TalkDetailPage.test.tsx`
