### PR TITLE
fix(talks): replay recent shared history

### DIFF
--- a/src/clawrocket/db/accessors.ts
+++ b/src/clawrocket/db/accessors.ts
@@ -1548,6 +1548,119 @@ export function listTalkMessages(input: {
   return rows;
 }
 
+export interface TalkReplayRow {
+  user: TalkMessageRecord;
+  assistant: TalkMessageRecord;
+}
+
+export function listTalkReplayRows(input: {
+  talkId: string;
+  currentRunId: string;
+  currentUserMessageId: string;
+  limit?: number;
+}): TalkReplayRow[] {
+  const limit =
+    typeof input.limit === 'number'
+      ? Math.min(500, Math.max(1, Math.floor(input.limit)))
+      : 500;
+
+  const rows = getDb()
+    .prepare(
+      `
+      WITH recent_messages AS (
+        SELECT id, talk_id, role, content, created_by, created_at, run_id, metadata_json, sequence_in_run
+        FROM talk_messages
+        WHERE talk_id = ?
+        ORDER BY created_at DESC, COALESCE(sequence_in_run, 0) DESC, id DESC
+        LIMIT ?
+      )
+      SELECT
+        u.id AS user_id,
+        u.talk_id AS user_talk_id,
+        u.role AS user_role,
+        u.content AS user_content,
+        u.created_by AS user_created_by,
+        u.created_at AS user_created_at,
+        u.run_id AS user_run_id,
+        u.metadata_json AS user_metadata_json,
+        u.sequence_in_run AS user_sequence_in_run,
+        a.id AS assistant_id,
+        a.talk_id AS assistant_talk_id,
+        a.role AS assistant_role,
+        a.content AS assistant_content,
+        a.created_by AS assistant_created_by,
+        a.created_at AS assistant_created_at,
+        a.run_id AS assistant_run_id,
+        a.metadata_json AS assistant_metadata_json,
+        a.sequence_in_run AS assistant_sequence_in_run
+      FROM recent_messages a
+      JOIN talk_runs r ON r.id = a.run_id
+      JOIN talk_messages u ON u.id = r.trigger_message_id
+      WHERE a.role = 'assistant'
+        AND a.run_id IS NOT NULL
+        AND a.run_id != ?
+        AND u.role = 'user'
+        AND u.id != ?
+      ORDER BY
+        u.created_at ASC,
+        u.id ASC,
+        a.created_at ASC,
+        COALESCE(a.sequence_in_run, 0) ASC,
+        a.id ASC
+    `,
+    )
+    .all(
+      input.talkId,
+      limit,
+      input.currentRunId,
+      input.currentUserMessageId,
+    ) as Array<{
+      user_id: string;
+      user_talk_id: string;
+      user_role: TalkMessageRole;
+      user_content: string;
+      user_created_by: string | null;
+      user_created_at: string;
+      user_run_id: string | null;
+      user_metadata_json: string | null;
+      user_sequence_in_run: number | null;
+      assistant_id: string;
+      assistant_talk_id: string;
+      assistant_role: TalkMessageRole;
+      assistant_content: string;
+      assistant_created_by: string | null;
+      assistant_created_at: string;
+      assistant_run_id: string | null;
+      assistant_metadata_json: string | null;
+      assistant_sequence_in_run: number | null;
+    }>;
+
+  return rows.map((row) => ({
+    user: {
+      id: row.user_id,
+      talk_id: row.user_talk_id,
+      role: row.user_role,
+      content: row.user_content,
+      created_by: row.user_created_by,
+      created_at: row.user_created_at,
+      run_id: row.user_run_id,
+      metadata_json: row.user_metadata_json,
+      sequence_in_run: row.user_sequence_in_run,
+    },
+    assistant: {
+      id: row.assistant_id,
+      talk_id: row.assistant_talk_id,
+      role: row.assistant_role,
+      content: row.assistant_content,
+      created_by: row.assistant_created_by,
+      created_at: row.assistant_created_at,
+      run_id: row.assistant_run_id,
+      metadata_json: row.assistant_metadata_json,
+      sequence_in_run: row.assistant_sequence_in_run,
+    },
+  }));
+}
+
 export function getTalkMessageById(
   messageId: string,
 ): TalkMessageRecord | undefined {

--- a/src/clawrocket/talks/context-assembler.test.ts
+++ b/src/clawrocket/talks/context-assembler.test.ts
@@ -1,0 +1,432 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  _initTestDatabase,
+  createTalk,
+  createTalkMessage,
+  createTalkRun,
+  enqueueTalkTurnAtomic as enqueueTalkTurnAtomicRaw,
+  upsertUser,
+} from '../db/index.js';
+
+import { assembleTalkPromptContext } from './context-assembler.js';
+
+const OWNER_ID = 'owner-1';
+const TALK_ID = 'talk-1';
+
+function seedTalk(): void {
+  upsertUser({
+    id: OWNER_ID,
+    email: 'owner@example.com',
+    displayName: 'Owner',
+    role: 'owner',
+  });
+  createTalk({
+    id: TALK_ID,
+    ownerId: OWNER_ID,
+    topicTitle: 'Context Assembly Test Talk',
+  });
+}
+
+function createHistoricalTurn(input: {
+  userMessageId: string;
+  userText: string;
+  userCreatedAt: string;
+  assistants: Array<{
+    runId: string;
+    content: string;
+    createdAt: string;
+    status?: 'running' | 'completed' | 'failed';
+    sequenceInRun?: number | null;
+    messageId?: string;
+    metadataJson?: string | null;
+  }>;
+}): void {
+  createTalkMessage({
+    id: input.userMessageId,
+    talkId: TALK_ID,
+    role: 'user',
+    content: input.userText,
+    createdBy: OWNER_ID,
+    createdAt: input.userCreatedAt,
+  });
+
+  for (const assistant of input.assistants) {
+    createTalkRun({
+      id: assistant.runId,
+      talk_id: TALK_ID,
+      requested_by: OWNER_ID,
+      status: assistant.status || 'completed',
+      trigger_message_id: input.userMessageId,
+      target_agent_id: null,
+      idempotency_key: null,
+      executor_alias: null,
+      executor_model: null,
+      created_at: assistant.createdAt,
+      started_at: assistant.createdAt,
+      ended_at:
+        assistant.status === 'running' ? null : assistant.createdAt,
+      cancel_reason: assistant.status === 'failed' ? 'failed' : null,
+    });
+    createTalkMessage({
+      id: assistant.messageId || `${assistant.runId}-assistant`,
+      talkId: TALK_ID,
+      role: 'assistant',
+      content: assistant.content,
+      createdBy: null,
+      runId: assistant.runId,
+      metadataJson: assistant.metadataJson || null,
+      sequenceInRun: assistant.sequenceInRun ?? null,
+      createdAt: assistant.createdAt,
+    });
+  }
+}
+
+function enqueueCurrentTurn(input: {
+  messageId: string;
+  runId: string;
+  content: string;
+  createdAt: string;
+}): void {
+  enqueueTalkTurnAtomicRaw({
+    talkId: TALK_ID,
+    userId: OWNER_ID,
+    content: input.content,
+    messageId: input.messageId,
+    runIds: [input.runId],
+    targetAgentIds: ['agent-default'],
+    now: input.createdAt,
+  });
+}
+
+function createCurrentTurn(input: {
+  messageId: string;
+  runId: string;
+  content: string;
+  createdAt: string;
+}): void {
+  createTalkMessage({
+    id: input.messageId,
+    talkId: TALK_ID,
+    role: 'user',
+    content: input.content,
+    createdBy: OWNER_ID,
+    createdAt: input.createdAt,
+  });
+  createTalkRun({
+    id: input.runId,
+    talk_id: TALK_ID,
+    requested_by: OWNER_ID,
+    status: 'queued',
+    trigger_message_id: input.messageId,
+    target_agent_id: null,
+    idempotency_key: null,
+    executor_alias: null,
+    executor_model: null,
+    created_at: input.createdAt,
+    started_at: null,
+    ended_at: null,
+    cancel_reason: null,
+  });
+}
+
+function assembleConversation(input: {
+  currentRunId: string;
+  currentUserMessageId: string;
+  currentUserMessage: string;
+  modelContextWindowTokens?: number;
+  maxOutputTokens?: number;
+}) {
+  return assembleTalkPromptContext({
+    talkId: TALK_ID,
+    talkTitle: 'Context Assembly Test Talk',
+    currentRunId: input.currentRunId,
+    currentUserMessageId: input.currentUserMessageId,
+    currentUserMessage: input.currentUserMessage,
+    agent: {
+      id: 'agent-default',
+      name: 'Opus',
+      personaRole: 'analyst',
+    },
+    modelContextWindowTokens: input.modelContextWindowTokens ?? 32_000,
+    maxOutputTokens: input.maxOutputTokens ?? 1_024,
+  });
+}
+
+function conversationMessages(result: ReturnType<typeof assembleConversation>) {
+  return result.messages
+    .filter((message) => message.role !== 'system')
+    .map((message) => ({
+      role: message.role,
+      text: message.text,
+    }));
+}
+
+describe('assembleTalkPromptContext', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    seedTalk();
+  });
+
+  it('replays shared multi-agent history from trigger_message_id linkage', () => {
+    createHistoricalTurn({
+      userMessageId: 'msg-prev',
+      userText: "Can you both evaluate Lila's fit?",
+      userCreatedAt: '2024-01-01T00:00:00.000Z',
+      assistants: [
+        {
+          runId: 'run-kimi',
+          content: 'Kimi: strong operator, weak game-economy depth.',
+          createdAt: '2024-01-01T00:00:01.000Z',
+        },
+        {
+          runId: 'run-opus-prev',
+          content: 'Opus: hire for AI tooling, not core game economy.',
+          createdAt: '2024-01-01T00:00:02.000Z',
+        },
+      ],
+    });
+    enqueueCurrentTurn({
+      messageId: 'msg-current',
+      runId: 'run-current',
+      content: 'Can you synthesize the parts you both agree with?',
+      createdAt: '2024-01-01T00:10:00.000Z',
+    });
+
+    const result = assembleConversation({
+      currentRunId: 'run-current',
+      currentUserMessageId: 'msg-current',
+      currentUserMessage:
+        'Can you synthesize the parts you both agree with?',
+    });
+
+    expect(conversationMessages(result)).toEqual([
+      {
+        role: 'user',
+        text: "Can you both evaluate Lila's fit?",
+      },
+      {
+        role: 'assistant',
+        text: 'Kimi: strong operator, weak game-economy depth.',
+      },
+      {
+        role: 'assistant',
+        text: 'Opus: hire for AI tooling, not core game economy.',
+      },
+      {
+        role: 'user',
+        text: 'Can you synthesize the parts you both agree with?',
+      },
+    ]);
+  });
+
+  it('drops orphan user turns and orphan assistant replies', () => {
+    createHistoricalTurn({
+      userMessageId: 'msg-complete',
+      userText: 'What happened yesterday?',
+      userCreatedAt: '2024-01-01T00:00:00.000Z',
+      assistants: [
+        {
+          runId: 'run-complete',
+          content: 'We reviewed the launch checklist.',
+          createdAt: '2024-01-01T00:00:01.000Z',
+        },
+      ],
+    });
+    createTalkMessage({
+      id: 'msg-orphan-user',
+      talkId: TALK_ID,
+      role: 'user',
+      content: 'This incomplete question should be dropped.',
+      createdBy: OWNER_ID,
+      createdAt: '2024-01-01T00:05:00.000Z',
+    });
+    createTalkRun({
+      id: 'run-orphan-assistant',
+      talk_id: TALK_ID,
+      requested_by: OWNER_ID,
+      status: 'completed',
+      trigger_message_id: null,
+      target_agent_id: null,
+      idempotency_key: null,
+      executor_alias: null,
+      executor_model: null,
+      created_at: '2024-01-01T00:06:00.000Z',
+      started_at: '2024-01-01T00:06:00.000Z',
+      ended_at: '2024-01-01T00:06:00.000Z',
+      cancel_reason: null,
+    });
+    createTalkMessage({
+      id: 'msg-orphan-assistant',
+      talkId: TALK_ID,
+      role: 'assistant',
+      content: 'Ghost assistant reply',
+      createdBy: null,
+      runId: 'run-orphan-assistant',
+      createdAt: '2024-01-01T00:06:01.000Z',
+    });
+    enqueueCurrentTurn({
+      messageId: 'msg-current',
+      runId: 'run-current',
+      content: 'What is the next step?',
+      createdAt: '2024-01-01T00:10:00.000Z',
+    });
+
+    const result = assembleConversation({
+      currentRunId: 'run-current',
+      currentUserMessageId: 'msg-current',
+      currentUserMessage: 'What is the next step?',
+    });
+    const joined = JSON.stringify(conversationMessages(result));
+
+    expect(joined).toContain('What happened yesterday?');
+    expect(joined).toContain('We reviewed the launch checklist.');
+    expect(joined).not.toContain('This incomplete question should be dropped.');
+    expect(joined).not.toContain('Ghost assistant reply');
+  });
+
+  it('excludes only the exact current run and not other running assistant replies', () => {
+    createHistoricalTurn({
+      userMessageId: 'msg-prev',
+      userText: 'Give both perspectives.',
+      userCreatedAt: '2024-01-01T00:00:00.000Z',
+      assistants: [
+        {
+          runId: 'run-peer-running',
+          content: 'Kimi is already drafting a response.',
+          createdAt: '2024-01-01T00:00:01.000Z',
+          status: 'running',
+        },
+        {
+          runId: 'run-peer-complete',
+          content: 'Opus already delivered a final answer.',
+          createdAt: '2024-01-01T00:00:02.000Z',
+          status: 'completed',
+        },
+      ],
+    });
+    createCurrentTurn({
+      messageId: 'msg-current',
+      runId: 'run-current',
+      content: 'Now tell me what they agree on.',
+      createdAt: '2024-01-01T00:10:00.000Z',
+    });
+
+    const result = assembleConversation({
+      currentRunId: 'run-current',
+      currentUserMessageId: 'msg-current',
+      currentUserMessage: 'Now tell me what they agree on.',
+    });
+    const texts = conversationMessages(result).map((message) => message.text);
+
+    expect(texts).toContain('Kimi is already drafting a response.');
+    expect(texts).toContain('Opus already delivered a final answer.');
+  });
+
+  it('excludes tool-use noise and preserves deterministic assistant order', () => {
+    createHistoricalTurn({
+      userMessageId: 'msg-prev',
+      userText: 'Summarize the evidence.',
+      userCreatedAt: '2024-01-01T00:00:00.000Z',
+      assistants: [
+        {
+          runId: 'run-tool',
+          content: 'Tool call details',
+          createdAt: '2024-01-01T00:00:01.000Z',
+          messageId: 'msg-tool',
+          metadataJson: JSON.stringify({ kind: 'assistant_tool_use' }),
+        },
+        {
+          runId: 'run-b',
+          content: 'Second persisted reply',
+          createdAt: '2024-01-01T00:00:02.000Z',
+          messageId: 'msg-b',
+        },
+        {
+          runId: 'run-a',
+          content: 'First persisted reply',
+          createdAt: '2024-01-01T00:00:02.000Z',
+          messageId: 'msg-a',
+        },
+      ],
+    });
+    enqueueCurrentTurn({
+      messageId: 'msg-current',
+      runId: 'run-current',
+      content: 'What matters most?',
+      createdAt: '2024-01-01T00:10:00.000Z',
+    });
+
+    const result = assembleConversation({
+      currentRunId: 'run-current',
+      currentUserMessageId: 'msg-current',
+      currentUserMessage: 'What matters most?',
+    });
+
+    expect(conversationMessages(result)).toEqual([
+      {
+        role: 'user',
+        text: 'Summarize the evidence.',
+      },
+      {
+        role: 'assistant',
+        text: 'First persisted reply',
+      },
+      {
+        role: 'assistant',
+        text: 'Second persisted reply',
+      },
+      {
+        role: 'user',
+        text: 'What matters most?',
+      },
+    ]);
+  });
+
+  it('keeps the newest contiguous fitting turns only', () => {
+    createHistoricalTurn({
+      userMessageId: 'msg-old',
+      userText: 'Old request that should be dropped.',
+      userCreatedAt: '2024-01-01T00:00:00.000Z',
+      assistants: [
+        {
+          runId: 'run-old',
+          content: 'x'.repeat(900),
+          createdAt: '2024-01-01T00:00:01.000Z',
+        },
+      ],
+    });
+    createHistoricalTurn({
+      userMessageId: 'msg-recent',
+      userText: 'Recent request to keep.',
+      userCreatedAt: '2024-01-01T00:05:00.000Z',
+      assistants: [
+        {
+          runId: 'run-recent',
+          content: 'Recent answer to keep.',
+          createdAt: '2024-01-01T00:05:01.000Z',
+        },
+      ],
+    });
+    enqueueCurrentTurn({
+      messageId: 'msg-current',
+      runId: 'run-current',
+      content: 'Current question.',
+      createdAt: '2024-01-01T00:10:00.000Z',
+    });
+
+    const result = assembleConversation({
+      currentRunId: 'run-current',
+      currentUserMessageId: 'msg-current',
+      currentUserMessage: 'Current question.',
+      modelContextWindowTokens: 700,
+      maxOutputTokens: 100,
+    });
+    const joined = JSON.stringify(conversationMessages(result));
+
+    expect(joined).toContain('Recent request to keep.');
+    expect(joined).toContain('Recent answer to keep.');
+    expect(joined).not.toContain('Old request that should be dropped.');
+    expect(joined).not.toContain('x'.repeat(100));
+  });
+});

