### PR TITLE
fix(web): make Talk file attachments reliable

### DIFF
--- a/src/clawrocket/web/routes/talks.test.ts
+++ b/src/clawrocket/web/routes/talks.test.ts
@@ -306,6 +306,27 @@ describe('talk routes', () => {
     expect(body.error.code).toBe('csrf_failed');
   });
 
+  it('returns csrf_failed for cookie-authenticated attachment uploads', async () => {
+    const form = new FormData();
+    form.append(
+      'file',
+      new File(['hello'], 'notes.txt', { type: 'text/plain' }),
+    );
+
+    const res = await server.request('/api/v1/talks/talk-owner/attachments', {
+      method: 'POST',
+      headers: {
+        Cookie: 'cr_access_token=owner-token; cr_csrf_token=csrf-a',
+      },
+      body: form,
+    });
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as any;
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('csrf_failed');
+  });
+
   it('returns talk detail only for authorized users', async () => {
     const memberRes = await server.request('/api/v1/talks/talk-owner', {
       headers: {

--- a/src/clawrocket/web/server.ts
+++ b/src/clawrocket/web/server.ts
@@ -3041,7 +3041,7 @@ function buildApp(opts: WebServerOptions): Hono {
     });
     if (!csrf.ok) {
       return c.json(
-        { ok: false, error: { code: 'csrf_invalid', message: csrf.reason } },
+        { ok: false, error: { code: 'csrf_failed', message: csrf.reason } },
         403,
       );
     }
@@ -3101,7 +3101,7 @@ function buildApp(opts: WebServerOptions): Hono {
     });
     if (!csrf.ok) {
       return c.json(
-        { ok: false, error: { code: 'csrf_invalid', message: csrf.reason } },
+        { ok: false, error: { code: 'csrf_failed', message: csrf.reason } },
         403,
       );
     }
@@ -3147,7 +3147,7 @@ function buildApp(opts: WebServerOptions): Hono {
     });
     if (!csrf.ok) {
       return c.json(
-        { ok: false, error: { code: 'csrf_invalid', message: csrf.reason } },
+        { ok: false, error: { code: 'csrf_failed', message: csrf.reason } },
         403,
       );
     }
@@ -3208,7 +3208,7 @@ function buildApp(opts: WebServerOptions): Hono {
     });
     if (!csrf.ok) {
       return c.json(
-        { ok: false, error: { code: 'csrf_invalid', message: csrf.reason } },
+        { ok: false, error: { code: 'csrf_failed', message: csrf.reason } },
         403,
       );
     }
@@ -3244,7 +3244,7 @@ function buildApp(opts: WebServerOptions): Hono {
     });
     if (!csrf.ok) {
       return c.json(
-        { ok: false, error: { code: 'csrf_invalid', message: csrf.reason } },
+        { ok: false, error: { code: 'csrf_failed', message: csrf.reason } },
         403,
       );
     }
@@ -3322,7 +3322,7 @@ function buildApp(opts: WebServerOptions): Hono {
     });
     if (!csrf.ok) {
       return c.json(
-        { ok: false, error: { code: 'csrf_invalid', message: csrf.reason } },
+        { ok: false, error: { code: 'csrf_failed', message: csrf.reason } },
         403,
       );
     }
@@ -3388,7 +3388,7 @@ function buildApp(opts: WebServerOptions): Hono {
     });
     if (!csrf.ok) {
       return c.json(
-        { ok: false, error: { code: 'csrf_invalid', message: csrf.reason } },
+        { ok: false, error: { code: 'csrf_failed', message: csrf.reason } },
         403,
       );
     }
@@ -3426,7 +3426,7 @@ function buildApp(opts: WebServerOptions): Hono {
       });
       if (!csrf.ok) {
         return c.json(
-          { ok: false, error: { code: 'csrf_invalid', message: csrf.reason } },
+          { ok: false, error: { code: 'csrf_failed', message: csrf.reason } },
           403,
         );
       }
@@ -3474,7 +3474,7 @@ function buildApp(opts: WebServerOptions): Hono {
     });
     if (!csrf.ok) {
       return c.json(
-        { ok: false, error: { code: 'csrf_invalid', message: csrf.reason } },
+        { ok: false, error: { code: 'csrf_failed', message: csrf.reason } },
         403,
       );
     }

--- a/webapp/src/lib/api.test.ts
+++ b/webapp/src/lib/api.test.ts
@@ -363,6 +363,87 @@ describe('api auth retry behavior', () => {
     );
   });
 
