### PR TITLE
Backfill known model tool support

### DIFF
--- a/src/clawrocket/db/llm-accessors.test.ts
+++ b/src/clawrocket/db/llm-accessors.test.ts
@@ -16,6 +16,7 @@ import {
   listClaudeModelSuggestions,
   listTalkLlmSettingsSnapshot,
   replaceTalkLlmSettingsSnapshot,
+  syncKnownProviderModels,
   upsertKnownProviderCredential,
 } from './llm-accessors.js';
 
@@ -229,5 +230,54 @@ describe('registered agent accessors', () => {
         }),
       ]),
     );
+  });
+
+  it('backfills supportsTools for legacy known provider model rows on startup sync', () => {
+    getDb()
+      .prepare(
+        `
+        INSERT INTO llm_provider_models (
+          provider_id,
+          model_id,
+          display_name,
+          context_window_tokens,
+          default_max_output_tokens,
+          supports_tools,
+          enabled,
+          updated_at,
+          updated_by
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+      )
+      .run(
+        'provider.anthropic',
+        'claude-opus-4-6',
+        'Claude Opus 4.6',
+        200000,
+        4096,
+        0,
+        0,
+        new Date().toISOString(),
+        null,
+      );
+
+    syncKnownProviderModels();
+
+    const row = getDb()
+      .prepare(
+        `
+        SELECT supports_tools, enabled
+        FROM llm_provider_models
+        WHERE provider_id = ? AND model_id = ?
+      `,
+      )
+      .get('provider.anthropic', 'claude-opus-4-6') as
+      | { supports_tools: number; enabled: number }
+      | undefined;
+
+    expect(row).toEqual({
+      supports_tools: 1,
+      enabled: 0,
+    });
   });
 });

--- a/src/clawrocket/db/llm-accessors.ts
+++ b/src/clawrocket/db/llm-accessors.ts
@@ -834,6 +834,49 @@ export function listKnownProviderCredentialCards(): AgentProviderCardSnapshot[] 
   });
 }
 
+export function syncKnownProviderModels(updatedAt?: string): void {
+  const now = normalizeTimestamp(updatedAt);
+  const tx = getDb().transaction(() => {
+    const upsertModel = getDb().prepare(
+      `
+      INSERT INTO llm_provider_models (
+        provider_id, model_id, display_name, context_window_tokens,
+        default_max_output_tokens, supports_tools, enabled, updated_at, updated_by
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+      ON CONFLICT(provider_id, model_id) DO UPDATE SET
+        display_name = excluded.display_name,
+        context_window_tokens = excluded.context_window_tokens,
+        default_max_output_tokens = excluded.default_max_output_tokens,
+        supports_tools = excluded.supports_tools,
+        enabled = excluded.enabled,
+        updated_at = excluded.updated_at,
+        updated_by = excluded.updated_by
+    `,
+    );
+
+    for (const template of KNOWN_PROVIDER_CATALOG) {
+      const provider = getLlmProviderById(template.id);
+      if (!provider) continue;
+
+      for (const suggestion of template.modelSuggestions) {
+        const existing = getLlmProviderModel(template.id, suggestion.modelId);
+        upsertModel.run(
+          template.id,
+          suggestion.modelId,
+          suggestion.displayName,
+          suggestion.contextWindowTokens,
+          suggestion.defaultMaxOutputTokens,
+          suggestion.supportsTools ? 1 : 0,
+          existing?.enabled ?? 1,
+          now,
+        );
+      }
+    }
+  });
+
+  tx();
+}
+
 export function upsertKnownProviderCredential(input: {
   providerId: string;
   credential: ProviderSecretPayload | null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,10 @@ import {
   storeChatMetadata,
   storeMessage,
 } from './db.js';
-import { initClawrocketSchema } from './clawrocket/db/index.js';
+import {
+  initClawrocketSchema,
+  syncKnownProviderModels,
+} from './clawrocket/db/index.js';
 import { registerClawrocketSchedulerMaintenanceHook } from './clawrocket/scheduler-maintenance.js';
 import { GroupQueue } from './group-queue.js';
 import { resolveGroupFolderPath } from './group-folder.js';
@@ -569,6 +572,7 @@ async function main(): Promise<void> {
     initDatabase();
     // ClawRocket integration seam: initialize ClawRocket schema in shared DB.
     initClawrocketSchema();
+    syncKnownProviderModels();
     // ClawRocket integration seam: register scheduler maintenance callbacks.
     registerClawrocketSchedulerMaintenanceHook();
     logger.info('Database initialized');


### PR DESCRIPTION
## Summary

- backfill supports_tools metadata for known built-in provider model rows at startup
- ensure legacy Anthropic model rows become tool-capable without requiring a manual Talk LLM settings resave
- add a regression test covering legacy rows with stale supports_tools = 0

## Testing

- `npm run typecheck`
- `npm test -- src/clawrocket/db/llm-accessors.test.ts src/clawrocket/talks/direct-executor.test.ts`