--- a/src/clawrocket/talks/context-assembler.ts
+++ b/src/clawrocket/talks/context-assembler.ts
@@ -1,4 +1,7 @@
-import { listTalkMessages, type TalkMessageRecord } from '../db/index.js';
+import {
+  listTalkReplayRows,
+  type TalkMessageRecord,
+} from '../db/index.js';
 import type { TalkPersonaRole } from '../llm/types.js';
 
 export interface PromptMessage {
@@ -32,9 +35,8 @@ export interface ContextAssemblyInput {
 }
 
 interface HistoricalTurn {
-  runId: string;
   user: TalkMessageRecord;
-  assistant: TalkMessageRecord;
+  assistants: TalkMessageRecord[];
 }
 
 export class ContextAssemblyError extends Error {
@@ -105,44 +107,50 @@ function buildPersonaPrompt(input: ContextAssemblyInput): string {
 function buildHistoricalTurns(
   talkId: string,
   currentRunId: string,
+  currentUserMessageId: string,
 ): HistoricalTurn[] {
-  // v1 simplification: cap the DB scan while context assembly is purely
-  // stateless replay. The actual retained history is still bounded by the
-  // route/model token budget below.
-  const messages = listTalkMessages({ talkId, limit: 500 });
-  const byRunId = new Map<
-    string,
-    {
-      user?: TalkMessageRecord;
-      assistant?: TalkMessageRecord;
-    }
-  >();
+  const replayRows = listTalkReplayRows({
+    talkId,
+    currentRunId,
+    currentUserMessageId,
+    limit: 500,
+  });
+  const byUserId = new Map<string, HistoricalTurn>();
 
-  for (const message of messages) {
-    if (!message.run_id || message.run_id === currentRunId) continue;
-    const group = byRunId.get(message.run_id) || {};
-    if (message.role === 'user' && !group.user) group.user = message;
-    if (
-      message.role === 'assistant' &&
-      parseMessageMetadataKind(message) !== 'assistant_tool_use'
-    ) {
-      group.assistant = message;
+  for (const row of replayRows) {
+    if (parseMessageMetadataKind(row.assistant) === 'assistant_tool_use') {
+      continue;
     }
-    byRunId.set(message.run_id, group);
+
+    const existing = byUserId.get(row.user.id);
+    if (existing) {
+      existing.assistants.push(row.assistant);
+      continue;
+    }
+
+    byUserId.set(row.user.id, {
+      user: row.user,
+      assistants: [row.assistant],
+    });
   }
 
-  return Array.from(byRunId.entries())
-    .map(([runId, group]) =>
-      group.user && group.assistant
-        ? {
-            runId,
-            user: group.user,
-            assistant: group.assistant,
-          }
-        : null,
-    )
-    .filter((turn): turn is HistoricalTurn => Boolean(turn))
-    .sort((a, b) => a.user.created_at.localeCompare(b.user.created_at));
+  return Array.from(byUserId.values()).sort((a, b) =>
+    compareMessagePosition(a.user, b.user),
+  );
+}
+
+function compareMessagePosition(
+  left: Pick<TalkMessageRecord, 'created_at' | 'sequence_in_run' | 'id'>,
+  right: Pick<TalkMessageRecord, 'created_at' | 'sequence_in_run' | 'id'>,
+): number {
+  const createdAtCompare = left.created_at.localeCompare(right.created_at);
+  if (createdAtCompare !== 0) return createdAtCompare;
+
+  const leftSequence = left.sequence_in_run ?? 0;
+  const rightSequence = right.sequence_in_run ?? 0;
+  if (leftSequence !== rightSequence) return leftSequence - rightSequence;
+
+  return left.id.localeCompare(right.id);
 }
 
 export function assembleTalkPromptContext(
@@ -207,26 +215,36 @@ export function assembleTalkPromptContext(
   const historicalTurns = buildHistoricalTurns(
     input.talkId,
     input.currentRunId,
+    input.currentUserMessageId,
   );
   for (let index = historicalTurns.length - 1; index >= 0; index -= 1) {
     const turn = historicalTurns[index];
-    const userMessage: PromptMessage = {
-      role: 'user',
-      text: turn.user.content,
-      talkMessageId: turn.user.id,
-    };
-    const assistantMessage: PromptMessage = {
-      role: 'assistant',
-      text: turn.assistant.content,
-      talkMessageId: turn.assistant.id,
-    };
-    const turnCost =
-      messageTokenCost(userMessage) + messageTokenCost(assistantMessage);
+    const turnMessages: PromptMessage[] = [
+      {
+        role: 'user',
+        text: turn.user.content,
+        talkMessageId: turn.user.id,
+      },
+      ...turn.assistants
+        .slice()
+        .sort(compareMessagePosition)
+        .map(
+          (assistant): PromptMessage => ({
+            role: 'assistant',
+            text: assistant.content,
+            talkMessageId: assistant.id,
+          }),
+        ),
+    ];
+    const turnCost = turnMessages.reduce(
+      (sum, message) => sum + messageTokenCost(message),
+      0,
+    );
     if (usedTokens + turnCost > inputBudgetTokens) {
       break;
     }
     usedTokens += turnCost;
-    selectedHistorical.unshift(userMessage, assistantMessage);
+    selectedHistorical.unshift(...turnMessages);
   }
 
   return {

--- a/src/clawrocket/talks/direct-executor.test.ts
+++ b/src/clawrocket/talks/direct-executor.test.ts
@@ -119,12 +119,21 @@ function createCompletedTurn(
   assistantText: string,
   createdAt: string,
 ): void {
+  const userMessageId = `${runId}-user`;
+  createTalkMessage({
+    id: userMessageId,
+    talkId: TALK_ID,
+    role: 'user',
+    content: userText,
+    createdBy: OWNER_ID,
+    createdAt,
+  });
   createTalkRun({
     id: runId,
     talk_id: TALK_ID,
     requested_by: OWNER_ID,
     status: 'completed',
-    trigger_message_id: null,
+    trigger_message_id: userMessageId,
     target_agent_id: null,
     idempotency_key: null,
     executor_alias: null,
@@ -133,15 +142,6 @@ function createCompletedTurn(
     started_at: createdAt,
     ended_at: createdAt,
     cancel_reason: null,
-  });
-  createTalkMessage({
-    id: `${runId}-user`,
-    talkId: TALK_ID,
-    role: 'user',
-    content: userText,
-    createdBy: OWNER_ID,
-    runId,
-    createdAt,
   });
   createTalkMessage({
     id: `${runId}-assistant`,
@@ -159,12 +159,21 @@ function createOrphanUserTurn(
   userText: string,
   createdAt: string,
 ): void {
+  const userMessageId = `${runId}-user`;
+  createTalkMessage({
+    id: userMessageId,
+    talkId: TALK_ID,
+    role: 'user',
+    content: userText,
+    createdBy: OWNER_ID,
+    createdAt,
+  });
   createTalkRun({
     id: runId,
     talk_id: TALK_ID,
     requested_by: OWNER_ID,
     status: 'failed',
-    trigger_message_id: null,
+    trigger_message_id: userMessageId,
     target_agent_id: null,
     idempotency_key: null,
     executor_alias: null,
@@ -173,15 +182,6 @@ function createOrphanUserTurn(
     started_at: createdAt,
     ended_at: createdAt,
     cancel_reason: 'failed',
-  });
-  createTalkMessage({
-    id: `${runId}-user`,
-    talkId: TALK_ID,
-    role: 'user',
-    content: userText,
-    createdBy: OWNER_ID,
-    runId,
-    createdAt,
   });
 }
 


### PR DESCRIPTION
## Summary
- rebuild recent Talk history replay from `talk_runs.trigger_message_id` instead of `talk_messages.run_id`
- group multi-agent replies under the triggering user turn so agents can see shared recent transcript
- add regression coverage for multi-agent replay, orphan filtering, exact `currentRunId` exclusion, and contiguous budget truncation

## Verification
- `npm -C ClawRocket run test -- src/clawrocket/talks/context-assembler.test.ts src/clawrocket/talks/direct-executor.test.ts`
- `npm -C ClawRocket run typecheck`