### PR TITLE
fix(webapp): rebuild csrf headers on mutation retry

### DIFF
--- a/webapp/src/lib/api.test.ts
+++ b/webapp/src/lib/api.test.ts
@@ -1,12 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+let cookieValue = '';
+
 describe('api auth retry behavior', () => {
   beforeEach(() => {
     vi.unstubAllGlobals();
     Object.defineProperty(document, 'cookie', {
       configurable: true,
-      value: 'cr_csrf_token=test-csrf-token',
+      get() {
+        return cookieValue;
+      },
+      set(value: string) {
+        cookieValue = value;
+      },
     });
+    cookieValue = 'cr_csrf_token=test-csrf-token';
   });
 
   afterEach(() => {
@@ -213,6 +221,358 @@ describe('api auth retry behavior', () => {
     await expect(api.logout()).rejects.toBeInstanceOf(api.UnauthorizedError);
     expect(paths).toEqual(['/api/v1/auth/logout']);
   });
+
+  it('rebuilds mutation headers after a 401 refresh retry and reuses the idempotency key', async () => {
+    const mutationHeaders: Array<Record<string, string>> = [];
+
+    vi.stubGlobal(
+      'fetch',
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const path = normalizePath(input);
+        if (path === '/api/v1/talks') {
+          mutationHeaders.push(readHeaders(init));
+          if (mutationHeaders.length === 1) {
+            return jsonResponse(401, {
+              ok: false,
+              error: {
+                code: 'unauthorized',
+                message: 'Authentication is required',
+              },
+            });
+          }
+
+          return jsonResponse(200, {
+            ok: true,
+            data: {
+              talk: {
+                id: 'talk-1',
+                ownerId: 'u1',
+                title: 'New Talk',
+                agents: [],
+                status: 'active',
+                folderId: null,
+                sortOrder: 0,
+                version: 1,
+                createdAt: '2026-03-08T00:00:00.000Z',
+                updatedAt: '2026-03-08T00:00:00.000Z',
+                accessRole: 'owner',
+              },
+            },
+          });
+        }
+
+        if (path === '/api/v1/auth/refresh') {
+          cookieValue = 'cr_csrf_token=fresh-csrf-token';
+          return jsonResponse(200, {
+            ok: true,
+            data: {
+              user: {
+                id: 'u1',
+                email: 'owner@example.com',
+                displayName: 'Owner',
+                role: 'owner',
+              },
+            },
+          });
+        }
+
+        throw new Error(`Unexpected fetch path: ${path}`);
+      },
+    );
+
+    const api = await loadApiModule();
+    const talk = await api.createTalk('New Talk');
+
+    expect(talk.id).toBe('talk-1');
+    expect(mutationHeaders).toHaveLength(2);
+    expect(mutationHeaders[0]['x-csrf-token']).toBe('test-csrf-token');
+    expect(mutationHeaders[1]['x-csrf-token']).toBe('fresh-csrf-token');
+    expect(mutationHeaders[0]['idempotency-key']).toBeTruthy();
+    expect(mutationHeaders[0]['idempotency-key']).toBe(
+      mutationHeaders[1]['idempotency-key'],
+    );
+  });
+
+  it('retries csrf_failed mutations once after refreshing session with fresh headers', async () => {
+    const mutationHeaders: Array<Record<string, string>> = [];
+
+    cookieValue = '';
+    vi.stubGlobal(
+      'fetch',
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const path = normalizePath(input);
+        if (path === '/api/v1/talks') {
+          mutationHeaders.push(readHeaders(init));
+          if (mutationHeaders.length === 1) {
+            return jsonResponse(403, {
+              ok: false,
+              error: {
+                code: 'csrf_failed',
+                message: 'Missing X-CSRF-Token header',
+              },
+            });
+          }
+          return jsonResponse(200, {
+            ok: true,
+            data: {
+              talk: {
+                id: 'talk-2',
+                ownerId: 'u1',
+                title: 'Recovered Talk',
+                agents: [],
+                status: 'active',
+                folderId: null,
+                sortOrder: 0,
+                version: 1,
+                createdAt: '2026-03-08T00:00:00.000Z',
+                updatedAt: '2026-03-08T00:00:00.000Z',
+                accessRole: 'owner',
+              },
+            },
+          });
+        }
+
+        if (path === '/api/v1/auth/refresh') {
+          cookieValue = 'cr_csrf_token=recovered-csrf-token';
+          return jsonResponse(200, {
+            ok: true,
+            data: {
+              user: {
+                id: 'u1',
+                email: 'owner@example.com',
+                displayName: 'Owner',
+                role: 'owner',
+              },
+            },
+          });
+        }
+
+        throw new Error(`Unexpected fetch path: ${path}`);
+      },
+    );
+
+    const api = await loadApiModule();
+    const talk = await api.createTalk('Recovered Talk');
+
+    expect(talk.id).toBe('talk-2');
+    expect(mutationHeaders).toHaveLength(2);
+    expect(mutationHeaders[0]['x-csrf-token']).toBeUndefined();
+    expect(mutationHeaders[1]['x-csrf-token']).toBe('recovered-csrf-token');
+    expect(mutationHeaders[0]['idempotency-key']).toBe(
+      mutationHeaders[1]['idempotency-key'],
+    );
+  });
+
+  it('coalesces concurrent mutation refreshes and rebuilds fresh headers for both retries', async () => {
+    const counts = new Map<string, number>();
+    const createTalkHeaders: Array<Record<string, string>> = [];
+    const metadataHeaders: Array<Record<string, string>> = [];
+    let refreshCalls = 0;
+
+    vi.stubGlobal(
+      'fetch',
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const path = normalizePath(input);
+        const count = counts.get(path) || 0;
+        counts.set(path, count + 1);
+
+        if (path === '/api/v1/auth/refresh') {
+          refreshCalls += 1;
+          cookieValue = 'cr_csrf_token=shared-fresh-token';
+          return jsonResponse(200, {
+            ok: true,
+            data: {
+              user: {
+                id: 'u1',
+                email: 'owner@example.com',
+                displayName: 'Owner',
+                role: 'owner',
+              },
+            },
+          });
+        }
+
+        if (path === '/api/v1/talks') {
+          createTalkHeaders.push(readHeaders(init));
+          if (createTalkHeaders.length === 1) {
+            return jsonResponse(401, {
+              ok: false,
+              error: {
+                code: 'unauthorized',
+                message: 'Authentication is required',
+              },
+            });
+          }
+          return jsonResponse(200, {
+            ok: true,
+            data: {
+              talk: {
+                id: 'talk-3',
+                ownerId: 'u1',
+                title: 'Concurrent Create',
+                agents: [],
+                status: 'active',
+                folderId: null,
+                sortOrder: 0,
+                version: 1,
+                createdAt: '2026-03-08T00:00:00.000Z',
+                updatedAt: '2026-03-08T00:00:00.000Z',
+                accessRole: 'owner',
+              },
+            },
+          });
+        }
+
+        if (path === '/api/v1/talks/talk-99') {
+          metadataHeaders.push(readHeaders(init));
+          if (metadataHeaders.length === 1) {
+            return jsonResponse(401, {
+              ok: false,
+              error: {
+                code: 'unauthorized',
+                message: 'Authentication is required',
+              },
+            });
+          }
+          return jsonResponse(200, {
+            ok: true,
+            data: {
+              talk: {
+                id: 'talk-99',
+                ownerId: 'u1',
+                title: 'Updated Talk',
+                agents: [],
+                status: 'active',
+                folderId: null,
+                sortOrder: 0,
+                version: 2,
+                createdAt: '2026-03-08T00:00:00.000Z',
+                updatedAt: '2026-03-08T00:01:00.000Z',
+                accessRole: 'owner',
+              },
+            },
+          });
+        }
+
+        throw new Error(`Unexpected fetch path: ${path}`);
+      },
+    );
+
+    const api = await loadApiModule();
+    const [createdTalk, patchedTalk] = await Promise.all([
+      api.createTalk('Concurrent Create'),
+      api.patchTalkMetadata({ talkId: 'talk-99', title: 'Updated Talk' }),
+    ]);
+
+    expect(createdTalk.id).toBe('talk-3');
+    expect(patchedTalk.id).toBe('talk-99');
+    expect(refreshCalls).toBe(1);
+    expect(createTalkHeaders).toHaveLength(2);
+    expect(metadataHeaders).toHaveLength(2);
+    expect(createTalkHeaders[1]['x-csrf-token']).toBe('shared-fresh-token');
+    expect(metadataHeaders[1]['x-csrf-token']).toBe('shared-fresh-token');
+    expect(createTalkHeaders[0]['idempotency-key']).toBe(
+      createTalkHeaders[1]['idempotency-key'],
+    );
+    expect(metadataHeaders[0]['idempotency-key']).toBe(
+      metadataHeaders[1]['idempotency-key'],
+    );
+  });
+
+  it('does not retry non-csrf 403 responses for mutations', async () => {
+    const paths: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        paths.push(normalizePath(input));
+        if (normalizePath(input) === '/api/v1/talks') {
+          expect(readHeaders(init)['x-csrf-token']).toBe('test-csrf-token');
+        }
+        return jsonResponse(403, {
+          ok: false,
+          error: {
+            code: 'forbidden',
+            message: 'Forbidden',
+          },
+        });
+      },
+    );
+
+    const api = await loadApiModule();
+
+    await expect(api.createTalk('Forbidden')).rejects.toMatchObject({
+      status: 403,
+      code: 'forbidden',
+    });
+    expect(paths).toEqual(['/api/v1/talks']);
+  });
+
+  it('stops retrying after one auth refresh and one csrf refresh', async () => {
+    const mutationHeaders: Array<Record<string, string>> = [];
+    let refreshCalls = 0;
+
+    vi.stubGlobal(
+      'fetch',
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const path = normalizePath(input);
+        if (path === '/api/v1/talks') {
+          mutationHeaders.push(readHeaders(init));
+          if (mutationHeaders.length === 1) {
+            return jsonResponse(401, {
+              ok: false,
+              error: {
+                code: 'unauthorized',
+                message: 'Authentication is required',
+              },
+            });
+          }
+          return jsonResponse(403, {
+            ok: false,
+            error: {
+              code: 'csrf_failed',
+              message: 'CSRF token mismatch',
+            },
+          });
+        }
+
+        if (path === '/api/v1/auth/refresh') {
+          refreshCalls += 1;
+          cookieValue = `cr_csrf_token=retry-token-${refreshCalls}`;
+          return jsonResponse(200, {
+            ok: true,
+            data: {
+              user: {
+                id: 'u1',
+                email: 'owner@example.com',
+                displayName: 'Owner',
+                role: 'owner',
+              },
+            },
+          });
+        }
+
+        throw new Error(`Unexpected fetch path: ${path}`);
+      },
+    );
+
+    const api = await loadApiModule();
+
+    await expect(api.createTalk('Still Failing')).rejects.toMatchObject({
+      status: 403,
+      code: 'csrf_failed',
+    });
+    expect(refreshCalls).toBe(2);
+    expect(mutationHeaders).toHaveLength(3);
+    expect(mutationHeaders[0]['x-csrf-token']).toBe('test-csrf-token');
+    expect(mutationHeaders[1]['x-csrf-token']).toBe('retry-token-1');
+    expect(mutationHeaders[2]['x-csrf-token']).toBe('retry-token-2');
+    expect(mutationHeaders[0]['idempotency-key']).toBe(
+      mutationHeaders[1]['idempotency-key'],
+    );
+    expect(mutationHeaders[1]['idempotency-key']).toBe(
+      mutationHeaders[2]['idempotency-key'],
+    );
+  });
 });
 
 async function loadApiModule() {
@@ -235,4 +595,13 @@ function jsonResponse(status: number, body: unknown): Response {
       'content-type': 'application/json',
     },
   });
