### PR TITLE
fix(container): refresh stale web-talk runner source

### DIFF
--- a/src/container-runner.test.ts
+++ b/src/container-runner.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
 import { PassThrough } from 'stream';
+import fs from 'fs';
 
 // Sentinel markers must match container-runner.ts
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
@@ -41,6 +42,7 @@ vi.mock('fs', async () => {
       readdirSync: vi.fn(() => []),
       statSync: vi.fn(() => ({ isDirectory: () => false })),
       copyFileSync: vi.fn(),
+      cpSync: vi.fn(),
     },
   };
 });
@@ -114,6 +116,9 @@ describe('container-runner timeout behavior', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     fakeProc = createFakeProcess();
+    vi.mocked(fs.existsSync).mockReset();
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.cpSync).mockReset();
   });
 
   afterEach(() => {
@@ -205,5 +210,50 @@ describe('container-runner timeout behavior', () => {
     const result = await resultPromise;
     expect(result.status).toBe('success');
     expect(result.newSessionId).toBe('session-456');
+  });
+
+  it('refreshes the web-talk agent runner source even when a cached copy exists', async () => {
+    const projectRoot = process.cwd();
+    const agentRunnerSrc = `${projectRoot}/container/agent-runner/src`;
+    const groupRunnerDst =
+      '/tmp/nanoclaw-test-data/sessions/test-group/agent-runner-src';
+
+    vi.mocked(fs.existsSync).mockImplementation((targetPath) => {
+      const normalized =
+        typeof targetPath === 'string' ? targetPath : String(targetPath);
+      if (
+        normalized === agentRunnerSrc ||
+        normalized === groupRunnerDst ||
+        normalized === '/tmp/nanoclaw-test-groups/test-group'
+      ) {
+        return true;
+      }
+      return false;
+    });
+
+    const resultPromise = runContainerAgent(
+      testGroup,
+      {
+        ...testInput,
+        toolProfile: 'web_talk',
+      },
+      () => {},
+    );
+
+    emitOutputMarker(fakeProc, {
+      status: 'success',
+      result: 'Synced runner',
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    fakeProc.emit('close', 0);
+    await vi.advanceTimersByTimeAsync(10);
+
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'success',
+    });
+    expect(fs.cpSync).toHaveBeenCalledWith(agentRunnerSrc, groupRunnerDst, {
+      recursive: true,
+      force: true,
+    });
   });
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -99,6 +99,7 @@ interface VolumeMount {
 function buildVolumeMounts(
   group: RegisteredGroup,
   isMain: boolean,
+  syncAgentRunnerSource = false,
 ): VolumeMount[] {
   const mounts: VolumeMount[] = [];
   const projectRoot = process.cwd();
@@ -230,8 +231,14 @@ function buildVolumeMounts(
     group.folder,
     'agent-runner-src',
   );
-  if (!fs.existsSync(groupAgentRunnerDir) && fs.existsSync(agentRunnerSrc)) {
-    fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, { recursive: true });
+  if (
+    fs.existsSync(agentRunnerSrc) &&
+    (syncAgentRunnerSource || !fs.existsSync(groupAgentRunnerDir))
+  ) {
+    fs.cpSync(agentRunnerSrc, groupAgentRunnerDir, {
+      recursive: true,
+      force: true,
+    });
   }
   mounts.push({
     hostPath: groupAgentRunnerDir,
@@ -303,7 +310,11 @@ export async function runContainerAgent(
   const groupDir = resolveGroupFolderPath(group.folder);
   fs.mkdirSync(groupDir, { recursive: true });
 
-  const mounts = buildVolumeMounts(group, input.isMain);
+  const mounts = buildVolumeMounts(
+    group,
+    input.isMain,
+    input.toolProfile === 'web_talk',
+  );
   const safeName = group.folder.replace(/[^a-zA-Z0-9-]/g, '-');
   const containerName = `nanoclaw-${safeName}-${Date.now()}`;
   const containerArgs = buildContainerArgs(mounts, containerName);


### PR DESCRIPTION
## Summary

- refresh the copied `agent-runner-src` for `web_talk` runs so newly merged connector MCP changes are actually picked up by the web-talk container
- add a regression test covering the cached runner-copy case for the `web-talks` group
- follow up on PR #55 without reintroducing any of the already-merged subscription-mode commits

## Testing

- `npm run typecheck`
- `npm --prefix container/agent-runner run build`
- `npm test -- src/container-runner.test.ts src/clawrocket/talks/direct-executor.test.ts`
