### PR TITLE
fix(agents): refresh provider verification state

### DIFF
--- a/src/clawrocket/db/llm-accessors.test.ts
+++ b/src/clawrocket/db/llm-accessors.test.ts
@@ -90,4 +90,64 @@ describe('registered agent accessors', () => {
       modelDisplayName: expectedModelDisplayName,
     });
   });
+
+  it('resets old mock default talk agents to the Claude default agent', () => {
+    upsertUser({
+      id: 'owner-2',
+      email: 'owner2@example.com',
+      displayName: 'Owner Two',
+      role: 'owner',
+    });
+    upsertTalk({
+      id: 'talk-2',
+      ownerId: 'owner-2',
+      topicTitle: 'Mock Reset Test',
+    });
+
+    getDb()
+      .prepare(
+        `
+        INSERT INTO talk_agents (
+          id,
+          talk_id,
+          name,
+          source_kind,
+          persona_role,
+          route_id,
+          registered_agent_id,
+          provider_id,
+          model_id,
+          is_primary,
+          sort_order,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+      )
+      .run(
+        'agent-mock',
+        'talk-2',
+        'Mock',
+        'provider',
+        'assistant',
+        'route.default.mock',
+        null,
+        null,
+        null,
+        1,
+        0,
+        new Date().toISOString(),
+        new Date().toISOString(),
+      );
+
+    const expectedModelId = getDefaultClaudeModelId();
+    const [agent] = listTalkAgentInstances('talk-2');
+
+    expect(agent).toMatchObject({
+      name: 'Claude',
+      sourceKind: 'claude_default',
+      providerId: 'provider.anthropic',
+      modelId: expectedModelId,
+    });
+  });
 });

--- a/src/clawrocket/db/llm-accessors.ts
+++ b/src/clawrocket/db/llm-accessors.ts
@@ -1656,7 +1656,26 @@ export function ensureTalkHasDefaultAgent(
   now?: string,
 ): TalkAgentRecord[] {
   const existing = listTalkAgents(talkId);
-  if (existing.length > 0) return existing;
+  if (existing.length > 0) {
+    const shouldResetToClaudeDefault = existing.every((agent) => {
+      const route = getTalkRouteById(agent.route_id);
+      const primaryStep = route ? listTalkRouteSteps(route.id)[0] : undefined;
+      return (
+        agent.route_id === BUILTIN_MOCK_ROUTE_ID ||
+        agent.provider_id === BUILTIN_MOCK_PROVIDER_ID ||
+        agent.model_id === 'mock-default' ||
+        primaryStep?.provider_id === BUILTIN_MOCK_PROVIDER_ID ||
+        primaryStep?.model_id === 'mock-default' ||
+        agent.name === 'Mock'
+      );
+    });
+
+    if (!shouldResetToClaudeDefault) {
+      return existing;
+    }
+
+    return resetTalkAgentsToDefault(talkId, now);
+  }
   return resetTalkAgentsToDefault(talkId, now);
 }
 

--- a/webapp/src/pages/AiAgentsPage.test.tsx
+++ b/webapp/src/pages/AiAgentsPage.test.tsx
@@ -13,6 +13,7 @@ import type {
 describe('AiAgentsPage', () => {
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -134,6 +135,11 @@ describe('AiAgentsPage', () => {
       ),
     ).toBeTruthy();
     expect(within(nvidiaCard).getByText('Needs verification')).toBeTruthy();
+
+    expect(
+      await screen.findByText('NVIDIA Kimi2.5 credential verified.', {}, { timeout: 4_000 }),
+    ).toBeTruthy();
+    expect(within(nvidiaCard).getByText('Configured')).toBeTruthy();
   });
 });
 
@@ -141,6 +147,7 @@ function installAiAgentsFetch() {
   let snapshot = buildAiAgentsData();
   let settings = buildExecutorSettings();
   let status = buildExecutorStatus();
+  let nvidiaVerificationPending = false;
 
   vi.stubGlobal(
     'fetch',
@@ -156,6 +163,24 @@ function installAiAgentsFetch() {
       const method = init?.method || 'GET';
 
       if (url.endsWith('/api/v1/agents') && method === 'GET') {
+        if (nvidiaVerificationPending) {
+          snapshot = {
+            ...snapshot,
+            additionalProviders: snapshot.additionalProviders.map((provider) =>
+              provider.id === 'provider.nvidia'
+                ? {
+                    ...provider,
+                    hasCredential: true,
+                    credentialHint: '••••X6za',
+                    verificationStatus: 'verified',
+                    lastVerifiedAt: '2026-03-06T20:28:56.000Z',
+                    lastVerificationError: null,
+                  }
+                : provider,
+            ),
+          };
+          nvidiaVerificationPending = false;
+        }
         return jsonResponse(200, { ok: true, data: snapshot });
       }
 
@@ -215,6 +240,7 @@ function installAiAgentsFetch() {
       }
 
       if (url.endsWith('/api/v1/agents/providers/provider.nvidia') && method === 'PUT') {
+        nvidiaVerificationPending = true;
         snapshot = {
           ...snapshot,
           additionalProviders: snapshot.additionalProviders.map((provider) =>

--- a/webapp/src/pages/AiAgentsPage.tsx
+++ b/webapp/src/pages/AiAgentsPage.tsx
@@ -171,6 +171,12 @@ function formatProviderSaveNotice(provider: AgentProviderCard): string {
   }
 }
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
 export function AiAgentsPage({
   onUnauthorized,
   userRole,
@@ -357,6 +363,39 @@ export function AiAgentsPage({
     });
   };
 
+  const pollProviderAfterSave = async (providerId: string): Promise<void> => {
+    const delays = [1_500, 1_500, 2_500, 3_500, 5_000];
+
+    for (const delayMs of delays) {
+      await delay(delayMs);
+      try {
+        const nextData = await getAiAgents();
+        const nextProvider = nextData.additionalProviders.find(
+          (entry) => entry.id === providerId,
+        );
+        if (!nextProvider) return;
+
+        refreshProvider(nextProvider);
+        if (nextProvider.verificationStatus !== 'not_verified') {
+          if (nextProvider.verificationStatus === 'verified') {
+            setNotice(`${nextProvider.name} credential verified.`);
+          } else {
+            setNotice(
+              `${nextProvider.name} verification status: ${formatVerificationStatus(nextProvider.verificationStatus)}.`,
+            );
+          }
+          return;
+        }
+      } catch (err) {
+        if (err instanceof UnauthorizedError) {
+          onUnauthorized();
+          return;
+        }
+        return;
+      }
+    }
+  };
+
   const handleApiFailure = (err: unknown, fallback: string): void => {
     if (err instanceof UnauthorizedError) {
       onUnauthorized();
@@ -460,6 +499,9 @@ export function AiAgentsPage({
       });
       refreshProvider(provider);
       setNotice(formatProviderSaveNotice(provider));
+      if (provider.hasCredential && provider.verificationStatus === 'not_verified') {
+        void pollProviderAfterSave(provider.id);
+      }
     } catch (err) {
       handleApiFailure(err, 'Failed to save provider credential.');
     } finally {


### PR DESCRIPTION
## Summary
- simplify `AI Agents` around a single `Default Claude Agent` card plus `Additional Providers`
- streamline the Claude card UX with a subscription/API toggle, clearer copy, and fewer redundant controls
- split Moonshot Kimi and NVIDIA Kimi2.5 into separate provider cards
- persist provider keys immediately, verify them in the background, and refresh the card state automatically
- fix old mock default talk agents so they reset to real Claude defaults with a valid model

## What Changed

### Default Claude Agent
- replaced the Claude billing-model dropdown with a `Subscription` / `API` toggle
- renamed `Default Claude model` to `Model for new talks`
- removed redundant Claude controls:
  - `Check host Claude login`
  - `Hide manual token entry`
  - `Clear stored subscription token`
- kept a single top-right status badge and green configured styling
- added the latest Claude suggestions:
  - `Claude Opus 4.6`
  - `Claude Sonnet 4.6`
- removed:
  - `Claude Opus 4.1`

### Provider cards
- kept `Moonshot / Kimi` as the Moonshot-native provider
- added separate `NVIDIA Kimi2.5`
- NVIDIA now uses:
  - `nvapi-...` placeholder
  - fixed NVIDIA endpoint
  - background verification after save
- added show/hide controls for pasted provider keys so users can inspect what they entered before saving
- provider save now persists first and verifies asynchronously
- the UI now polls and refreshes the provider card after save so `Needs verification` settles automatically to a final state

### Talk agent fixes
- fixed old built-in mock default talk agents so they are replaced with the real default Claude agent
- this restores the primary Claude row in the talk editor to a real Claude model instead of showing:
  - source `Claude`
  - blank model
  - `Mock · General` preview

### Database
- added a migration for older `llm_providers` schemas so `provider_kind = 'nvidia'` can be saved on existing databases

## Validation
- `npm -C ClawRocket run typecheck`
- `npm -C ClawRocket run test -- --run src/clawrocket/db/init.test.ts src/clawrocket/db/llm-accessors.test.ts src/clawrocket/web/routes/agents.test.ts`
- `npm --prefix ClawRocket/webapp run typecheck`
- `npm --prefix ClawRocket/webapp run test -- --run src/pages/AiAgentsPage.test.tsx src/pages/TalkDetailPage.test.tsx`

## User Impact
- Claude setup is simpler and clearer
- NVIDIA Kimi2.5 is now a real first-class provider instead of being confused with Moonshot Kimi
- provider saves feel immediate, and verification status now updates without a manual reload
- old placeholder/mock default talk agents no longer break the primary Claude model picker
