### PR TITLE
fix(talks): reflect unsaved draft agents in talk tab

### DIFF
--- a/webapp/src/pages/TalkDetailPage.test.tsx
+++ b/webapp/src/pages/TalkDetailPage.test.tsx
@@ -145,6 +145,61 @@ describe('TalkDetailPage', () => {
     });
   });
 
+  it('shows unsaved draft agents in the Talk tab and blocks send until agent changes are saved', async () => {
+    const user = userEvent.setup();
+
+    installTalkDetailFetch({
+      messages: [],
+      runs: [],
+      talkAgents: [
+        buildTalkAgent({
+          id: 'agent-claude',
+          nickname: 'Claude Sonnet 4.6',
+          sourceKind: 'claude_default',
+          role: 'assistant',
+          isPrimary: true,
+          displayOrder: 0,
+          health: 'ready',
+          providerId: null,
+          modelId: 'claude-sonnet-4-6',
+          modelDisplayName: 'Claude Sonnet 4.6',
+        }),
+      ],
+    });
+
+    renderDetailPage('/app/talks/talk-1/agents');
+    await screen.findByRole('heading', { name: 'Agents' });
+
+    const footerSourceSelect = screen.getAllByLabelText('Source')[0];
+    await user.selectOptions(footerSourceSelect, 'provider.openai');
+    await user.selectOptions(screen.getAllByLabelText('Role')[1], 'critic');
+    await user.click(screen.getByRole('button', { name: 'Add Agent' }));
+
+    const tabs = within(screen.getByRole('navigation', { name: 'Talk sections' }));
+    await user.click(tabs.getByRole('link', { name: 'Talk' }));
+    await screen.findByLabelText('Talk timeline');
+
+    const statusPills = screen.getByRole('list', { name: 'Talk agent status' });
+    expect(within(statusPills).getByText('Claude Sonnet 4.6 (General)')).toBeTruthy();
+    expect(within(statusPills).getByText('GPT-5 Mini (Critic)')).toBeTruthy();
+
+    const targetGroup = screen.getByRole('group', { name: 'Selected agents' });
+    expect(
+      within(targetGroup).getByRole('button', { name: /Claude Sonnet 4\.6 \(General\)/i }),
+    ).toBeTruthy();
+    expect(
+      within(targetGroup).getByRole('button', { name: /GPT-5 Mini \(Critic\)/i }),
+    ).toBeTruthy();
+
+    expect(
+      screen.getByText('Save agent changes before sending a message.'),
+    ).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Send' })).toHaveAttribute('disabled');
+    expect(screen.getByPlaceholderText('Send a message to this talk')).toHaveAttribute(
+      'disabled',
+    );
+  });
+
   it('uses primary-target chips by default and sends plural targetAgentIds', async () => {
     const user = userEvent.setup();
     let sendBody:

--- a/webapp/src/pages/TalkDetailPage.tsx
+++ b/webapp/src/pages/TalkDetailPage.tsx
@@ -736,6 +736,34 @@ function buildTargetSelection(agents: TalkAgent[], current: string[]): string[] 
   return primary ? [primary.id] : agents[0] ? [agents[0].id] : [];
 }
 
+function serializeTalkAgentForDraftCompare(agent: TalkAgent): string {
+  return JSON.stringify({
+    id: agent.id,
+    nickname: agent.nickname,
+    nicknameMode: agent.nicknameMode,
+    sourceKind: agent.sourceKind,
+    providerId: agent.providerId,
+    modelId: agent.modelId,
+    modelDisplayName: agent.modelDisplayName,
+    role: agent.role,
+    isPrimary: agent.isPrimary,
+    displayOrder: agent.displayOrder,
+  });
+}
+
+function haveSameTalkAgentDraftState(left: TalkAgent[], right: TalkAgent[]): boolean {
+  if (left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1) {
+    if (
+      serializeTalkAgentForDraftCompare(left[index]) !==
+      serializeTalkAgentForDraftCompare(right[index])
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function TalkDetailPage({
   onUnauthorized,
   titleOverride,
@@ -925,10 +953,6 @@ export function TalkDetailPage({
   }, [handleUnauthorized]);
 
   useEffect(() => {
-    setTargetAgentIds((current) => buildTargetSelection(agents, current));
-  }, [agents]);
-
-  useEffect(() => {
     if (state.kind !== 'ready') return;
     const stream = openTalkStream({
       talkId,
@@ -1094,21 +1118,21 @@ export function TalkDetailPage({
       }),
     [aiAgentsData, newAgentDraft.providerId, newAgentDraft.sourceKind],
   );
+  const hasUnsavedAgentChanges = useMemo(
+    () => !haveSameTalkAgentDraftState(agents, agentDrafts),
+    [agentDrafts, agents],
+  );
+  const effectiveAgents = hasUnsavedAgentChanges ? agentDrafts : agents;
+  useEffect(() => {
+    setTargetAgentIds((current) => buildTargetSelection(effectiveAgents, current));
+  }, [effectiveAgents]);
   const agentLabelById = useMemo(
     () =>
-      agents.reduce<Record<string, string>>((acc, agent) => {
+      effectiveAgents.reduce<Record<string, string>>((acc, agent) => {
         acc[agent.id] = buildAgentLabel(agent);
         return acc;
       }, {}),
-    [agents],
-  );
-  const draftAgentLabelById = useMemo(
-    () =>
-      agentDrafts.reduce<Record<string, string>>((acc, agent) => {
-        acc[agent.id] = buildAgentLabel(agent);
-        return acc;
-      }, {}),
-    [agentDrafts],
+    [effectiveAgents],
   );
   const messageLookup = useMemo(
     () => new Map(state.messages.map((message) => [message.id, message] as const)),
@@ -1185,6 +1209,14 @@ export function TalkDetailPage({
       dispatch({
         type: 'SEND_FAILED',
         message: 'Wait for the current round to finish or cancel it first.',
+        lastDraft: content,
+      });
+      return;
+    }
+    if (hasUnsavedAgentChanges) {
+      dispatch({
+        type: 'SEND_FAILED',
+        message: 'Save agent changes before sending a message.',
         lastDraft: content,
       });
       return;
@@ -1526,9 +1558,9 @@ export function TalkDetailPage({
                 </h1>
               )}
               <p>Event-authoritative live timeline.</p>
-              {agents.length > 0 ? (
+              {effectiveAgents.length > 0 ? (
                 <div className="talk-status-strip" role="list" aria-label="Talk agent status">
-                  {agents.map((agent) => (
+                  {effectiveAgents.map((agent) => (
                     <span
                       key={agent.id}
                       className={`talk-status-pill talk-status-pill-${agent.health}`}
@@ -1929,7 +1961,7 @@ export function TalkDetailPage({
         {currentTab === 'talk' ? (
           <form className="composer talk-workspace-composer" onSubmit={handleSend}>
             <div className="composer-targets" role="group" aria-label="Selected agents">
-              {agents.map((agent) => {
+              {effectiveAgents.map((agent) => {
                 const selected = targetAgentIds.includes(agent.id);
                 return (
                   <button
@@ -1962,7 +1994,9 @@ export function TalkDetailPage({
               placeholder="Send a message to this talk"
               rows={3}
               maxLength={TALK_MESSAGE_MAX_CHARS}
-              disabled={state.sendState.status === 'posting' || activeRound}
+              disabled={
+                state.sendState.status === 'posting' || activeRound || hasUnsavedAgentChanges
+              }
             />
 
             <div className="composer-controls">
@@ -1972,7 +2006,9 @@ export function TalkDetailPage({
               <button
                 type="submit"
                 className="primary-btn"
-                disabled={state.sendState.status === 'posting' || activeRound}
+                disabled={
+                  state.sendState.status === 'posting' || activeRound || hasUnsavedAgentChanges
+                }
               >
                 {state.sendState.status === 'posting' ? 'Sending…' : 'Send'}
               </button>
@@ -1992,6 +2028,12 @@ export function TalkDetailPage({
               <div className="inline-banner inline-banner-warning" role="status">
                 Wait for the current round to finish or cancel it before sending another
                 message.
+              </div>
+            ) : null}
+
+            {!activeRound && hasUnsavedAgentChanges ? (
+              <div className="inline-banner inline-banner-warning" role="status">
+                Save agent changes before sending a message.
               </div>
             ) : null}
 


### PR DESCRIPTION
## Summary
- make the Talk tab reflect unsaved draft agent changes immediately
- keep the header status strip and composer target chips in sync with the draft agent list
- block sending while agent edits are unsaved so the chat view and saved talk configuration cannot drift

## What Changed
- update `webapp/src/pages/TalkDetailPage.tsx` so the `Talk` tab renders from an effective agent set:
  - saved agents when there are no edits
  - draft agents when the user has unsaved changes in the `Agents` tab
- recalculate target-chip selection from that same effective agent set
- disable the composer and show:
  - `Save agent changes before sending a message.`
  when draft agent edits are still unsaved
- add regression coverage in:
  - `webapp/src/pages/TalkDetailPage.test.tsx`

## User Impact
- after adding or editing an agent in the `Agents` tab, that agent now appears immediately in:
  - the header status strip
  - the bottom target-chip selector
- users are prevented from sending a message against stale agent state before saving the changes

## Validation
- `npm --prefix webapp run test -- --run src/pages/TalkDetailPage.test.tsx`
- `npm --prefix webapp run typecheck`
