### PR TITLE
fix(context): harden browser-backed URL ingestion

### DIFF
--- a/src/clawrocket/talks/browser-source-container.test.ts
+++ b/src/clawrocket/talks/browser-source-container.test.ts
@@ -1,0 +1,98 @@
+import { EventEmitter } from 'events';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const spawnMock = vi.fn();
+
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+vi.mock('../../config.js', () => ({
+  CONTAINER_IMAGE: 'test-image',
+  TIMEZONE: 'UTC',
+}));
+
+vi.mock('../../container-runtime.js', () => ({
+  CONTAINER_RUNTIME_BIN: 'docker',
+  readonlyMountArgs: (src: string, dest: string) => ['-v', `${src}:${dest}:ro`],
+}));
+
+import { runBrowserSourceFetchInContainer } from './browser-source-container.js';
+
+class MockReadable extends EventEmitter {
+  setEncoding(_encoding: string): void {
+    // no-op for tests
+  }
+}
+
+class MockWritable {
+  readonly chunks: string[] = [];
+
+  write(chunk: string): void {
+    this.chunks.push(chunk);
+  }
+
+  end(): void {
+    // no-op for tests
+  }
+}
+
+function createMockProcess() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: MockReadable;
+    stderr: MockReadable;
+    stdin: MockWritable;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  proc.stdout = new MockReadable();
+  proc.stderr = new MockReadable();
+  proc.stdin = new MockWritable();
+  proc.kill = vi.fn();
+  return proc;
+}
+
+describe('browser-source-container', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it('uses the local TypeScript binary and reserves stdout for JSON', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+
+    const promise = runBrowserSourceFetchInContainer({
+      url: 'https://www.gamemakers.com/',
+      timeoutMs: 1_000,
+    });
+
+    process.nextTick(() => {
+      proc.stdout.emit(
+        'data',
+        JSON.stringify({
+          status: 'success',
+          finalUrl: 'https://www.gamemakers.com/',
+          pageTitle: 'GameMakers',
+          extractedText: 'hello world',
+          contentType: 'text/html',
+        }),
+      );
+      proc.emit('close', 0);
+    });
+
+    await expect(promise).resolves.toEqual({
+      finalUrl: 'https://www.gamemakers.com/',
+      pageTitle: 'GameMakers',
+      extractedText: 'hello world',
+      contentType: 'text/html',
+      strategy: 'browser',
+    });
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const args = spawnMock.mock.calls[0]?.[1] as string[];
+    expect(args).toContain('-lc');
+    expect(args.at(-1)).toContain('./node_modules/.bin/tsc --outDir /tmp/dist');
+    expect(args.at(-1)).toContain('>/dev/stderr 2>&1');
+    expect(args.at(-1)).not.toContain('npx tsc');
+  });
+});

--- a/src/clawrocket/talks/browser-source-container.ts
+++ b/src/clawrocket/talks/browser-source-container.ts
@@ -33,7 +33,7 @@ export async function runBrowserSourceFetchInContainer(input: {
   const containerName = `nanoclaw-browser-fetch-${Date.now()}`;
   const compileAndRun =
     'cd /app && ' +
-    'npx tsc --outDir /tmp/dist 2>&1 >&2 && ' +
+    './node_modules/.bin/tsc --outDir /tmp/dist >/dev/stderr 2>&1 && ' +
     'ln -sf /app/node_modules /tmp/dist/node_modules && ' +
     'node /tmp/dist/browser-fetch.js';
 

--- a/src/clawrocket/talks/source-ingestion.ts
+++ b/src/clawrocket/talks/source-ingestion.ts
@@ -271,22 +271,31 @@ function nodeRequest(
   return new Promise((resolve, reject) => {
     const isHttps = url.protocol === 'https:';
     const mod = isHttps ? https : http;
-
-    const customLookup: net.LookupFunction = (_hostname, _options, cb) => {
-      const family: 4 | 6 = net.isIPv6(resolvedIp) ? 6 : 4;
-      cb(null, resolvedIp, family);
-    };
+    if (!resolvedIp) {
+      reject(
+        new SourceIngestionError(
+          'dns_resolution_failed',
+          `Could not resolve hostname: ${url.hostname}`,
+        ),
+      );
+      return;
+    }
 
     const req = mod.request(
-      url,
       {
+        protocol: url.protocol,
+        hostname: resolvedIp,
+        port: url.port.length > 0 ? Number(url.port) : isHttps ? 443 : 80,
+        path: `${url.pathname}${url.search}`,
         method: 'GET',
         headers: {
+          Host: url.host,
           'User-Agent': 'RocketClaw-SourceIngestion/1.0',
           Accept: 'text/html, text/plain, application/pdf, */*',
         },
         timeout: FETCH_TIMEOUT_MS,
-        lookup: customLookup as net.LookupFunction,
+        servername: isHttps ? url.hostname : undefined,
+        family: net.isIPv6(resolvedIp) ? 6 : 4,
       },
       (res) => {
         const chunks: Buffer[] = [];


### PR DESCRIPTION
## Summary
- fix the HTTP URL ingestion path so validated IPs are used safely for the actual socket connection
- keep browser-runner stdout JSON-only so npm/compiler output cannot corrupt browser fallback results
- add a regression test covering the browser container runner command and stdout handling

## Problem
Adding saved-source URLs for public sites like https://www.gamemakers.com/ could fail even though the page was reachable. The HTTP path could surface ERR_INVALID_IP_ADDRESS, and the browser fallback could fail with invalid JSON because compiler output leaked into stdout.

## Testing
- pnpm vitest run src/clawrocket/talks/browser-source-container.test.ts src/clawrocket/talks/source-ingestion.test.ts src/clawrocket/web/routes/talk-context.test.ts
- npm run typecheck
- npm run format:check
