### PR TITLE
fix(webapp): keep sidebar menus in view

### DIFF
--- a/webapp/src/components/ClawTalkSidebar.test.tsx
+++ b/webapp/src/components/ClawTalkSidebar.test.tsx
@@ -1,0 +1,138 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+import { ClawTalkSidebar } from './ClawTalkSidebar';
+import type { Talk, TalkSidebarFolder, TalkSidebarItem } from '../lib/api';
+
+function buildTalk(): Talk {
+  return {
+    id: 'talk-created',
+    ownerId: 'owner-1',
+    title: 'Created Talk',
+    agents: [],
+    status: 'active',
+    folderId: null,
+    sortOrder: 0,
+    version: 1,
+    createdAt: '2026-03-09T00:00:00.000Z',
+    updatedAt: '2026-03-09T00:00:00.000Z',
+    accessRole: 'owner',
+  };
+}
+
+function buildFolder(): TalkSidebarFolder {
+  return {
+    type: 'folder',
+    id: 'folder-created',
+    title: 'Created Folder',
+    sortOrder: 0,
+    talks: [],
+  };
+}
+
+function rect(input: Partial<DOMRect> = {}): DOMRect {
+  return {
+    x: input.left ?? 0,
+    y: input.top ?? 0,
+    top: input.top ?? 0,
+    left: input.left ?? 0,
+    right: input.right ?? 0,
+    bottom: input.bottom ?? 0,
+    width: input.width ?? 0,
+    height: input.height ?? 0,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+describe('ClawTalkSidebar', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders menus in a portal and repositions them above the trigger when needed', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+      this: HTMLElement,
+    ) {
+      const element = this;
+      if (element.getAttribute('aria-label') === 'Manage D1 Retro') {
+        return rect({
+          top: 560,
+          bottom: 592,
+          left: 230,
+          right: 262,
+          width: 32,
+          height: 32,
+        });
+      }
+      if (element.classList.contains('clawtalk-sidebar-menu-portal')) {
+        return rect({
+          top: 0,
+          bottom: 180,
+          left: 0,
+          right: 170,
+          width: 170,
+          height: 180,
+        });
+      }
+      return rect({ width: 100, height: 32, right: 100, bottom: 32 });
+    });
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 300,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 640,
+    });
+
+    const items: TalkSidebarItem[] = [
+      {
+        type: 'talk',
+        id: 'talk-1',
+        title: 'D1 Retro',
+        status: 'active',
+        sortOrder: 0,
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <ClawTalkSidebar
+          items={items}
+          loading={false}
+          error={null}
+          userRole="owner"
+          canManageSettings={true}
+          onCreateTalk={vi.fn(async () => buildTalk())}
+          onCreateFolder={vi.fn(async () => buildFolder())}
+          onRenameTalk={vi.fn()}
+          onPatchTalk={vi.fn(async () => undefined)}
+          onDeleteTalk={vi.fn(async () => undefined)}
+          onRenameFolder={vi.fn(async () => undefined)}
+          onDeleteFolder={vi.fn(async () => undefined)}
+          onReorder={vi.fn()}
+          renameDraft={null}
+        />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Manage D1 Retro' }));
+
+    await waitFor(() => {
+      const menu = document.body.querySelector('.clawtalk-sidebar-menu-portal');
+      expect(menu).toBeTruthy();
+      expect(menu).toHaveStyle({
+        top: '374px',
+        left: '92px',
+        maxHeight: '542px',
+      });
+    });
+
+    expect(screen.getByRole('button', { name: 'Rename Talk' })).toBeTruthy();
+  });
+});

--- a/webapp/src/components/ClawTalkSidebar.tsx
+++ b/webapp/src/components/ClawTalkSidebar.tsx
@@ -10,7 +10,16 @@ import {
   useSensors,
 } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