+}
+
+function readHeaders(init?: RequestInit): Record<string, string> {
+  const headers = new Headers(init?.headers);
+  const result: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    result[key] = value;
+  });
+  return result;
 }

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -384,9 +384,9 @@ export async function listTalks(): Promise<Talk[]> {
 }
 
 export async function createTalk(title: string): Promise<Talk> {
-  const envelope = await apiRequest<{ talk: Talk }>('/api/v1/talks', {
+  const envelope = await apiMutationRequest<{ talk: Talk }>('/api/v1/talks', {
     method: 'POST',
-    headers: buildMutationHeaders({ includeJson: true }),
+    includeJson: true,
     body: JSON.stringify({ title }),
   });
   return envelope.talk;
@@ -397,11 +397,11 @@ export async function getTalkSidebar(): Promise<TalkSidebarTree> {
 }
 
 export async function createTalkFolder(title?: string): Promise<TalkSidebarFolder> {
-  const envelope = await apiRequest<{
+  const envelope = await apiMutationRequest<{
     folder: { id: string; title: string; sortOrder: number; talks: TalkSidebarTalk[] };
   }>('/api/v1/talk-folders', {
     method: 'POST',
-    headers: buildMutationHeaders({ includeJson: true }),
+    includeJson: true,
     body: JSON.stringify({ title }),
   });
   return { ...envelope.folder, type: 'folder' };
@@ -411,22 +411,21 @@ export async function patchTalkFolder(input: {
   folderId: string;
   title: string;
 }): Promise<TalkSidebarFolder> {
-  const envelope = await apiRequest<{
+  const envelope = await apiMutationRequest<{
     folder: { id: string; title: string; sortOrder: number; talks: TalkSidebarTalk[] };
   }>(`/api/v1/talk-folders/${encodeURIComponent(input.folderId)}`, {
     method: 'PATCH',
-    headers: buildMutationHeaders({ includeJson: true }),
+    includeJson: true,
     body: JSON.stringify({ title: input.title }),
   });
   return { ...envelope.folder, type: 'folder' };
 }
 
 export async function deleteTalkFolder(folderId: string): Promise<void> {
-  await apiRequest<{ deleted: true }>(
+  await apiMutationRequest<{ deleted: true }>(
     `/api/v1/talk-folders/${encodeURIComponent(folderId)}`,
     {
       method: 'DELETE',
-      headers: buildMutationHeaders({ includeJson: false }),
     },
   );
 }
@@ -436,11 +435,11 @@ export async function patchTalkMetadata(input: {
   title?: string;
   folderId?: string | null;
 }): Promise<Talk> {
-  const envelope = await apiRequest<{ talk: Talk }>(
+  const envelope = await apiMutationRequest<{ talk: Talk }>(
     `/api/v1/talks/${encodeURIComponent(input.talkId)}`,
     {
       method: 'PATCH',
-      headers: buildMutationHeaders({ includeJson: true }),
+      includeJson: true,
       body: JSON.stringify({
         title: input.title,
         folderId: input.folderId,
@@ -451,9 +450,8 @@ export async function patchTalkMetadata(input: {
 }
 
 export async function deleteTalk(talkId: string): Promise<void> {
-  await apiRequest<{ deleted: true }>(`/api/v1/talks/${encodeURIComponent(talkId)}`, {
+  await apiMutationRequest<{ deleted: true }>(`/api/v1/talks/${encodeURIComponent(talkId)}`, {
     method: 'DELETE',
-    headers: buildMutationHeaders({ includeJson: false }),
   });
 }
 
@@ -463,9 +461,9 @@ export async function reorderTalkSidebar(input: {
   destinationFolderId: string | null;
   destinationIndex: number;
 }): Promise<void> {
-  await apiRequest<{ reordered: true }>('/api/v1/talks/sidebar/reorder', {
+  await apiMutationRequest<{ reordered: true }>('/api/v1/talks/sidebar/reorder', {
     method: 'POST',
-    headers: buildMutationHeaders({ includeJson: true }),
+    includeJson: true,
     body: JSON.stringify(input),
   });
 }
@@ -485,11 +483,11 @@ export async function updateTalkPolicy(input: {
   talkId: string;
   agents: string[];
 }): Promise<TalkPolicy> {
-  return apiRequest<TalkPolicy>(
+  return apiMutationRequest<TalkPolicy>(
     `/api/v1/talks/${encodeURIComponent(input.talkId)}/policy`,
     {
       method: 'PUT',
-      headers: buildMutationHeaders({ includeJson: true }),
+      includeJson: true,
       body: JSON.stringify({ agents: input.agents }),
     },
   );
@@ -524,12 +522,12 @@ export async function updateTalkAgents(input: {
   talkId: string;
   agents: TalkAgent[];
 }): Promise<TalkAgent[]> {
-  const envelope = await apiRequest<{
+  const envelope = await apiMutationRequest<{
     talkId: string;
     agents: TalkAgent[];
   }>(`/api/v1/talks/${encodeURIComponent(input.talkId)}/agents`, {
     method: 'PUT',
-    headers: buildMutationHeaders({ includeJson: true }),
+    includeJson: true,
     body: JSON.stringify({ agents: input.agents }),
   });
   return envelope.agents;
@@ -542,9 +540,9 @@ export async function getAiAgents(): Promise<AiAgentsPageData> {
 export async function updateDefaultClaudeModel(
   modelId: string,
 ): Promise<AiAgentsPageData> {
-  return apiRequest<AiAgentsPageData>('/api/v1/agents/default-claude', {
+  return apiMutationRequest<AiAgentsPageData>('/api/v1/agents/default-claude', {
     method: 'PUT',
-    headers: buildMutationHeaders({ includeJson: true }),
+    includeJson: true,
     body: JSON.stringify({ modelId }),
   });
 }
@@ -556,11 +554,11 @@ export async function saveAiProviderCredential(input: {
   baseUrl?: string | null;
   authScheme?: 'x_api_key' | 'bearer';
 }): Promise<AgentProviderCard> {
-  const envelope = await apiRequest<{ provider: AgentProviderCard }>(
+  const envelope = await apiMutationRequest<{ provider: AgentProviderCard }>(
     `/api/v1/agents/providers/${encodeURIComponent(input.providerId)}`,
     {
       method: 'PUT',
-      headers: buildMutationHeaders({ includeJson: true }),
+      includeJson: true,
       body: JSON.stringify(input),
     },
   );
@@ -570,11 +568,10 @@ export async function saveAiProviderCredential(input: {
 export async function verifyAiProviderCredential(
   providerId: string,
 ): Promise<AgentProviderCard> {
-  const envelope = await apiRequest<{ provider: AgentProviderCard }>(
+  const envelope = await apiMutationRequest<{ provider: AgentProviderCard }>(
     `/api/v1/agents/providers/${encodeURIComponent(providerId)}/verify`,
     {
       method: 'POST',
-      headers: buildMutationHeaders({ includeJson: false }),
     },
   );
   return envelope.provider;
@@ -587,9 +584,9 @@ export async function getTalkLlmSettings(): Promise<TalkLlmSettings> {
 export async function updateTalkLlmSettings(
   update: TalkLlmSettingsUpdate,
 ): Promise<TalkLlmSettings> {
-  return apiRequest<TalkLlmSettings>('/api/v1/settings/talk-llm', {
+  return apiMutationRequest<TalkLlmSettings>('/api/v1/settings/talk-llm', {
     method: 'PUT',
-    headers: buildMutationHeaders({ includeJson: true }),
+    includeJson: true,
     body: JSON.stringify(update),
   });
 }
@@ -601,9 +598,9 @@ export async function getExecutorSettings(): Promise<ExecutorSettings> {
 export async function updateExecutorSettings(
   update: ExecutorSettingsUpdate,
 ): Promise<ExecutorSettings> {
-  return apiRequest<ExecutorSettings>('/api/v1/settings/executor', {
+  return apiMutationRequest<ExecutorSettings>('/api/v1/settings/executor', {
     method: 'PUT',
-    headers: buildMutationHeaders({ includeJson: true }),
+    includeJson: true,
     body: JSON.stringify(update),
   });
 }
@@ -617,13 +614,12 @@ export async function verifyExecutorCredentials(): Promise<{
   code: string;
   message: string;
 }> {
-  return apiRequest<{
+  return apiMutationRequest<{
     scheduled: boolean;
     code: string;
     message: string;
   }>('/api/v1/settings/executor/verify', {
     method: 'POST',
-    headers: buildMutationHeaders({ includeJson: false }),
   });
 }
 
@@ -636,11 +632,11 @@ export async function getExecutorSubscriptionHostStatus(): Promise<ExecutorSubsc
 export async function importExecutorSubscriptionFromHost(
   expectedFingerprint: string,
 ): Promise<ExecutorSubscriptionImportResult> {
-  return apiRequest<ExecutorSubscriptionImportResult>(
+  return apiMutationRequest<ExecutorSubscriptionImportResult>(
     '/api/v1/settings/executor/subscription/import',
     {
       method: 'POST',
-      headers: buildMutationHeaders({ includeJson: true }),
+      includeJson: true,
       body: JSON.stringify({
         expectedFingerprint,
       }),
@@ -652,11 +648,10 @@ export async function restartService(): Promise<{
   status: string;
   activeRunCount: number;
 }> {
-  return apiRequest<{ status: string; activeRunCount: number }>(
+  return apiMutationRequest<{ status: string; activeRunCount: number }>(
     '/api/v1/settings/restart',
     {
       method: 'POST',
-      headers: buildMutationHeaders({ includeJson: false }),
     },
   );
 }
@@ -681,11 +676,11 @@ export async function sendTalkMessage(input: {
   content: string;
   targetAgentIds?: string[];
 }): Promise<{ talkId: string; message: TalkMessage; runs: TalkRun[] }> {
-  return apiRequest<{ talkId: string; message: TalkMessage; runs: TalkRun[] }>(
+  return apiMutationRequest<{ talkId: string; message: TalkMessage; runs: TalkRun[] }>(
     `/api/v1/talks/${encodeURIComponent(input.talkId)}/chat`,
     {
       method: 'POST',
-      headers: buildMutationHeaders({ includeJson: true }),
+      includeJson: true,
       body: JSON.stringify({
         content: input.content,
         targetAgentIds: input.targetAgentIds ?? [],
@@ -697,19 +692,17 @@ export async function sendTalkMessage(input: {
 export async function cancelTalkRuns(
   talkId: string,
 ): Promise<{ talkId: string; cancelledRuns: number }> {
-  return apiRequest<{ talkId: string; cancelledRuns: number }>(
+  return apiMutationRequest<{ talkId: string; cancelledRuns: number }>(
     `/api/v1/talks/${encodeURIComponent(talkId)}/chat/cancel`,
     {
       method: 'POST',
-      headers: buildMutationHeaders({ includeJson: false }),
     },
   );
 }
 
 export async function logout(): Promise<void> {
-  await apiRequest<{ loggedOut: boolean }>(AUTH_LOGOUT_PATH, {
+  await apiMutationRequest<{ loggedOut: boolean }>(AUTH_LOGOUT_PATH, {
     method: 'POST',
-    headers: buildMutationHeaders({ includeJson: false }),
   });
 }
 
@@ -718,6 +711,28 @@ async function apiRequest<T>(
   init?: RequestInit,
 ): Promise<T> {
   return apiRequestWithRefresh<T>(path, init, true);
+}
+
+type MutationRequestInit = Omit<RequestInit, 'headers'> & {
+  headers?: HeadersInit;
+  includeJson?: boolean;
+};
+
+type MutationRetryState = {
+  allowAuthRetry: boolean;
+  allowCsrfRetry: boolean;
+  idempotencyKey: string;
+};
+
+async function apiMutationRequest<T>(
+  path: string,
+  init?: MutationRequestInit,
+): Promise<T> {
+  return apiMutationRequestWithRefresh<T>(path, init, {
+    allowAuthRetry: true,
+    allowCsrfRetry: true,
+    idempotencyKey: buildIdempotencyKey(),
+  });
 }
 
 async function apiRequestWithRefresh<T>(
@@ -756,8 +771,68 @@ async function apiRequestWithRefresh<T>(
   return payload.data;
 }
 
+async function apiMutationRequestWithRefresh<T>(
+  path: string,
+  init: MutationRequestInit | undefined,
+  retryState: MutationRetryState,
+): Promise<T> {
+  const response = await fetch(path, {
+    ...init,
+    credentials: 'include',
+    headers: buildMutationAttemptHeaders({
+      includeJson: init?.includeJson === true,
+      explicitHeaders: init?.headers,
+      idempotencyKey: retryState.idempotencyKey,
+    }),
+  });
+
+  if (response.status === 401) {
+    if (retryState.allowAuthRetry && !shouldSkipRefresh(path)) {
+      const refreshed = await ensureRefreshedSession();
+      if (refreshed) {
+        return apiMutationRequestWithRefresh<T>(path, init, {
+          ...retryState,
+          allowAuthRetry: false,
+        });
+      }
+    }
+    throw new UnauthorizedError();
+  }
+
+  const payload = (await response.json()) as ApiEnvelope<T>;
+
+  if (
+    response.status === 403 &&
+    !payload.ok &&
+    payload.error?.code === 'csrf_failed' &&
+    retryState.allowCsrfRetry &&
+    !shouldSkipRefresh(path)
+  ) {
+    const refreshed = await ensureRefreshedSession();
+    if (refreshed) {
+      return apiMutationRequestWithRefresh<T>(path, init, {
+        ...retryState,
+        allowAuthRetry: false,
+        allowCsrfRetry: false,
+      });
+    }
+  }
+
+  if (!response.ok || !payload.ok) {
+    const message =
+      !payload.ok && payload.error?.message
+        ? payload.error.message
+        : `Request failed with status ${response.status}`;
+    const code = !payload.ok ? payload.error?.code : undefined;
+    throw new ApiError(message, response.status, code);
+  }
+  return payload.data;
+}
+
 function shouldSkipRefresh(path: string): boolean {
   const normalizedPath = path.split('?')[0];
+  // Logout intentionally skips refresh-based recovery so we never revive the
+  // same session the user is actively trying to end.
   return (
     normalizedPath === AUTH_REFRESH_PATH || normalizedPath === AUTH_LOGOUT_PATH
   );
@@ -793,14 +868,35 @@ async function ensureRefreshedSession(): Promise<boolean> {
   }
 }
 
-function buildMutationHeaders(input: { includeJson: boolean }): HeadersInit {
-  const headers: Record<string, string> = {
-    'x-csrf-token': getCsrfTokenFromCookie() || '',
-    'idempotency-key': buildIdempotencyKey(),
-  };
-  if (input.includeJson) {
-    headers['content-type'] = 'application/json';
+function buildMutationAttemptHeaders(input: {
+  includeJson: boolean;
+  explicitHeaders?: HeadersInit;
+  idempotencyKey: string;
+}): HeadersInit {
+  const headers = new Headers();
+  headers.set('accept', 'application/json');
+
+  if (input.explicitHeaders) {
+    const explicitHeaders = new Headers(input.explicitHeaders);
+    explicitHeaders.forEach((value, key) => {
+      headers.set(key, value);
+    });
   }
+
+  if (input.includeJson && !headers.has('content-type')) {
+    headers.set('content-type', 'application/json');
+  }
+
+  // Caller headers may supply generic metadata, but CSRF and idempotency are
+  // always owned by this wrapper and written last from current cookie state.
+  const csrfToken = getCsrfTokenFromCookie();
+  if (csrfToken) {
+    headers.set('x-csrf-token', csrfToken);
+  } else {
+    headers.delete('x-csrf-token');
+  }
+
+  headers.set('idempotency-key', input.idempotencyKey);
   return headers;
 }
 


### PR DESCRIPTION
## Summary
- fix mutation failures caused by stale or missing CSRF headers in the shared web API client
- rebuild mutation headers on every send attempt so 401 refresh retries use the current CSRF cookie
- add a single retry path for `403 csrf_failed` mutation failures
- keep the fix global so all mutation requests benefit, not just talk-agent saves

## What Changed
- added a dedicated `apiMutationRequest()` path in:
  - `webapp/src/lib/api.ts`
- removed eager mutation header construction at call sites
- mutation requests now:
  - generate one idempotency key per logical mutation
  - rebuild `x-csrf-token` from the current cookie before each fetch attempt
  - rebuild headers after `401 -> refresh -> retry`
  - retry once on `403 csrf_failed` with fresh headers
- kept logout special-cased so it does not try to refresh the session it is ending
- added comments clarifying that the wrapper owns CSRF/idempotency headers

## Tests
- updated:
  - `webapp/src/lib/api.test.ts`
- added coverage for:
  - normal mutation success
  - `401 -> refresh -> retry` with fresh CSRF headers
  - `403 csrf_failed -> refresh -> retry`
  - concurrent mutations sharing a single refresh
  - non-CSRF `403` not retried
  - worst-case retry ceiling behavior

## Validation
- `npm --prefix webapp run test -- --run src/lib/api.test.ts`
- `npm --prefix webapp run typecheck`
- `npm --prefix webapp run test`

## Notes
- this patch does not add duplicate-agent validation
- no backend API shape changed; the fix is confined to the shared frontend mutation client