+  it('retries multipart attachment uploads after csrf_failed and preserves the file payload', async () => {
+    const mutationHeaders: Array<Record<string, string>> = [];
+    const uploadedFiles: string[] = [];
+
+    cookieValue = '';
+    vi.stubGlobal(
+      'fetch',
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const path = normalizePath(input);
+        if (path === '/api/v1/talks/talk-1/attachments') {
+          mutationHeaders.push(readHeaders(init));
+
+          if (!(init?.body instanceof FormData)) {
+            throw new Error('Expected multipart FormData upload body');
+          }
+
+          const file = init.body.get('file');
+          if (!(file instanceof File)) {
+            throw new Error('Expected file entry in upload FormData');
+          }
+          uploadedFiles.push(`${file.name}:${file.type}:${file.size}`);
+
+          if (mutationHeaders.length === 1) {
+            return jsonResponse(403, {
+              ok: false,
+              error: {
+                code: 'csrf_failed',
+                message: 'Missing X-CSRF-Token header',
+              },
+            });
+          }
+
+          return jsonResponse(201, {
+            ok: true,
+            data: {
+              attachment: {
+                id: 'att-1',
+                fileName: file.name,
+                fileSize: file.size,
+                mimeType: file.type,
+                extractionStatus: 'extracted',
+              },
+            },
+          });
+        }
+
+        if (path === '/api/v1/auth/refresh') {
+          cookieValue = 'cr_csrf_token=upload-refresh-token';
+          return jsonResponse(200, {
+            ok: true,
+            data: {
+              user: {
+                id: 'u1',
+                email: 'owner@example.com',
+                displayName: 'Owner',
+                role: 'owner',
+              },
+            },
+          });
+        }
+
+        throw new Error(`Unexpected fetch path: ${path}`);
+      },
+    );
+
+    const api = await loadApiModule();
+    const attachment = await api.uploadTalkAttachment(
+      'talk-1',
+      new File(['hello'], 'notes.txt', { type: 'text/plain' }),
+    );
+
+    expect(attachment.attachment.id).toBe('att-1');
+    expect(mutationHeaders).toHaveLength(2);
+    expect(mutationHeaders[0]['x-csrf-token']).toBeUndefined();
+    expect(mutationHeaders[1]['x-csrf-token']).toBe('upload-refresh-token');
+    expect(uploadedFiles).toEqual([
+      'notes.txt:text/plain:5',
+      'notes.txt:text/plain:5',
+    ]);
+  });
+
   it('coalesces concurrent mutation refreshes and rebuilds fresh headers for both retries', async () => {
     const counts = new Map<string, number>();
     const createTalkHeaders: Array<Record<string, string>> = [];

--- a/webapp/src/pages/TalkDetailPage.test.tsx
+++ b/webapp/src/pages/TalkDetailPage.test.tsx
@@ -1,6 +1,7 @@
 import {
   act,
   cleanup,
+  fireEvent,
   render,
   screen,
   waitFor,
@@ -25,6 +26,7 @@ import type {
   TalkChannelBinding,
   TalkDataConnector,
   TalkMessage,
+  TalkMessageAttachment,
   TalkRun,
 } from '../lib/api';
 
@@ -486,6 +488,89 @@ describe('TalkDetailPage', () => {
     await waitFor(() => expect(composer).toHaveValue(''));
   });
 
+  it('attaches dropped files from the talk workspace and sends their attachment ids', async () => {
+    const user = userEvent.setup();
+    let uploadedFileName: string | null = null;
+    let sentBody:
+      | {
+          content: string;
+          targetAgentIds: string[];
+          attachmentIds?: string[];
+        }
+      | undefined;
+
+    installTalkDetailFetch({
+      messages: [],
+      runs: [],
+      onUploadAttachment: (formData) => {
+        const file = formData.get('file');
+        if (!(file instanceof File)) {
+          throw new Error('Expected file in attachment upload payload');
+        }
+        uploadedFileName = file.name;
+        return buildMessageAttachment({
+          id: 'att-1',
+          fileName: file.name,
+          fileSize: file.size,
+          mimeType: file.type,
+          extractionStatus: 'extracted',
+        });
+      },
+      onSendMessage: (body) => {
+        sentBody = body;
+        return {
+          talkId: 'talk-1',
+          message: buildMessage({
+            id: 'msg-posted',
+            role: 'user',
+            content: body.content,
+            createdAt: '2026-03-06T00:00:05.000Z',
+          }),
+          runs: [],
+        };
+      },
+    });
+
+    renderDetailPage('/app/talks/talk-1');
+    const composer = await screen.findByPlaceholderText('Send a message to this talk');
+    const workspace = composer.closest('.talk-workspace');
+    if (!workspace) {
+      throw new Error('Expected talk workspace wrapper');
+    }
+
+    const file = new File(['hello world'], 'notes.txt', { type: 'text/plain' });
+    const dataTransfer = createFileDataTransfer([file]);
+
+    const windowDragOverEvent = new Event('dragover', {
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(windowDragOverEvent, 'dataTransfer', {
+      value: dataTransfer,
+    });
+    window.dispatchEvent(windowDragOverEvent);
+    expect(windowDragOverEvent.defaultPrevented).toBe(true);
+
+    fireEvent.dragEnter(workspace, { dataTransfer });
+    expect(await screen.findByText('Drop files to attach')).toBeTruthy();
+
+    fireEvent.drop(workspace, { dataTransfer });
+
+    expect(await screen.findByText('notes.txt')).toBeTruthy();
+    expect(uploadedFileName).toBe('notes.txt');
+
+    await user.type(composer, 'Please review the attachment.');
+    await user.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() =>
+      expect(sentBody).toMatchObject({
+        content: 'Please review the attachment.',
+        targetAgentIds: ['agent-claude'],
+        attachmentIds: ['att-1'],
+      }),
+    );
+  });
+
   it('renders concurrent live responses as separate streaming bubbles', async () => {
     installTalkDetailFetch();
 
@@ -777,6 +862,22 @@ function buildMessage(
   };
 }
 
+function buildMessageAttachment(
+  input: Partial<TalkMessageAttachment> &
+    Pick<
+      TalkMessageAttachment,
+      'id' | 'fileName' | 'fileSize' | 'mimeType' | 'extractionStatus'
+    >,
+): TalkMessageAttachment {
+  return {
+    id: input.id,
+    fileName: input.fileName,
+    fileSize: input.fileSize,
+    mimeType: input.mimeType,
+    extractionStatus: input.extractionStatus,
+  };
+}
+
 function buildRun(
   input: Partial<TalkRun> & Pick<TalkRun, 'id' | 'status' | 'createdAt'>,
 ): TalkRun {
@@ -794,6 +895,25 @@ function buildRun(
     executorAlias: input.executorAlias ?? null,
     executorModel: input.executorModel ?? null,
   };
+}
+
+function createFileDataTransfer(files: File[]): DataTransfer {
+  return {
+    files,
+    items: files.map((file) => ({
+      kind: 'file',
+      type: file.type,
+      getAsFile: () => file,
+    })),
+    types: {
+      0: 'Files',
+      length: 1,
+      contains: (value: string) => value === 'Files',
+      item: (index: number) => (index === 0 ? 'Files' : null),
+    },
+    dropEffect: 'copy',
+    effectAllowed: 'all',
+  } as unknown as DataTransfer;
 }
 
 function buildDataConnector(
@@ -1011,9 +1131,11 @@ function installTalkDetailFetch(input?: {
   onPutAgents?: (body: SavedTalkAgentRequest) => TalkAgent[];
   onGetContext?: () => TalkContext;
   onRetryContextSource?: (sourceId: string) => ContextSource;
+  onUploadAttachment?: (formData: FormData) => TalkMessageAttachment;
   onSendMessage?: (body: {
     content: string;
     targetAgentIds: string[];
+    attachmentIds?: string[];
   }) => { talkId: string; message: TalkMessage; runs: TalkRun[] };
 }) {
   const talk = input?.talk ?? buildTalk();
@@ -1155,6 +1277,32 @@ function installTalkDetailFetch(input?: {
             deletedCount: deletedMessageIds.length,
             deletedMessageIds,
           },
+        });
+      }
+
+      if (url.endsWith('/api/v1/talks/talk-1/attachments') && method === 'POST') {
+        if (!(init?.body instanceof FormData)) {
+          throw new Error('Expected attachment uploads to use FormData');
+        }
+
+        const file = init.body.get('file');
+        if (!(file instanceof File)) {
+          throw new Error('Expected file payload for attachment upload');
+        }
+
+        const attachment =
+          input?.onUploadAttachment?.(init.body) ??
+          buildMessageAttachment({
+            id: 'att-1',
+            fileName: file.name,
+            fileSize: file.size,
+            mimeType: file.type,
+            extractionStatus: 'extracted',
+          });
+
+        return jsonResponse(201, {
+          ok: true,
+          data: { attachment },
         });
       }
 

--- a/webapp/src/pages/TalkDetailPage.tsx
+++ b/webapp/src/pages/TalkDetailPage.tsx
@@ -315,6 +315,21 @@ function mapRunsById(runs: TalkRun[]): Record<string, RunView> {
   }, {});
 }
 
+function hasFileTransfer(dataTransfer: DataTransfer | null | undefined): boolean {
+  if (!dataTransfer) return false;
+  if (dataTransfer.files.length > 0) return true;
+
+  const { types } = dataTransfer;
+  if (!types) return false;
+
+  const domTypes = types as unknown as DOMStringList;
+  if (typeof domTypes.contains === 'function') {
+    return domTypes.contains('Files');
+  }
+
+  return Array.from(types as ArrayLike<string>).includes('Files');
+}
+
 function withRun(
   state: DetailState,
   runId: string,
@@ -2516,7 +2531,7 @@ export function TalkDetailPage({
     event.preventDefault();
     event.stopPropagation();
     dragCounterRef.current += 1;
-    if (event.dataTransfer.types.includes('Files')) {
+    if (hasFileTransfer(event.dataTransfer)) {
       setIsDragOver(true);
     }
   };
@@ -2524,7 +2539,7 @@ export function TalkDetailPage({
   const handleDragLeave = (event: React.DragEvent) => {
     event.preventDefault();
     event.stopPropagation();
-    dragCounterRef.current -= 1;
+    dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
     if (dragCounterRef.current === 0) {
       setIsDragOver(false);
     }
@@ -2533,6 +2548,9 @@ export function TalkDetailPage({
   const handleDragOver = (event: React.DragEvent) => {
     event.preventDefault();
     event.stopPropagation();
+    if (hasFileTransfer(event.dataTransfer)) {
+      event.dataTransfer.dropEffect = 'copy';
+    }
   };
 
   const handleDrop = (event: React.DragEvent) => {
@@ -2544,6 +2562,36 @@ export function TalkDetailPage({
       void handleFilesSelected(event.dataTransfer.files);
     }
   };
+
+  useEffect(() => {
+    if (currentTab !== 'talk') {
+      dragCounterRef.current = 0;
+      setIsDragOver(false);
+      return;
+    }
+
+    const preventWindowFileNavigation = (event: DragEvent) => {
+      if (!hasFileTransfer(event.dataTransfer)) return;
+      event.preventDefault();
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = 'copy';
+      }
+      if (event.type === 'drop') {
+        dragCounterRef.current = 0;
+        setIsDragOver(false);
+      }
+    };
+
+    window.addEventListener('dragenter', preventWindowFileNavigation, true);
+    window.addEventListener('dragover', preventWindowFileNavigation, true);
+    window.addEventListener('drop', preventWindowFileNavigation, true);
+
+    return () => {
+      window.removeEventListener('dragenter', preventWindowFileNavigation, true);
+      window.removeEventListener('dragover', preventWindowFileNavigation, true);
+      window.removeEventListener('drop', preventWindowFileNavigation, true);
+    };
+  }, [currentTab]);
 
   const handleToggleTarget = (agentId: string) => {
     setTargetAgentIds((current) => {


### PR DESCRIPTION
## Summary
- expand the Talk file drop target to the full chat workspace and suppress browser file-drop navigation defensively
- fix newer Talk context and attachment routes to return `csrf_failed` so multipart uploads retry correctly after CSRF refresh
- add regression coverage for dropped-file attach flow, multipart upload retry behavior, and attachment-route CSRF responses

## Why
Users could not reliably add files to a Talk.

In the running app, there was no effective drag/drop target across the chat area, so dropping a `.txt` file could navigate the browser to the file instead of attaching it. Separately, attachment uploads could fail after a stale CSRF token because the server returned `csrf_invalid` while the frontend only retries on `csrf_failed`.

This PR combines both fixes so there is a single merge/deploy path.

## Verification
- `npm --prefix ClawRocket/webapp test -- src/lib/api.test.ts -t "retries multipart attachment uploads"`
- `npm --prefix ClawRocket/webapp test -- src/pages/TalkDetailPage.test.tsx -t "attaches dropped files"`
- `npm --prefix ClawRocket test -- src/clawrocket/web/routes/talks.test.ts -t "returns csrf_failed for cookie-authenticated attachment uploads"`
- `npm --prefix ClawRocket/webapp run typecheck`
- `npm --prefix ClawRocket run typecheck`