### PR TITLE
feat(talks): add talk history edit mode

### DIFF
--- a/src/clawrocket/db/accessors.ts
+++ b/src/clawrocket/db/accessors.ts
@@ -1538,6 +1538,85 @@ export function getTalkMessageById(
     .get(messageId) as TalkMessageRecord | undefined;
 }
 
+export function deleteTalkMessagesAtomic(input: {
+  talkId: string;
+  messageIds: string[];
+  now?: string;
+}): { deletedCount: number; deletedMessageIds: string[] } {
+  const normalizedIds = Array.from(
+    new Set(
+      input.messageIds
+        .map((messageId) => messageId.trim())
+        .filter((messageId) => messageId.length > 0),
+    ),
+  );
+
+  const tx = getDb().transaction(
+    (
+      txInput: typeof input,
+      ids: string[],
+    ): { deletedCount: number; deletedMessageIds: string[] } => {
+      if (ids.length === 0) {
+        throw new Error('talk history edit requires at least one message');
+      }
+      if (hasActiveTalkRuns(txInput.talkId)) {
+        throw new Error('talk already has an active round');
+      }
+
+      const placeholders = ids.map(() => '?').join(', ');
+      const rows = getDb()
+        .prepare(
+          `
+          SELECT id, role
+          FROM talk_messages
+          WHERE talk_id = ?
+            AND id IN (${placeholders})
+        `,
+        )
+        .all(txInput.talkId, ...ids) as Array<{
+        id: string;
+        role: TalkMessageRole;
+      }>;
+
+      if (rows.length !== ids.length) {
+        throw new Error('one or more talk messages were not found');
+      }
+      if (rows.some((row) => row.role === 'system')) {
+        throw new Error('system messages cannot be deleted');
+      }
+
+      const now = txInput.now || new Date().toISOString();
+      getDb()
+        .prepare(
+          `
+          DELETE FROM talk_messages
+          WHERE talk_id = ?
+            AND id IN (${placeholders})
+        `,
+        )
+        .run(txInput.talkId, ...ids);
+
+      // Reset cached executor session so future runs do not retain deleted context.
+      deleteTalkExecutorSession(txInput.talkId);
+      touchTalkUpdatedAt(txInput.talkId, now);
+      appendOutboxEvent({
+        topic: `talk:${txInput.talkId}`,
+        eventType: 'talk_history_edited',
+        payload: JSON.stringify({
+          talkId: txInput.talkId,
+          deletedCount: ids.length,
+          deletedMessageIds: ids,
+          editedAt: now,
+        }),
+      });
+
+      return { deletedCount: ids.length, deletedMessageIds: ids };
+    },
+  );
+
+  return tx(input, normalizedIds);
+}
+
 export function enqueueTalkTurnAtomic(input: {
   talkId: string;
   userId: string;

--- a/src/clawrocket/web/routes/talks.test.ts
+++ b/src/clawrocket/web/routes/talks.test.ts
@@ -6,12 +6,15 @@ import {
   createTalkRun,
   getQueuedTalkRuns,
   getRunningTalkRun,
+  getTalkExecutorSession,
   upsertTalk,
+  upsertTalkExecutorSession,
   upsertTalkLlmPolicy,
   upsertTalkMember,
   upsertUser,
   upsertWebSession,
 } from '../../db/index.js';
+import { computeSessionCompatKey } from '../../talks/executor-settings.js';
 import { hashSessionToken } from '../../identity/session.js';
 import { _resetRateLimitStateForTests } from '../middleware/rate-limit.js';
 import { createWebServer, WebServerHandle } from '../server.js';
@@ -645,6 +648,119 @@ describe('talk routes', () => {
         displaySummary: 'Checking FTUE funnel',
       },
     });
+  });
+
+  it('deletes selected talk messages and clears the cached executor session', async () => {
+    createTalkMessage({
+      id: 'msg-edit-1',
+      talkId: 'talk-owner',
+      role: 'user',
+      content: 'Remove me',
+      createdBy: 'owner-1',
+      createdAt: '2026-03-07T01:00:00.000Z',
+    });
+    createTalkMessage({
+      id: 'msg-edit-2',
+      talkId: 'talk-owner',
+      role: 'assistant',
+      content: 'Remove me too',
+      createdBy: null,
+      createdAt: '2026-03-07T01:00:01.000Z',
+    });
+    createTalkMessage({
+      id: 'msg-edit-3',
+      talkId: 'talk-owner',
+      role: 'user',
+      content: 'Keep me',
+      createdBy: 'owner-1',
+      createdAt: '2026-03-07T01:00:02.000Z',
+    });
+    upsertTalkExecutorSession({
+      talkId: 'talk-owner',
+      sessionId: 'session-edit-1',
+      executorAlias: 'Claude',
+      executorModel: 'claude-sonnet-4-6',
+      sessionCompatKey: computeSessionCompatKey('Claude', 'claude-sonnet-4-6'),
+      updatedAt: '2026-03-07T01:00:03.000Z',
+    });
+
+    const res = await server.request(
+      '/api/v1/talks/talk-owner/messages/delete',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer owner-token',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ messageIds: ['msg-edit-1', 'msg-edit-2'] }),
+      },
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.ok).toBe(true);
+    expect(body.data).toMatchObject({
+      talkId: 'talk-owner',
+      deletedCount: 2,
+      deletedMessageIds: ['msg-edit-1', 'msg-edit-2'],
+    });
+    expect(getTalkExecutorSession('talk-owner')).toBeUndefined();
+
+    const messagesRes = await server.request(
+      '/api/v1/talks/talk-owner/messages',
+      {
+        headers: {
+          Authorization: 'Bearer owner-token',
+        },
+      },
+    );
+    const messagesBody = (await messagesRes.json()) as any;
+    expect(
+      messagesBody.data.messages.map((message: any) => message.id),
+    ).toEqual(['msg-edit-3']);
+  });
+
+  it('rejects history edits while a talk round is active', async () => {
+    createTalkMessage({
+      id: 'msg-edit-active',
+      talkId: 'talk-owner',
+      role: 'user',
+      content: 'Still here',
+      createdBy: 'owner-1',
+      createdAt: '2026-03-07T01:10:00.000Z',
+    });
+    createTalkRun({
+      id: 'run-edit-active',
+      talk_id: 'talk-owner',
+      requested_by: 'owner-1',
+      status: 'queued',
+      trigger_message_id: 'msg-edit-active',
+      target_agent_id: null,
+      idempotency_key: null,
+      executor_alias: null,
+      executor_model: null,
+      created_at: '2026-03-07T01:10:01.000Z',
+      started_at: null,
+      ended_at: null,
+      cancel_reason: null,
+    });
+
+    const res = await server.request(
+      '/api/v1/talks/talk-owner/messages/delete',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer owner-token',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ messageIds: ['msg-edit-active'] }),
+      },
+    );
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as any;
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('talk_active_round');
   });
 
   it('requires editor permission to enqueue chat', async () => {

--- a/src/clawrocket/web/routes/talks.ts
+++ b/src/clawrocket/web/routes/talks.ts
@@ -7,6 +7,7 @@ import {
   deleteTalkFolderAndMoveTalksToTopLevel,
   deleteTalkForOwner,
   deleteTalkLlmPolicy,
+  deleteTalkMessagesAtomic,
   enqueueTalkTurnAtomic,
   ensureTalkHasDefaultAgent,
   getPrimaryTalkAgent,
@@ -1275,6 +1276,142 @@ export function listTalkMessagesRoute(input: {
       },
     },
   };
+}
+
+export function deleteTalkMessagesRoute(input: {
+  talkId: string;
+  auth: AuthContext;
+  messageIds: string[];
+}): {
+  statusCode: number;
+  body: ApiEnvelope<{
+    talkId: string;
+    deletedCount: number;
+    deletedMessageIds: string[];
+  }>;
+} {
+  const talk = getTalkForUser(input.talkId, input.auth.userId);
+  if (!talk) {
+    return {
+      statusCode: 404,
+      body: {
+        ok: false,
+        error: {
+          code: 'talk_not_found',
+          message: 'Talk not found',
+        },
+      },
+    };
+  }
+  if (!canEditTalk(input.talkId, input.auth.userId, input.auth.role)) {
+    return {
+      statusCode: 403,
+      body: {
+        ok: false,
+        error: { code: 'forbidden', message: 'Talk is read-only' },
+      },
+    };
+  }
+
+  const normalizedIds = Array.from(
+    new Set(
+      input.messageIds
+        .map((messageId) => messageId.trim())
+        .filter((messageId) => messageId.length > 0),
+    ),
+  );
+  if (normalizedIds.length === 0) {
+    return {
+      statusCode: 400,
+      body: {
+        ok: false,
+        error: {
+          code: 'invalid_message_ids',
+          message: 'Select at least one message to delete.',
+        },
+      },
+    };
+  }
+  if (normalizedIds.length > 200) {
+    return {
+      statusCode: 400,
+      body: {
+        ok: false,
+        error: {
+          code: 'too_many_message_ids',
+          message: 'Delete at most 200 messages at a time.',
+        },
+      },
+    };
+  }
+
+  try {
+    const deleted = deleteTalkMessagesAtomic({
+      talkId: input.talkId,
+      messageIds: normalizedIds,
+    });
+    return {
+      statusCode: 200,
+      body: {
+        ok: true,
+        data: {
+          talkId: input.talkId,
+          deletedCount: deleted.deletedCount,
+          deletedMessageIds: deleted.deletedMessageIds,
+        },
+      },
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unable to edit talk history';
+    if (message === 'talk already has an active round') {
+      return {
+        statusCode: 409,
+        body: {
+          ok: false,
+          error: {
+            code: 'talk_active_round',
+            message:
+              'Wait for the current round to finish or cancel it before editing history.',
+          },
+        },
+      };
+    }
+    if (message === 'one or more talk messages were not found') {
+      return {
+        statusCode: 404,
+        body: {
+          ok: false,
+          error: {
+            code: 'message_not_found',
+            message: 'One or more selected messages no longer exist.',
+          },
+        },
+      };
+    }
+    if (message === 'system messages cannot be deleted') {
+      return {
+        statusCode: 400,
+        body: {
+          ok: false,
+          error: {
+            code: 'invalid_message_role',
+            message: 'System messages cannot be deleted.',
+          },
+        },
+      };
+    }
+    return {
+      statusCode: 500,
+      body: {
+        ok: false,
+        error: {
+          code: 'talk_history_edit_failed',
+          message,
+        },
+      },
+    };
+  }
 }
 
 export function enqueueTalkChat(input: {

--- a/src/clawrocket/web/server.ts
+++ b/src/clawrocket/web/server.ts
@@ -67,6 +67,7 @@ import {
   createTalkFolderRoute,
   cancelTalkChat,
   createTalkRoute,
+  deleteTalkMessagesRoute,
   deleteTalkFolderRoute,
   deleteTalkRoute,
   enqueueTalkChat,
@@ -2315,6 +2316,62 @@ function buildApp(opts: WebServerOptions): Hono {
       auth,
       limit: limit ?? undefined,
       beforeCreatedAt,
+    });
+    return new Response(JSON.stringify(result.body), {
+      status: result.statusCode,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    });
+  });
+
+  app.post('/api/v1/talks/:talkId/messages/delete', async (c) => {
+    const auth = requireAuth(c);
+    if (!auth) return unauthorized(c);
+
+    const rateResult = checkRateLimit({ userId: auth.userId, bucket: 'write' });
+    if (!rateResult.allowed) {
+      return rateLimitedResponse(c, rateResult);
+    }
+
+    const csrf = validateCsrfToken({
+      method: c.req.method,
+      authType: auth.authType,
+      cookieHeader: c.req.header('cookie'),
+      csrfHeader: c.req.header('x-csrf-token'),
+    });
+    if (!csrf.ok) {
+      return c.json(
+        { ok: false, error: { code: 'csrf_failed', message: csrf.reason } },
+        403,
+      );
+    }
+
+    const bodyText = await c.req.text();
+    const payload = parseJsonPayload<{ messageIds?: unknown }>(bodyText);
+    if (!payload.ok) {
+      return c.json(
+        { ok: false, error: { code: 'invalid_json', message: payload.error } },
+        400,
+      );
+    }
+    if (!payload.data || typeof payload.data !== 'object') {
+      return c.json(
+        {
+          ok: false,
+          error: { code: 'invalid_json', message: 'JSON object expected.' },
+        },
+        400,
+      );
+    }
+
+    const messageIds = Array.isArray(payload.data.messageIds)
+      ? payload.data.messageIds.filter(
+          (value): value is string => typeof value === 'string',
+        )
+      : [];
+    const result = deleteTalkMessagesRoute({
+      talkId: c.req.param('talkId'),
+      auth,
+      messageIds,
     });
     return new Response(JSON.stringify(result.body), {
       status: result.statusCode,

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -27,6 +27,7 @@ import {
   createTalk,
   createTalkMessage,
   createTalkRun,
+  deleteTalkMessagesAtomic,
   enqueueTalkTurnAtomic as enqueueTalkTurnAtomicRaw,
   failInterruptedRunsOnStartup,
   failRunAndPromoteNextAtomic,
@@ -690,6 +691,69 @@ describe('phase 0 schema and reliability tables', () => {
       beforeCreatedAt: '2024-01-01T00:00:01.000Z',
     });
     expect(before.map((message) => message.id)).toEqual(['tm-1']);
+  });
+
+  it('deletes selected talk messages, clears executor session, and emits a history-edited event', () => {
+    upsertTalkExecutorSession({
+      talkId: 'talk-1',
+      sessionId: 'session-edit-1',
+      executorAlias: 'Claude',
+      executorModel: 'claude-sonnet-4-6',
+      sessionCompatKey: computeSessionCompatKey('Claude', 'claude-sonnet-4-6'),
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+
+    createTalkMessage({
+      id: 'tm-edit-1',
+      talkId: 'talk-1',
+      role: 'user',
+      content: 'old question',
+      createdBy: 'owner-1',
+      createdAt: '2024-01-01T00:00:00.000Z',
+    });
+    createTalkMessage({
+      id: 'tm-edit-2',
+      talkId: 'talk-1',
+      role: 'assistant',
+      content: 'old answer',
+      createdAt: '2024-01-01T00:00:01.000Z',
+    });
+    createTalkMessage({
+      id: 'tm-edit-3',
+      talkId: 'talk-1',
+      role: 'user',
+      content: 'keep me',
+      createdBy: 'owner-1',
+      createdAt: '2024-01-01T00:00:02.000Z',
+    });
+
+    const result = deleteTalkMessagesAtomic({
+      talkId: 'talk-1',
+      messageIds: ['tm-edit-1', 'tm-edit-2'],
+      now: '2024-01-01T00:00:03.000Z',
+    });
+
+    expect(result).toEqual({
+      deletedCount: 2,
+      deletedMessageIds: ['tm-edit-1', 'tm-edit-2'],
+    });
+    expect(
+      listTalkMessages({ talkId: 'talk-1', limit: 10 }).map(
+        (message) => message.id,
+      ),
+    ).toEqual(['tm-edit-3']);
+    expect(getTalkExecutorSession('talk-1')).toBeUndefined();
+
+    const historyEvent = getOutboxEventsForTopics(['talk:talk-1'], 0, 20).find(
+      (event) => event.event_type === 'talk_history_edited',
+    );
+    expect(historyEvent).toBeDefined();
+    expect(JSON.parse(historyEvent!.payload)).toMatchObject({
+      talkId: 'talk-1',
+      deletedCount: 2,
+      deletedMessageIds: ['tm-edit-1', 'tm-edit-2'],
+      editedAt: '2024-01-01T00:00:03.000Z',
+    });
   });
 
   it('orders same-timestamp talk messages by sequence_in_run and includes runtime metadata in outbox events', () => {

--- a/webapp/src/components/TalkHistoryEditor.css
+++ b/webapp/src/components/TalkHistoryEditor.css
@@ -1,0 +1,169 @@
+.talk-history-editor-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.52);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 40;
+}
+
+.talk-history-editor {
+  width: min(840px, 100%);
+  max-height: min(80vh, 760px);
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 18px;
+  box-shadow: 0 24px 64px rgba(15, 23, 42, 0.18);
+  overflow: hidden;
+}
+
+.talk-history-editor-header {
+  padding: 20px 22px 14px;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.9);
+}
+
+.talk-history-editor-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.talk-history-editor-title h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.talk-history-editor-title button {
+  border: 0;
+  background: transparent;
+  color: #475569;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.talk-history-editor-header p {
+  margin: 10px 0 0;
+  color: #475569;
+  line-height: 1.45;
+}
+
+.talk-history-editor-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 22px;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.9);
+  background: #f8fafc;
+}
+
+.talk-history-editor-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.talk-history-editor-toolbar button {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: #ffffff;
+  border-radius: 999px;
+  color: #1e3a8a;
+  padding: 6px 12px;
+  cursor: pointer;
+  font: inherit;
+}
+
+.talk-history-editor-toolbar button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.talk-history-editor-list {
+  overflow: auto;
+  padding: 14px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.talk-history-editor-row {
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  border-radius: 14px;
+  background: #ffffff;
+}
+
+.talk-history-editor-row label {
+  display: block;
+  cursor: pointer;
+  padding: 14px 16px;
+}
+
+.talk-history-editor-row-selected {
+  border-color: rgba(37, 99, 235, 0.45);
+  background: #eff6ff;
+}
+
+.talk-history-editor-row-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.talk-history-editor-row-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.talk-history-editor-row-role {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.talk-history-editor-row-time {
+  color: #64748b;
+  font-size: 0.92rem;
+}
+
+.talk-history-editor-row-preview {
+  margin: 0;
+  color: #334155;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.talk-history-editor-footer {
+  padding: 14px 22px 18px;
+  border-top: 1px solid rgba(226, 232, 240, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.talk-history-editor-footer-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.talk-history-editor-footer-summary {
+  color: #475569;
+}
+
+.talk-history-editor-empty {
+  padding: 32px 22px;
+  color: #475569;
+}

--- a/webapp/src/components/TalkHistoryEditor.tsx
+++ b/webapp/src/components/TalkHistoryEditor.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import type { TalkMessage } from '../lib/api';
+import './TalkHistoryEditor.css';
+
+type TalkHistoryEditorProps = {
+  isOpen: boolean;
+  messages: TalkMessage[];
+  selectedCountLabel?: string;
+  busy?: boolean;
+  errorMessage?: string | null;
+  onClose: () => void;
+  onConfirm: (messageIds: string[]) => void;
+  resolveActorLabel: (message: TalkMessage) => string | null;
+};
+
+function summarizeMessage(message: TalkMessage): string {
+  const compact = message.content.trim().replace(/\s+/g, ' ');
+  if (!compact) return '(empty message)';
+  return compact.length > 220 ? `${compact.slice(0, 220)}…` : compact;
+}
+
+function formatRoleLabel(message: TalkMessage, actorLabel: string | null): string {
+  if (message.role === 'user') return 'You';
+  if (message.role === 'assistant') {
+    return actorLabel ? `${actorLabel}` : 'Assistant';
+  }
+  if (message.role === 'tool') {
+    return actorLabel ? `${actorLabel} tool` : 'Tool';
+  }
+  return 'System';
+}
+
+export function TalkHistoryEditor({
+  isOpen,
+  messages,
+  selectedCountLabel,
+  busy = false,
+  errorMessage = null,
+  onClose,
+  onConfirm,
+  resolveActorLabel,
+}: TalkHistoryEditorProps): JSX.Element | null {
+  const editableMessages = useMemo(
+    () => messages.filter((message) => message.role !== 'system'),
+    [messages],
+  );
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setSelectedIds(new Set());
+  }, [isOpen, messages]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !busy) {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [busy, isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const selectedCount = selectedIds.size;
+  const selectionLabel =
+    selectedCountLabel ||
+    `${selectedCount} message${selectedCount === 1 ? '' : 's'} selected`;
+
+  const toggleMessage = (messageId: string) => {
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (next.has(messageId)) {
+        next.delete(messageId);
+      } else {
+        next.add(messageId);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div
+      className="talk-history-editor-backdrop"
+      role="presentation"
+      onClick={() => {
+        if (!busy) onClose();
+      }}
+    >
+      <section
+        className="talk-history-editor"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="talk-history-editor-title"
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
+      >
+        <header className="talk-history-editor-header">
+          <div className="talk-history-editor-title">
+            <h2 id="talk-history-editor-title">Edit history</h2>
+            <button type="button" onClick={onClose} disabled={busy}>
+              Close
+            </button>
+          </div>
+          <p>
+            Select messages to delete from this Talk. Future runs will start from
+            the edited history, and the cached executor session will be reset.
+          </p>
+          {errorMessage ? (
+            <div className="inline-banner inline-banner-error" role="alert">
+              {errorMessage}
+            </div>
+          ) : null}
+        </header>
+
+        <div className="talk-history-editor-toolbar">
+          <span className="talk-history-editor-footer-summary">{selectionLabel}</span>
+          <div className="talk-history-editor-toolbar-actions">
+            <button
+              type="button"
+              onClick={() =>
+                setSelectedIds(new Set(editableMessages.map((message) => message.id)))
+              }
+              disabled={busy || editableMessages.length === 0}
+            >
+              Select all
+            </button>
+            <button
+              type="button"
+              onClick={() => setSelectedIds(new Set())}
+              disabled={busy || selectedCount === 0}
+            >
+              Clear selection
+            </button>
+          </div>
+        </div>
+
+        {editableMessages.length === 0 ? (
+          <div className="talk-history-editor-empty">
+            There are no editable messages in this Talk yet.
+          </div>
+        ) : (
+          <div className="talk-history-editor-list">
+            {editableMessages.map((message) => {
+              const actorLabel = resolveActorLabel(message);
+              const roleLabel = formatRoleLabel(message, actorLabel);
+              const isSelected = selectedIds.has(message.id);
+              return (
+                <article
+                  key={message.id}
+                  className={`talk-history-editor-row${
+                    isSelected ? ' talk-history-editor-row-selected' : ''
+                  }`}
+                >
+                  <label>
+                    <div className="talk-history-editor-row-header">
+                      <div className="talk-history-editor-row-meta">
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => toggleMessage(message.id)}
+                          disabled={busy}
+                        />
+                        <span className="talk-history-editor-row-role">{roleLabel}</span>
+                        <time className="talk-history-editor-row-time">
+                          {new Date(message.createdAt).toLocaleString()}
+                        </time>
+                      </div>
+                    </div>
+                    <p className="talk-history-editor-row-preview">
+                      {summarizeMessage(message)}
+                    </p>
+                  </label>
+                </article>
+              );
+            })}
+          </div>
+        )}
+
+        <footer className="talk-history-editor-footer">
+          <span className="talk-history-editor-footer-summary">
+            Tip: type <code>/edit</code> in the composer to open this panel.
+          </span>
+          <div className="talk-history-editor-footer-actions">
+            <button type="button" className="secondary-btn" onClick={onClose} disabled={busy}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="primary-btn"
+              onClick={() => onConfirm(Array.from(selectedIds))}
+              disabled={busy || selectedCount === 0}
+            >
+              {busy ? 'Deleting…' : 'Delete selected'}
+            </button>
+          </div>
+        </footer>
+      </section>
+    </div>
+  );
+}

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -576,6 +576,23 @@ export async function listTalkMessages(talkId: string): Promise<TalkMessage[]> {
   return envelope.messages;
 }
 
+export async function deleteTalkMessages(input: {
+  talkId: string;
+  messageIds: string[];
+}): Promise<{ talkId: string; deletedCount: number; deletedMessageIds: string[] }> {
+  return apiMutationRequest<{
+    talkId: string;
+    deletedCount: number;
+    deletedMessageIds: string[];
+  }>(`/api/v1/talks/${encodeURIComponent(input.talkId)}/messages/delete`, {
+    method: 'POST',
+    includeJson: true,
+    body: JSON.stringify({
+      messageIds: input.messageIds,
+    }),
+  });
+}
+
 export async function getTalkAgents(talkId: string): Promise<TalkAgent[]> {
   const envelope = await apiRequest<{
     talkId: string;

--- a/webapp/src/lib/talkStream.ts
+++ b/webapp/src/lib/talkStream.ts
@@ -98,6 +98,13 @@ export type TalkRunCancelledEvent = {
   runIds: string[];
 };
 
+export type TalkHistoryEditedEvent = {
+  talkId: string;
+  deletedCount: number;
+  deletedMessageIds: string[];
+  editedAt: string;
+};
+
 interface EventSourceLike {
   onopen: ((event: Event) => void) | null;
   onerror: ((event: Event) => void) | null;
@@ -121,6 +128,7 @@ interface TalkStreamCallbacks {
   onRunCompleted: (event: TalkRunCompletedEvent) => void;
   onRunFailed: (event: TalkRunFailedEvent) => void;
   onRunCancelled: (event: TalkRunCancelledEvent) => void;
+  onHistoryEdited?: (event: TalkHistoryEditedEvent) => void;
   onReplayGap: () => void | Promise<void>;
   onStateChange?: (state: TalkStreamState) => void;
   onUnauthorized: () => void;
@@ -350,6 +358,13 @@ export function openTalkStream(input: OpenTalkStreamInput): TalkStreamHandle {
       const payload = parse<TalkRunCancelledEvent>(event);
       if (!payload) return;
       input.onRunCancelled(payload);
+    });
+
+    next.addEventListener('talk_history_edited', (event) => {
+      if (next !== source || stopped) return;
+      const payload = parse<TalkHistoryEditedEvent>(event);
+      if (!payload) return;
+      input.onHistoryEdited?.(payload);
     });
 
     next.addEventListener('replay_gap', () => {

--- a/webapp/src/pages/TalkDetailPage.test.tsx
+++ b/webapp/src/pages/TalkDetailPage.test.tsx
@@ -38,6 +38,7 @@ describe('TalkDetailPage', () => {
   beforeEach(() => {
     document.cookie = 'cr_csrf_token=test-csrf-token';
     streamInput = null;
+    vi.stubGlobal('confirm', vi.fn(() => true));
     openTalkStreamMock.mockImplementation((input) => {
       streamInput = input;
       return {
@@ -423,6 +424,55 @@ describe('TalkDetailPage', () => {
     ).toBeTruthy();
     expect(screen.getByRole('heading', { name: 'Economy Sheet' })).toBeTruthy();
   });
+
+  it('opens edit history from /edit and deletes selected messages', async () => {
+    const user = userEvent.setup();
+
+    installTalkDetailFetch({
+      messages: [
+        buildMessage({
+          id: 'msg-1',
+          role: 'user',
+          content: 'Old user prompt',
+          createdAt: '2026-03-06T00:00:00.000Z',
+        }),
+        buildMessage({
+          id: 'msg-2',
+          role: 'assistant',
+          content: 'Old assistant answer',
+          createdAt: '2026-03-06T00:00:01.000Z',
+        }),
+        buildMessage({
+          id: 'msg-3',
+          role: 'user',
+          content: 'Keep this latest note',
+          createdAt: '2026-03-06T00:00:02.000Z',
+        }),
+      ],
+      runs: [],
+    });
+
+    renderDetailPage('/app/talks/talk-1');
+    const composer = await screen.findByPlaceholderText('Send a message to this talk');
+
+    await user.type(composer, '/edit');
+    await user.keyboard('{Enter}');
+
+    expect(await screen.findByRole('dialog', { name: 'Edit history' })).toBeTruthy();
+    const removeOldUser = screen.getByLabelText(/You.*Old user prompt/i);
+    const removeOldAssistant = screen.getByLabelText(/Assistant.*Old assistant answer/i);
+    await user.click(removeOldUser);
+    await user.click(removeOldAssistant);
+    await user.click(screen.getByRole('button', { name: 'Delete selected' }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: 'Edit history' })).toBeNull(),
+    );
+    expect(await screen.findByText('Deleted 2 messages from this Talk history.')).toBeTruthy();
+    expect(screen.queryByText('Old user prompt')).toBeNull();
+    expect(screen.queryByText('Old assistant answer')).toBeNull();
+    expect(screen.getByText('Keep this latest note')).toBeTruthy();
+  });
 });
 
 function renderDetailPage(initialEntry: string): ReturnType<typeof render> {
@@ -608,7 +658,7 @@ function installTalkDetailFetch(input?: {
   }) => { talkId: string; message: TalkMessage; runs: TalkRun[] };
 }) {
   const talk = input?.talk ?? buildTalk();
-  const messages =
+  let messages =
     input?.messages ??
     [
       buildMessage({
@@ -710,6 +760,24 @@ function installTalkDetailFetch(input?: {
             talkId: 'talk-1',
             messages,
             page: { limit: 100, count: messages.length, beforeCreatedAt: null },
+          },
+        });
+      }
+
+      if (url.endsWith('/api/v1/talks/talk-1/messages/delete') && method === 'POST') {
+        const body = JSON.parse(String(init?.body || '{}')) as {
+          messageIds?: string[];
+        };
+        const deletedMessageIds = Array.isArray(body.messageIds) ? body.messageIds : [];
+        messages = messages.filter(
+          (message) => !deletedMessageIds.includes(message.id),
+        );
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            talkId: 'talk-1',
+            deletedCount: deletedMessageIds.length,
+            deletedMessageIds,
           },
         });
       }

--- a/webapp/src/pages/TalkDetailPage.tsx
+++ b/webapp/src/pages/TalkDetailPage.tsx
@@ -22,6 +22,7 @@ import {
   createTalkContextRule,
   createTalkContextSource,
   DataConnector,
+  deleteTalkMessages,
   deleteTalkContextRule,
   deleteTalkContextSource,
   detachTalkDataConnector,
@@ -45,9 +46,11 @@ import {
   updateTalkAgents,
   UnauthorizedError,
 } from '../lib/api';
+import { TalkHistoryEditor } from '../components/TalkHistoryEditor';
 import { openTalkStream } from '../lib/talkStream';
 import type {
   MessageAppendedEvent,
+  TalkHistoryEditedEvent,
   TalkResponseDeltaEvent,
   TalkResponseStartedEvent,
   TalkResponseTerminalEvent,
@@ -873,6 +876,11 @@ export function TalkDetailPage({
     status: 'idle' | 'loading' | 'saving' | 'error' | 'success';
     message?: string;
   }>({ status: 'idle' });
+  const [historyEditorOpen, setHistoryEditorOpen] = useState(false);
+  const [historyEditState, setHistoryEditState] = useState<{
+    status: 'idle' | 'saving' | 'error' | 'success';
+    message?: string;
+  }>({ status: 'idle' });
 
   // Context tab state
   const [contextGoal, setContextGoal] = useState<ContextGoal | null>(null);
@@ -970,6 +978,8 @@ export function TalkDetailPage({
     setOrgConnectors([]);
     setAttachConnectorId('');
     setConnectorState({ status: 'idle' });
+    setHistoryEditorOpen(false);
+    setHistoryEditState({ status: 'idle' });
     setContextLoaded(false);
     setContextGoal(null);
     setContextRules([]);
@@ -1160,6 +1170,10 @@ export function TalkDetailPage({
         if (event.talkId !== talkId) return;
         dispatch({ type: 'RUN_CANCELLED_BATCH', runIds: event.runIds });
       },
+      onHistoryEdited: (event: TalkHistoryEditedEvent) => {
+        if (event.talkId !== talkId) return;
+        void resyncTalkState();
+      },
       onReplayGap: async () => {
         await resyncTalkState();
       },
@@ -1264,6 +1278,23 @@ export function TalkDetailPage({
         (run) => run.status === 'queued' || run.status === 'running',
       ),
     [state.runsById],
+  );
+  const canEditHistory = useMemo(
+    () =>
+      state.kind === 'ready' &&
+      !activeRound &&
+      state.messages.some((message) => message.role !== 'system'),
+    [activeRound, state],
+  );
+  const resolveMessageActorLabel = useCallback(
+    (message: TalkMessage): string | null => {
+      return (
+        (message.agentId ? agentLabelById[message.agentId] : null) ||
+        message.agentNickname ||
+        null
+      );
+    },
+    [agentLabelById],
   );
   const availableConnectors = useMemo(
     () =>
@@ -1466,6 +1497,81 @@ export function TalkDetailPage({
     }
   };
 
+  const openHistoryEditor = useCallback(() => {
+    if (state.kind !== 'ready') return;
+    if (activeRound) {
+      setHistoryEditState({
+        status: 'error',
+        message:
+          'Wait for the current round to finish or cancel it before editing history.',
+      });
+      return;
+    }
+    if (!state.messages.some((message) => message.role !== 'system')) {
+      setHistoryEditState({
+        status: 'error',
+        message: 'There are no editable messages in this Talk yet.',
+      });
+      return;
+    }
+    setHistoryEditState({ status: 'idle' });
+    setHistoryEditorOpen(true);
+  }, [activeRound, state]);
+
+  const handleCloseHistoryEditor = useCallback(() => {
+    if (historyEditState.status === 'saving') return;
+    setHistoryEditorOpen(false);
+    setHistoryEditState((current) =>
+      current.status === 'success' ? current : { status: 'idle' },
+    );
+  }, [historyEditState.status]);
+
+  const handleDeleteHistoryMessages = useCallback(
+    async (messageIds: string[]) => {
+      if (state.kind !== 'ready' || !state.talk) return;
+      if (messageIds.length === 0) {
+        setHistoryEditState({
+          status: 'error',
+          message: 'Select at least one message to delete.',
+        });
+        return;
+      }
+      const confirmed = window.confirm(
+        `Delete ${messageIds.length} selected message${
+          messageIds.length === 1 ? '' : 's'
+        } from this Talk history?`,
+      );
+      if (!confirmed) return;
+
+      setHistoryEditState({ status: 'saving' });
+      try {
+        const result = await deleteTalkMessages({
+          talkId: state.talk.id,
+          messageIds,
+        });
+        await resyncTalkState();
+        setHistoryEditorOpen(false);
+        setHistoryEditState({
+          status: 'success',
+          message: `Deleted ${result.deletedCount} message${
+            result.deletedCount === 1 ? '' : 's'
+          } from this Talk history.`,
+        });
+      } catch (err) {
+        if (err instanceof UnauthorizedError) {
+          handleUnauthorized();
+          return;
+        }
+        setHistoryEditState({
+          status: 'error',
+          message:
+            err instanceof Error ? err.message : 'Unable to edit Talk history.',
+        });
+      }
+    },
+    [handleUnauthorized, resyncTalkState, state],
+  );
+
   const handleDraftChange = (value: string) => {
     setDraft(value);
     if (state.kind === 'ready' && state.sendState.status === 'error') {
@@ -1494,6 +1600,12 @@ export function TalkDetailPage({
         message: 'Message content is required.',
         lastDraft: draft,
       });
+      return;
+    }
+    if (content === '/edit') {
+      setDraft('');
+      dispatch({ type: 'SEND_CLEARED' });
+      openHistoryEditor();
       return;
     }
     if (content.length > TALK_MESSAGE_MAX_CHARS) {
@@ -2709,6 +2821,34 @@ export function TalkDetailPage({
 
           {currentTab === 'talk' ? (
             <div className="timeline" aria-label="Talk timeline">
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: '12px',
+                marginBottom: '12px',
+                flexWrap: 'wrap',
+              }}
+            >
+              <p
+                style={{
+                  margin: 0,
+                  color: '#475569',
+                  fontSize: '0.94rem',
+                }}
+              >
+                Use <code>/edit</code> or the button here to remove old Talk messages.
+              </p>
+              <button
+                type="button"
+                className="secondary-btn"
+                onClick={openHistoryEditor}
+                disabled={!canEditHistory}
+              >
+                Edit history
+              </button>
+            </div>
             {state.messages.length === 0 ? (
               <p className="page-state">No messages yet.</p>
             ) : (
@@ -2864,6 +3004,18 @@ export function TalkDetailPage({
               </div>
             ) : null}
 
+            {historyEditState.status === 'success' ? (
+              <div className="inline-banner inline-banner-success" role="status">
+                {historyEditState.message}
+              </div>
+            ) : null}
+
+            {historyEditState.status === 'error' ? (
+              <div className="inline-banner inline-banner-error" role="alert">
+                {historyEditState.message}
+              </div>
+            ) : null}
+
             {state.cancelState.status === 'success' ? (
               <div className="inline-banner inline-banner-success" role="status">
                 {state.cancelState.message}
@@ -2878,6 +3030,19 @@ export function TalkDetailPage({
           </form>
         ) : null}
       </div>
+      <TalkHistoryEditor
+        isOpen={historyEditorOpen}
+        messages={state.messages}
+        busy={historyEditState.status === 'saving'}
+        errorMessage={
+          historyEditorOpen && historyEditState.status === 'error'
+            ? historyEditState.message || null
+            : null
+        }
+        onClose={handleCloseHistoryEditor}
+        onConfirm={handleDeleteHistoryMessages}
+        resolveActorLabel={resolveMessageActorLabel}
+      />
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- add a Talk history edit flow that opens from /edit or an Edit history button in the Talk tab
- let editors multi-select and delete persisted Talk messages, then resync the timeline and clear cached executor session state so deleted context does not leak into future runs
- add the backend history-edit mutation, SSE resync event, and focused backend/frontend tests for the edit flow

## Testing

- npm test -- src/db.test.ts src/clawrocket/web/routes/talks.test.ts
- npm run typecheck
- npm --prefix webapp test -- src/pages/TalkDetailPage.test.tsx
- npm --prefix webapp run typecheck