-import { FormEvent, KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  FormEvent,
+  KeyboardEvent,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
 import { NavLink } from 'react-router-dom';
 
 import type { Talk, TalkSidebarFolder, TalkSidebarItem } from '../lib/api';
@@ -19,6 +28,12 @@ type RenameDraft = {
   talkId: string;
   draft: string;
 } | null;
+
+type MenuPosition = {
+  top: number;
+  left: number;
+  maxHeight: number;
+};
 
 type Props = {
   items: TalkSidebarItem[];
@@ -188,7 +203,11 @@ export function ClawTalkSidebar({
   const [renamingFolderId, setRenamingFolderId] = useState<string | null>(null);
   const [folderDrafts, setFolderDrafts] = useState<Record<string, string>>({});
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const createMenuButtonRef = useRef<HTMLButtonElement | null>(null);
+  const talkMenuButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const folderMenuButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
 
   useEffect(() => {
@@ -214,7 +233,98 @@ export function ClawTalkSidebar({
     return () => window.removeEventListener('mousedown', handlePointerDown);
   }, [menuState]);
 
+  useLayoutEffect(() => {
+    if (!menuState) {
+      setMenuPosition(null);
+      return;
+    }
+
+    const getMenuAnchor = (): HTMLButtonElement | null => {
+      if (menuState.type === 'create') return createMenuButtonRef.current;
+      if (menuState.type === 'talk') return talkMenuButtonRefs.current[menuState.talkId] ?? null;
+      return folderMenuButtonRefs.current[menuState.folderId] ?? null;
+    };
+
+    const updateMenuPosition = () => {
+      const anchor = getMenuAnchor();
+      const menu = menuRef.current;
+      if (!anchor || !menu) return;
+
+      const viewportPadding = 12;
+      const offset = 6;
+      const anchorRect = anchor.getBoundingClientRect();
+      const menuRect = menu.getBoundingClientRect();
+      const menuWidth = Math.min(
+        Math.max(menuRect.width, 170),
+        window.innerWidth - viewportPadding * 2,
+      );
+      const menuHeight = Math.max(menuRect.height, 0);
+      const belowTop = anchorRect.bottom + offset;
+      const belowSpace = window.innerHeight - belowTop - viewportPadding;
+      const aboveSpace = anchorRect.top - offset - viewportPadding;
+      const openAbove = belowSpace < menuHeight && aboveSpace > belowSpace;
+      const maxHeight = Math.max(
+        120,
+        Math.floor(openAbove ? aboveSpace : belowSpace),
+      );
+      const left = Math.max(
+        viewportPadding,
+        Math.min(
+          anchorRect.right - menuWidth,
+          window.innerWidth - menuWidth - viewportPadding,
+        ),
+      );
+      const top = openAbove
+        ? Math.max(
+            viewportPadding,
+            anchorRect.top - offset - Math.min(menuHeight || maxHeight, maxHeight),
+          )
+        : Math.min(
+            belowTop,
+            window.innerHeight -
+              viewportPadding -
+              Math.min(menuHeight || maxHeight, maxHeight),
+          );
+
+      setMenuPosition({
+        top: Math.round(top),
+        left: Math.round(left),
+        maxHeight,
+      });
+    };
+
+    updateMenuPosition();
+    window.addEventListener('resize', updateMenuPosition);
+    window.addEventListener('scroll', updateMenuPosition, true);
+    return () => {
+      window.removeEventListener('resize', updateMenuPosition);
+      window.removeEventListener('scroll', updateMenuPosition, true);
+    };
+  }, [menuState]);
+
   const moveTargets = useMemo(() => buildMoveTargets(items), [items]);
+
+  const renderMenu = (children: React.ReactNode) => {
+    if (typeof document === 'undefined') return null;
+    return createPortal(
+      <div
+        className="clawtalk-sidebar-menu clawtalk-sidebar-menu-portal"
+        ref={menuRef}
+        style={
+          menuPosition
+            ? {
+                top: `${menuPosition.top}px`,
+                left: `${menuPosition.left}px`,
+                maxHeight: `${menuPosition.maxHeight}px`,
+              }
+            : { visibility: 'hidden' }
+        }
+      >
+        {children}
+      </div>,
+      document.body,
+    );
+  };
 
   const handleCreateTalkClick = async () => {
     setMenuState(null);
@@ -352,6 +462,9 @@ export function ClawTalkSidebar({
               <button
                 type="button"
                 className="clawtalk-sidebar-more"
+                ref={(node) => {
+                  talkMenuButtonRefs.current[talk.id] = node;
+                }}
                 aria-label={`Manage ${talk.title || 'Untitled talk'}`}
                 onClick={() =>
                   setMenuState((current) =>
@@ -364,45 +477,47 @@ export function ClawTalkSidebar({
                 …
               </button>
               {menuOpen ? (
-                <div className="clawtalk-sidebar-menu" ref={menuRef}>
-                  <button type="button" onClick={() => onRenameTalk(talk.id, talk.title)}>
-                    Rename Talk
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      setMenuState({ type: 'talk', talkId: talk.id, moveOpen: !moveOpen })
-                    }
-                  >
-                    Move To
-                  </button>
-                  {moveOpen ? (
-                    <div className="clawtalk-sidebar-submenu">
-                      {moveTargets.map((target) => (
-                        <button
-                          key={target.id || 'top-level'}
-                          type="button"
-                          onClick={async () => {
-                            setMenuState(null);
-                            await onPatchTalk({ talkId: talk.id, folderId: target.id });
-                          }}
-                        >
-                          {target.label}
-                        </button>
-                      ))}
-                    </div>
-                  ) : null}
-                  <button
-                    type="button"
-                    className="danger"
-                    onClick={async () => {
-                      setMenuState(null);
-                      await onDeleteTalk(talk.id);
-                    }}
-                  >
-                    Delete Talk
-                  </button>
-                </div>
+                renderMenu(
+                  <>
+                    <button type="button" onClick={() => onRenameTalk(talk.id, talk.title)}>
+                      Rename Talk
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setMenuState({ type: 'talk', talkId: talk.id, moveOpen: !moveOpen })
+                      }
+                    >
+                      Move To
+                    </button>
+                    {moveOpen ? (
+                      <div className="clawtalk-sidebar-submenu">
+                        {moveTargets.map((target) => (
+                          <button
+                            key={target.id || 'top-level'}
+                            type="button"
+                            onClick={async () => {
+                              setMenuState(null);
+                              await onPatchTalk({ talkId: talk.id, folderId: target.id });
+                            }}
+                          >
+                            {target.label}
+                          </button>
+                        ))}
+                      </div>
+                    ) : null}
+                    <button
+                      type="button"
+                      className="danger"
+                      onClick={async () => {
+                        setMenuState(null);
+                        await onDeleteTalk(talk.id);
+                      }}
+                    >
+                      Delete Talk
+                    </button>
+                  </>,
+                )
               ) : null}
             </div>
           </div>
@@ -485,6 +600,9 @@ export function ClawTalkSidebar({
                 <button
                   type="button"
                   className="clawtalk-sidebar-more"
+                  ref={(node) => {
+                    folderMenuButtonRefs.current[folder.id] = node;
+                  }}
                   aria-label={`Manage ${folder.title || 'Untitled folder'}`}
                   onClick={() =>
                     setMenuState((current) =>
@@ -497,35 +615,37 @@ export function ClawTalkSidebar({
                   …
                 </button>
                 {menuOpen ? (
-                  <div className="clawtalk-sidebar-menu" ref={menuRef}>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setMenuState(null);
-                        setRenamingFolderId(folder.id);
-                        setFolderDrafts((current) => ({
-                          ...current,
-                          [folder.id]: folder.title,
-                        }));
-                      }}
-                    >
-                      Rename Folder
-                    </button>
-                    <button
-                      type="button"
-                      className="danger"
-                      onClick={async () => {
-                        setMenuState(null);
-                        const confirmed = window.confirm(
-                          `Delete "${folder.title || 'Untitled folder'}"? Its talks will be moved to Top Level.`,
-                        );
-                        if (!confirmed) return;
-                        await onDeleteFolder(folder.id);
-                      }}
-                    >
-                      Delete Folder
-                    </button>
-                  </div>
+                  renderMenu(
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setMenuState(null);
+                          setRenamingFolderId(folder.id);
+                          setFolderDrafts((current) => ({
+                            ...current,
+                            [folder.id]: folder.title,
+                          }));
+                        }}
+                      >
+                        Rename Folder
+                      </button>
+                      <button
+                        type="button"
+                        className="danger"
+                        onClick={async () => {
+                          setMenuState(null);
+                          const confirmed = window.confirm(
+                            `Delete "${folder.title || 'Untitled folder'}"? Its talks will be moved to Top Level.`,
+                          );
+                          if (!confirmed) return;
+                          await onDeleteFolder(folder.id);
+                        }}
+                      >
+                        Delete Folder
+                      </button>
+                    </>,
+                  )
                 ) : null}
               </div>
             </div>
@@ -608,6 +728,7 @@ export function ClawTalkSidebar({
             <button
               type="button"
               className="clawtalk-sidebar-add"
+              ref={createMenuButtonRef}
               aria-label="Create talk or folder"
               onClick={() =>
                 setMenuState((current) => (current?.type === 'create' ? null : { type: 'create' }))
@@ -616,14 +737,16 @@ export function ClawTalkSidebar({
               +
             </button>
             {menuState?.type === 'create' ? (
-              <div className="clawtalk-sidebar-menu" ref={menuRef}>
-                <button type="button" onClick={() => void handleCreateTalkClick()}>
-                  New Talk
-                </button>
-                <button type="button" onClick={() => void handleCreateFolderClick()}>
-                  New Folder
-                </button>
-              </div>
+              renderMenu(
+                <>
+                  <button type="button" onClick={() => void handleCreateTalkClick()}>
+                    New Talk
+                  </button>
+                  <button type="button" onClick={() => void handleCreateFolderClick()}>
+                    New Folder
+                  </button>
+                </>,
+              )
             ) : null}
           </div>
         </div>

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -327,9 +327,6 @@ a {
 
 .clawtalk-sidebar-menu,
 .clawtalk-sidebar-submenu {
-  position: absolute;
-  right: 0;
-  top: calc(100% + 0.35rem);
   z-index: 10;
   min-width: 170px;
   display: grid;
@@ -339,6 +336,23 @@ a {
   border-radius: 12px;
   background: #fff;
   box-shadow: 0 12px 28px rgba(31, 52, 88, 0.14);
+}
+
+.clawtalk-sidebar-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.35rem);
+}
+
+.clawtalk-sidebar-menu-portal {
+  position: fixed;
+  right: auto;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  overflow-y: auto;
+  min-width: min(170px, calc(100vw - 24px));
+  max-width: calc(100vw - 24px);
 }
 
 .clawtalk-sidebar-submenu {


### PR DESCRIPTION
## Summary
- render sidebar create/talk/folder menus in a body portal so they are not clipped by the sidebar panel or talk list scroller
- clamp menu position and height to the viewport so options stay reachable near the bottom edge
- add a sidebar regression test for the near-bottom menu case

## Testing
- npm test -- src/components/ClawTalkSidebar.test.tsx
- npm run typecheck