### PR TITLE
Fix Claude setup UX and hide internal talk traces

### DIFF
--- a/src/clawrocket/talks/internal-tags.ts
+++ b/src/clawrocket/talks/internal-tags.ts
@@ -1,0 +1,25 @@
+const INTERNAL_TAG_PATTERN = /<internal>[\s\S]*?(?:<\/internal>|$)/g;
+
+export function stripInternalTalkResponseText(text: string): string {
+  if (!text) return '';
+  return text.replace(INTERNAL_TAG_PATTERN, '');
+}
+
+export interface TalkResponseStreamSanitizer {
+  push(chunk: string): string;
+}
+
+export function createTalkResponseStreamSanitizer(): TalkResponseStreamSanitizer {
+  let rawText = '';
+  let visibleText = '';
+
+  return {
+    push(chunk: string): string {
+      rawText += chunk;
+      const nextVisibleText = stripInternalTalkResponseText(rawText);
+      const nextDeltaText = nextVisibleText.slice(visibleText.length);
+      visibleText = nextVisibleText;
+      return nextDeltaText;
+    },
+  };
+}

--- a/src/clawrocket/talks/run-worker.test.ts
+++ b/src/clawrocket/talks/run-worker.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../db/index.js';
 
 import type {
+  TalkExecutionEvent,
   TalkExecutor,
   TalkExecutorInput,
   TalkExecutorOutput,
@@ -59,6 +60,53 @@ class AliasUnmappedExecutor implements TalkExecutor {
       'executor_alias_unmapped',
       'No model mapping configured for alias',
     );
+  }
+}
+
+class InternalTagExecutor implements TalkExecutor {
+  async execute(
+    input: TalkExecutorInput,
+    _signal: AbortSignal,
+    emit?: (event: TalkExecutionEvent) => void,
+  ): Promise<TalkExecutorOutput> {
+    emit?.({
+      type: 'talk_response_started',
+      runId: input.runId,
+      talkId: input.talkId,
+      agentNickname: 'Claude Sonnet 4.6',
+    });
+    emit?.({
+      type: 'talk_response_delta',
+      runId: input.runId,
+      talkId: input.talkId,
+      deltaText: '<internal>thinking',
+      agentNickname: 'Claude Sonnet 4.6',
+    });
+    emit?.({
+      type: 'talk_response_delta',
+      runId: input.runId,
+      talkId: input.talkId,
+      deltaText: ' harder</internal>Hello',
+      agentNickname: 'Claude Sonnet 4.6',
+    });
+    emit?.({
+      type: 'talk_response_delta',
+      runId: input.runId,
+      talkId: input.talkId,
+      deltaText: ' world',
+      agentNickname: 'Claude Sonnet 4.6',
+    });
+    emit?.({
+      type: 'talk_response_completed',
+      runId: input.runId,
+      talkId: input.talkId,
+      agentNickname: 'Claude Sonnet 4.6',
+    });
+
+    return {
+      content: '<internal>thinking harder</internal>Hello world',
+      agentNickname: 'Claude Sonnet 4.6',
+    };
   }
 }
 
@@ -368,6 +416,51 @@ describe('TalkRunWorker', () => {
     expect(failedEvent?.payload).toContain(
       '"errorCode":"executor_alias_unmapped"',
     );
+
+    await worker.stop();
+  });
+
+  it('strips internal tags from streamed events and persisted assistant messages', async () => {
+    const worker = new TalkRunWorker({
+      executor: new InternalTagExecutor(),
+      pollMs: 10_000,
+      maxConcurrency: 1,
+    });
+    await worker.start();
+
+    enqueueTalkTurnAtomic({
+      talkId: 'talk-1',
+      userId: 'owner-1',
+      content: 'tell me something',
+      messageId: 'msg-8',
+      runId: 'run-8',
+    });
+
+    worker.wake();
+    await waitFor(() => getTalkRunById('run-8')?.status === 'completed');
+
+    const events = getOutboxEventsForTopics(['talk:talk-1'], 0, 100).filter(
+      (event) =>
+        event.event_type === 'talk_response_delta' &&
+        event.payload.includes('"runId":"run-8"'),
+    );
+    expect(events.map((event) => event.payload).join('')).not.toContain(
+      '<internal>',
+    );
+    expect(
+      events
+        .map((event) => JSON.parse(event.payload) as { deltaText: string })
+        .map((event) => event.deltaText)
+        .join(''),
+    ).toBe('Hello world');
+
+    const assistantMessage = listTalkMessages({
+      talkId: 'talk-1',
+      limit: 20,
+    }).find(
+      (message) => message.run_id === 'run-8' && message.role === 'assistant',
+    );
+    expect(assistantMessage?.content).toBe('Hello world');
 
     await worker.stop();
   });

--- a/src/clawrocket/talks/run-worker.ts
+++ b/src/clawrocket/talks/run-worker.ts
@@ -18,6 +18,11 @@ import {
   type TalkExecutionEvent,
   type TalkExecutor,
 } from './executor.js';
+import {
+  createTalkResponseStreamSanitizer,
+  stripInternalTalkResponseText,
+  type TalkResponseStreamSanitizer,
+} from './internal-tags.js';
 import { MockTalkExecutor } from './mock-executor.js';
 
 export interface TalkRunWorkerOptions {
@@ -63,6 +68,10 @@ export class TalkRunWorker implements TalkRunWorkerControl {
 
   private readonly activeRunsById = new Map<string, ActiveRun>();
   private readonly activeRunTasks = new Map<string, Promise<void>>();
+  private readonly responseSanitizersByRunId = new Map<
+    string,
+    TalkResponseStreamSanitizer
+  >();
 
   constructor(options: TalkRunWorkerOptions = {}) {
     this.executor = options.executor || new MockTalkExecutor();
@@ -225,7 +234,7 @@ export class TalkRunWorker implements TalkRunWorkerControl {
       const completed = completeRunAndPromoteNextAtomic({
         runId: run.id,
         responseMessageId: `msg_${randomUUID()}`,
-        responseContent: output.content,
+        responseContent: stripInternalTalkResponseText(output.content),
         responseMetadataJson: output.metadataJson,
         agentId: output.agentId,
         agentNickname: output.agentNickname,
@@ -259,6 +268,34 @@ export class TalkRunWorker implements TalkRunWorkerControl {
   }
 
   private emitExecutionEvent(event: TalkExecutionEvent): void {
+    if (event.type === 'talk_response_started') {
+      this.responseSanitizersByRunId.set(
+        event.runId,
+        createTalkResponseStreamSanitizer(),
+      );
+    } else if (event.type === 'talk_response_delta') {
+      const sanitizer =
+        this.responseSanitizersByRunId.get(event.runId) ||
+        createTalkResponseStreamSanitizer();
+      this.responseSanitizersByRunId.set(event.runId, sanitizer);
+
+      const deltaText = sanitizer.push(event.deltaText);
+      if (!deltaText) {
+        return;
+      }
+
+      event = {
+        ...event,
+        deltaText,
+      };
+    } else if (
+      event.type === 'talk_response_completed' ||
+      event.type === 'talk_response_failed' ||
+      event.type === 'talk_response_cancelled'
+    ) {
+      this.responseSanitizersByRunId.delete(event.runId);
+    }
+
     appendOutboxEvent({
       topic: `talk:${event.talkId}`,
       eventType: event.type,

--- a/webapp/src/lib/assistantText.ts
+++ b/webapp/src/lib/assistantText.ts
@@ -1,0 +1,6 @@
+const INTERNAL_TAG_PATTERN = /<internal>[\s\S]*?(?:<\/internal>|$)/g;
+
+export function stripInternalAssistantText(text: string): string {
+  if (!text) return '';
+  return text.replace(INTERNAL_TAG_PATTERN, '');
+}

--- a/webapp/src/pages/AiAgentsPage.test.tsx
+++ b/webapp/src/pages/AiAgentsPage.test.tsx
@@ -47,11 +47,11 @@ describe('AiAgentsPage', () => {
       screen.queryByRole('button', { name: /Check host Claude login/i }),
     ).toBeNull();
     expect(screen.getByLabelText('Claude Code OAuth token')).toBeTruthy();
-    expect(
-      await screen.findByText(/Checked as user k1min8r/i),
-    ).toBeTruthy();
+    expect(await screen.findByText(/Checked as user k1min8r/i)).toBeTruthy();
 
-    const openAiCard = screen.getByRole('heading', { name: 'OpenAI' }).closest('article');
+    const openAiCard = screen
+      .getByRole('heading', { name: 'OpenAI' })
+      .closest('article');
     if (!openAiCard) {
       throw new Error('Expected OpenAI provider card');
     }
@@ -91,7 +91,9 @@ describe('AiAgentsPage', () => {
 
     await screen.findByRole('heading', { name: 'AI Agents' });
 
-    const openAiCard = screen.getByRole('heading', { name: 'OpenAI' }).closest('article');
+    const openAiCard = screen
+      .getByRole('heading', { name: 'OpenAI' })
+      .closest('article');
     if (!openAiCard) {
       throw new Error('Expected OpenAI provider card');
     }
@@ -100,7 +102,9 @@ describe('AiAgentsPage', () => {
     await user.click(within(openAiCard).getByRole('button', { name: 'Save' }));
 
     expect(
-      await screen.findByText('OpenAI credential saved. Verification status: invalid.'),
+      await screen.findByText(
+        'OpenAI credential saved. Verification status: invalid.',
+      ),
     ).toBeTruthy();
   });
 
@@ -137,9 +141,66 @@ describe('AiAgentsPage', () => {
     expect(within(nvidiaCard).getByText('Needs verification')).toBeTruthy();
 
     expect(
-      await screen.findByText('NVIDIA Kimi2.5 credential verified.', {}, { timeout: 4_000 }),
+      await screen.findByText(
+        'NVIDIA Kimi2.5 credential verified.',
+        {},
+        { timeout: 4_000 },
+      ),
     ).toBeTruthy();
     expect(within(nvidiaCard).getByText('Configured')).toBeTruthy();
+  });
+
+  it('prefers manual token guidance when host import is unavailable', async () => {
+    installAiAgentsFetch();
+
+    render(
+      <MemoryRouter initialEntries={['/app/agents']}>
+        <AiAgentsPage onUnauthorized={vi.fn()} userRole="owner" />
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole('heading', { name: 'AI Agents' });
+    expect(
+      await screen.findByText(
+        /Automatic host import is unavailable for this Claude login/i,
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText(/^claude login$/)).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: 'Import from host' }),
+    ).toBeNull();
+  });
+
+  it('auto-verifies Claude after saving a manually pasted subscription token', async () => {
+    const user = userEvent.setup();
+    const helpers = installAiAgentsFetch();
+
+    render(
+      <MemoryRouter initialEntries={['/app/agents']}>
+        <AiAgentsPage onUnauthorized={vi.fn()} userRole="owner" />
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole('heading', { name: 'AI Agents' });
+    await user.type(
+      screen.getByLabelText('Claude Code OAuth token'),
+      'oauth-token-test',
+    );
+    expect(
+      screen.getByRole('button', { name: 'Save and verify Claude' }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole('button', { name: 'Verify stored credential' }),
+    ).toBeNull();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Save and verify Claude' }),
+    );
+
+    expect(
+      await screen.findByText('Claude verification started.'),
+    ).toBeTruthy();
+    expect(helpers.getExecutorVerifyCalls()).toBe(1);
   });
 });
 
@@ -148,6 +209,7 @@ function installAiAgentsFetch() {
   let settings = buildExecutorSettings();
   let status = buildExecutorStatus();
   let nvidiaVerificationPending = false;
+  let executorVerifyCalls = 0;
 
   vi.stubGlobal(
     'fetch',
@@ -188,8 +250,59 @@ function installAiAgentsFetch() {
         return jsonResponse(200, { ok: true, data: settings });
       }
 
-      if (url.endsWith('/api/v1/settings/executor-status') && method === 'GET') {
+      if (
+        url.endsWith('/api/v1/settings/executor-status') &&
+        method === 'GET'
+      ) {
         return jsonResponse(200, { ok: true, data: status });
+      }
+
+      if (url.endsWith('/api/v1/settings/executor') && method === 'PUT') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<
+          string,
+          string
+        >;
+        settings = {
+          ...settings,
+          executorAuthMode:
+            body.executorAuthMode === 'api_key' ? 'api_key' : 'subscription',
+          hasApiKey: body.anthropicApiKey ? true : settings.hasApiKey,
+          hasOauthToken: body.claudeOauthToken ? true : settings.hasOauthToken,
+          activeCredentialConfigured:
+            !!body.anthropicApiKey || !!body.claudeOauthToken
+              ? true
+              : settings.activeCredentialConfigured,
+          apiKeyHint: body.anthropicApiKey ? '••••test' : settings.apiKeyHint,
+          oauthTokenHint: body.claudeOauthToken
+            ? '••••uAAA'
+            : settings.oauthTokenHint,
+        };
+        status = {
+          ...status,
+          executorAuthMode: settings.executorAuthMode,
+          activeCredentialConfigured: settings.activeCredentialConfigured,
+        };
+        return jsonResponse(200, { ok: true, data: settings });
+      }
+
+      if (
+        url.endsWith('/api/v1/settings/executor/verify') &&
+        method === 'POST'
+      ) {
+        executorVerifyCalls += 1;
+        status = {
+          ...status,
+          verificationStatus: 'verifying',
+          activeCredentialConfigured: true,
+        };
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            scheduled: true,
+            code: 'verification_scheduled',
+            message: 'Claude verification started.',
+          },
+        });
       }
 
       if (
@@ -218,7 +331,10 @@ function installAiAgentsFetch() {
         });
       }
 
-      if (url.endsWith('/api/v1/agents/providers/provider.openai') && method === 'PUT') {
+      if (
+        url.endsWith('/api/v1/agents/providers/provider.openai') &&
+        method === 'PUT'
+      ) {
         snapshot = {
           ...snapshot,
           additionalProviders: snapshot.additionalProviders.map((provider) =>
@@ -239,7 +355,10 @@ function installAiAgentsFetch() {
         return jsonResponse(200, { ok: true, data: { provider } });
       }
 
-      if (url.endsWith('/api/v1/agents/providers/provider.nvidia') && method === 'PUT') {
+      if (
+        url.endsWith('/api/v1/agents/providers/provider.nvidia') &&
+        method === 'PUT'
+      ) {
         nvidiaVerificationPending = true;
         snapshot = {
           ...snapshot,
@@ -264,6 +383,10 @@ function installAiAgentsFetch() {
       throw new Error(`Unexpected fetch: ${method} ${url}`);
     }),
   );
+
+  return {
+    getExecutorVerifyCalls: (): number => executorVerifyCalls,
+  };
 }
 
 function buildAiAgentsData(): AiAgentsPageData {

--- a/webapp/src/pages/AiAgentsPage.tsx
+++ b/webapp/src/pages/AiAgentsPage.tsx
@@ -61,7 +61,9 @@ function validateReturnTo(value: string | null): string | null {
   return value;
 }
 
-function formatClaudeAuthMode(mode: ExecutorSettings['executorAuthMode']): string {
+function formatClaudeAuthMode(
+  mode: ExecutorSettings['executorAuthMode'],
+): string {
   switch (mode) {
     case 'subscription':
       return 'Subscription (Claude Pro/Max)';
@@ -75,7 +77,9 @@ function formatClaudeAuthMode(mode: ExecutorSettings['executorAuthMode']): strin
 }
 
 function formatVerificationStatus(
-  status: ExecutorStatus['verificationStatus'] | AgentProviderCard['verificationStatus'],
+  status:
+    | ExecutorStatus['verificationStatus']
+    | AgentProviderCard['verificationStatus'],
 ): string {
   switch (status) {
     case 'missing':
@@ -96,7 +100,9 @@ function formatVerificationStatus(
 }
 
 function verificationStatusClass(
-  status: ExecutorStatus['verificationStatus'] | AgentProviderCard['verificationStatus'],
+  status:
+    | ExecutorStatus['verificationStatus']
+    | AgentProviderCard['verificationStatus'],
 ): string {
   switch (status) {
     case 'verified':
@@ -129,7 +135,9 @@ function currentClaudeHint(
   settings: ExecutorSettings,
   mode: ClaudeAuthMode,
 ): string | null {
-  return mode === 'subscription' ? settings.oauthTokenHint : settings.apiKeyHint;
+  return mode === 'subscription'
+    ? settings.oauthTokenHint
+    : settings.apiKeyHint;
 }
 
 function currentClaudeStored(
@@ -177,10 +185,7 @@ function delay(ms: number): Promise<void> {
   });
 }
 
-export function AiAgentsPage({
-  onUnauthorized,
-  userRole,
-}: Props): JSX.Element {
+export function AiAgentsPage({ onUnauthorized, userRole }: Props): JSX.Element {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const [data, setData] = useState<AiAgentsPageData | null>(null);
@@ -190,10 +195,11 @@ export function AiAgentsPage({
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [busyKey, setBusyKey] = useState<string | null>(null);
-  const [providerDrafts, setProviderDrafts] = useState<Record<string, ProviderDraft>>(
-    {},
-  );
-  const [claudeModeDraft, setClaudeModeDraft] = useState<ClaudeAuthMode>('subscription');
+  const [providerDrafts, setProviderDrafts] = useState<
+    Record<string, ProviderDraft>
+  >({});
+  const [claudeModeDraft, setClaudeModeDraft] =
+    useState<ClaudeAuthMode>('subscription');
   const [claudeModelDraft, setClaudeModelDraft] = useState('');
   const [claudeApiKeyDraft, setClaudeApiKeyDraft] = useState('');
   const [claudeOauthDraft, setClaudeOauthDraft] = useState('');
@@ -251,7 +257,9 @@ export function AiAgentsPage({
         onUnauthorized();
         return;
       }
-      setError(err instanceof ApiError ? err.message : 'Failed to load AI agents.');
+      setError(
+        err instanceof ApiError ? err.message : 'Failed to load AI agents.',
+      );
     } finally {
       setLoading(false);
     }
@@ -414,6 +422,10 @@ export function AiAgentsPage({
       const update: Record<string, string | null> = {
         executorAuthMode: claudeModeDraft,
       };
+      const shouldAutoVerify =
+        (claudeModeDraft === 'subscription' &&
+          claudeOauthDraft.trim().length > 0) ||
+        (claudeModeDraft === 'api_key' && claudeApiKeyDraft.trim().length > 0);
       if (claudeModeDraft === 'subscription') {
         if (claudeOauthDraft.trim()) {
           update.claudeOauthToken = claudeOauthDraft.trim();
@@ -429,12 +441,18 @@ export function AiAgentsPage({
           : Promise.resolve(data),
       ]);
       syncDrafts(nextAgents, nextSettings);
+      let verifyMessage: string | null = null;
+      if (shouldAutoVerify) {
+        const result = await verifyExecutorCredentials();
+        verifyMessage = result.message || 'Claude verification started.';
+      }
       const nextStatus = await getExecutorStatus();
       setStatus(nextStatus);
       setNotice(
-        claudeModeDraft === 'subscription'
-          ? 'Default Claude Agent updated for subscription mode.'
-          : 'Default Claude Agent updated for API mode.',
+        verifyMessage ||
+          (claudeModeDraft === 'subscription'
+            ? 'Default Claude Agent updated for subscription mode.'
+            : 'Default Claude Agent updated for API mode.'),
       );
     } catch (err) {
       handleApiFailure(err, 'Failed to save Claude settings.');
@@ -499,7 +517,10 @@ export function AiAgentsPage({
       });
       refreshProvider(provider);
       setNotice(formatProviderSaveNotice(provider));
-      if (provider.hasCredential && provider.verificationStatus === 'not_verified') {
+      if (
+        provider.hasCredential &&
+        provider.verificationStatus === 'not_verified'
+      ) {
         void pollProviderAfterSave(provider.id);
       }
     } catch (err) {
@@ -543,10 +564,24 @@ export function AiAgentsPage({
   };
 
   const additionalProviders = data?.additionalProviders || [];
-  const selectedClaudeHint = settings ? currentClaudeHint(settings, claudeModeDraft) : null;
+  const selectedClaudeHint = settings
+    ? currentClaudeHint(settings, claudeModeDraft)
+    : null;
   const selectedClaudeStored = settings
     ? currentClaudeStored(settings, claudeModeDraft)
     : false;
+  const hasUnsavedClaudeCredentialDraft =
+    claudeModeDraft === 'subscription'
+      ? claudeOauthDraft.trim().length > 0
+      : claudeApiKeyDraft.trim().length > 0;
+  const showManualTokenFlow =
+    claudeModeDraft === 'subscription' &&
+    !!subscriptionHostStatus?.hostLoginDetected &&
+    !subscriptionHostStatus.importAvailable;
+  const showHostLoginFlow =
+    claudeModeDraft === 'subscription' && !showManualTokenFlow;
+  const canVerifyStoredClaude =
+    canManage && selectedClaudeStored && !hasUnsavedClaudeCredentialDraft;
 
   const selectedClaudeStatus = useMemo(() => {
     if (!settings || !status) return 'Loading…';
@@ -572,7 +607,10 @@ export function AiAgentsPage({
       <header className="page-header">
         <div>
           <h1>AI Agents</h1>
-          <p>Set up your default Claude agent and any additional provider keys you want available in talks.</p>
+          <p>
+            Set up your default Claude agent and any additional provider keys
+            you want available in talks.
+          </p>
         </div>
         {returnTo ? (
           <button
@@ -601,7 +639,8 @@ export function AiAgentsPage({
           <div>
             <h3>Default Claude Agent</h3>
             <p className="talk-llm-meta">
-              Every new talk starts with Claude as the default agent. You can add other agents and roles inside the talk itself.
+              Every new talk starts with Claude as the default agent. You can
+              add other agents and roles inside the talk itself.
             </p>
           </div>
         </div>
@@ -616,7 +655,8 @@ export function AiAgentsPage({
             </div>
             <span
               className={verificationStatusClass(
-                status.executorAuthMode !== claudeModeDraft || !selectedClaudeStored
+                status.executorAuthMode !== claudeModeDraft ||
+                  !selectedClaudeStored
                   ? 'not_verified'
                   : status.verificationStatus,
               )}
@@ -677,7 +717,9 @@ export function AiAgentsPage({
                 {selectedClaudeStored ? (
                   <div className="talk-llm-stored-key">
                     <div>
-                      <strong>{selectedClaudeHint || 'Stored in settings'}</strong>
+                      <strong>
+                        {selectedClaudeHint || 'Stored in settings'}
+                      </strong>
                       <p className="talk-llm-meta">
                         Last verified {formatDateTime(status.lastVerifiedAt)}
                       </p>
@@ -688,17 +730,27 @@ export function AiAgentsPage({
                     No Claude subscription credential is stored yet.
                   </p>
                 )}
+                {showHostLoginFlow ? (
+                  <p className="talk-llm-meta">
+                    Use Claude Code on the same machine and OS user as
+                    ClawRocket. Run{' '}
+                    <code>claude config set -g forceLoginMethod claudeai</code>{' '}
+                    and then <code>claude login</code>. If host import is
+                    unavailable, you can still run{' '}
+                    <code>claude setup-token</code> and paste the token manually
+                    below.
+                  </p>
+                ) : (
+                  <p className="talk-llm-meta">
+                    Automatic host import is unavailable for this Claude login.
+                    Run <code>claude setup-token</code>, paste the token below,
+                    and save to verify it.
+                  </p>
+                )}
                 <p className="talk-llm-meta">
-                  Use Claude Code on the same machine and OS user as ClawRocket. Run:
-                  <code> claude config set -g forceLoginMethod claudeai </code>
-                  then
-                  <code> claude login</code>.
-                </p>
-                <p className="talk-llm-meta">
-                  If host import is unavailable, you can run <code>claude setup-token</code> and paste the token manually below.
-                </p>
-                <p className="talk-llm-meta">
-                  Re-verify uses the stored subscription login/token. Paste a new token only if the stored one is expired, revoked, or incorrect.
+                  Saving a new token stores it and immediately verifies it.
+                  Verify stored credential only re-checks the subscription
+                  login/token already saved in ClawRocket.
                 </p>
                 <div className="talk-llm-inline-actions">
                   {subscriptionHostStatus?.importAvailable ? (
@@ -706,7 +758,9 @@ export function AiAgentsPage({
                       type="button"
                       className="secondary-btn"
                       onClick={() => void handleImportSubscription()}
-                      disabled={!canManage || subscriptionHostBusy === 'importing'}
+                      disabled={
+                        !canManage || subscriptionHostBusy === 'importing'
+                      }
                     >
                       {subscriptionHostBusy === 'importing'
                         ? 'Importing…'
@@ -715,20 +769,28 @@ export function AiAgentsPage({
                   ) : null}
                 </div>
                 {subscriptionHostBusy === 'checking' ? (
-                  <p className="talk-llm-meta">Checking Claude login on this host…</p>
+                  <p className="talk-llm-meta">
+                    Checking Claude login on this host…
+                  </p>
                 ) : null}
                 {subscriptionHostStatus ? (
                   <div className="talk-llm-host-status">
                     <p className="talk-llm-meta">
-                      Checked as user {subscriptionHostStatus.serviceUser || 'unknown'} · Home{' '}
+                      Checked as user{' '}
+                      {subscriptionHostStatus.serviceUser || 'unknown'} · Home{' '}
                       {subscriptionHostStatus.serviceHomePath}
                     </p>
-                    <p className="talk-llm-meta">{subscriptionHostStatus.message}</p>
-                    {subscriptionHostStatus.recommendedCommands.length > 0 ? (
+                    <p className="talk-llm-meta">
+                      {subscriptionHostStatus.message}
+                    </p>
+                    {!showManualTokenFlow &&
+                    subscriptionHostStatus.recommendedCommands.length > 0 ? (
                       <div className="talk-llm-command-list">
-                        {subscriptionHostStatus.recommendedCommands.map((command) => (
-                          <code key={command}>{command}</code>
-                        ))}
+                        {subscriptionHostStatus.recommendedCommands.map(
+                          (command) => (
+                            <code key={command}>{command}</code>
+                          ),
+                        )}
                       </div>
                     ) : null}
                   </div>
@@ -748,7 +810,9 @@ export function AiAgentsPage({
                     <button
                       type="button"
                       className="talk-llm-eye-toggle"
-                      onClick={() => setShowClaudeOauthToken((current) => !current)}
+                      onClick={() =>
+                        setShowClaudeOauthToken((current) => !current)
+                      }
                       disabled={!canManage || busyKey === 'claude-save'}
                       aria-label={
                         showClaudeOauthToken
@@ -769,10 +833,16 @@ export function AiAgentsPage({
                 {selectedClaudeStored ? (
                   <div className="talk-llm-stored-key">
                     <div>
-                      <strong>{selectedClaudeHint || 'Stored in settings'}</strong>
+                      <strong>
+                        {selectedClaudeHint || 'Stored in settings'}
+                      </strong>
                       <p className="talk-llm-meta">
                         Get a key from{' '}
-                        <a href="https://console.anthropic.com/settings/keys" target="_blank" rel="noreferrer">
+                        <a
+                          href="https://console.anthropic.com/settings/keys"
+                          target="_blank"
+                          rel="noreferrer"
+                        >
                           Anthropic Console
                         </a>
                         .
@@ -816,21 +886,31 @@ export function AiAgentsPage({
           )}
 
           <div className="talk-llm-inline-actions">
-            <button
-              type="button"
-              className="secondary-btn"
-              onClick={() => void handleVerifyClaude()}
-              disabled={!canManage || busyKey === 'claude-verify'}
-            >
-              {busyKey === 'claude-verify' ? 'Verifying…' : 'Re-verify'}
-            </button>
+            {canVerifyStoredClaude ? (
+              <button
+                type="button"
+                className="secondary-btn"
+                onClick={() => void handleVerifyClaude()}
+                disabled={busyKey === 'claude-verify'}
+              >
+                {busyKey === 'claude-verify'
+                  ? 'Verifying…'
+                  : 'Verify stored credential'}
+              </button>
+            ) : null}
             <button
               type="button"
               className="primary-btn"
               onClick={() => void handleSaveClaude()}
               disabled={!canManage || busyKey === 'claude-save'}
             >
-              {busyKey === 'claude-save' ? 'Saving…' : 'Save Claude Settings'}
+              {busyKey === 'claude-save'
+                ? hasUnsavedClaudeCredentialDraft
+                  ? 'Saving and verifying…'
+                  : 'Saving…'
+                : hasUnsavedClaudeCredentialDraft
+                  ? 'Save and verify Claude'
+                  : 'Save Claude Settings'}
             </button>
           </div>
         </article>
@@ -841,14 +921,16 @@ export function AiAgentsPage({
           <div>
             <h3>Additional Providers</h3>
             <p className="talk-llm-meta">
-              Add any other provider keys you want available when inviting extra agents into a talk.
+              Add any other provider keys you want available when inviting extra
+              agents into a talk.
             </p>
           </div>
         </div>
 
         <div className="talk-llm-card-list">
           {additionalProviders.map((provider) => {
-            const draft = providerDrafts[provider.id] || buildProviderDraft(provider);
+            const draft =
+              providerDrafts[provider.id] || buildProviderDraft(provider);
             const busySave = busyKey === `provider-save:${provider.id}`;
             const busyVerify = busyKey === `provider-verify:${provider.id}`;
             return (
@@ -863,22 +945,29 @@ export function AiAgentsPage({
                           target="_blank"
                           rel="noreferrer"
                         >
-                          Get key from {PROVIDER_DOCS_LABEL[provider.id] || provider.name}
+                          Get key from{' '}
+                          {PROVIDER_DOCS_LABEL[provider.id] || provider.name}
                         </a>
                       ) : (
                         'Configure this provider for additional talk agents.'
                       )}
                     </p>
                   </div>
-                    <span className={verificationStatusClass(provider.verificationStatus)}>
-                      {formatProviderVerificationSummary(provider)}
-                    </span>
+                  <span
+                    className={verificationStatusClass(
+                      provider.verificationStatus,
+                    )}
+                  >
+                    {formatProviderVerificationSummary(provider)}
+                  </span>
                 </div>
 
                 {provider.hasCredential ? (
                   <div className="talk-llm-stored-key">
                     <div>
-                      <strong>{provider.credentialHint || 'Stored in settings'}</strong>
+                      <strong>
+                        {provider.credentialHint || 'Stored in settings'}
+                      </strong>
                       <p className="talk-llm-meta">
                         Last verified {formatDateTime(provider.lastVerifiedAt)}
                       </p>
@@ -900,11 +989,14 @@ export function AiAgentsPage({
                   open={draft.expanded}
                   onToggle={(event) =>
                     updateProviderDraft(provider.id, {
-                      expanded: (event.currentTarget as HTMLDetailsElement).open,
+                      expanded: (event.currentTarget as HTMLDetailsElement)
+                        .open,
                     })
                   }
                 >
-                  <summary>{provider.hasCredential ? 'Update key' : 'Configure'}</summary>
+                  <summary>
+                    {provider.hasCredential ? 'Update key' : 'Configure'}
+                  </summary>
                   <div className="talk-llm-grid">
                     <label className="talk-llm-field-span">
                       <span>API key</span>
@@ -917,7 +1009,9 @@ export function AiAgentsPage({
                               apiKey: event.target.value,
                             })
                           }
-                          placeholder={PROVIDER_KEY_PLACEHOLDER[provider.id] || 'sk-...'}
+                          placeholder={
+                            PROVIDER_KEY_PLACEHOLDER[provider.id] || 'sk-...'
+                          }
                           disabled={!canManage || busySave}
                         />
                         <button
@@ -946,7 +1040,11 @@ export function AiAgentsPage({
                         onClick={() => void handleSaveProvider(provider.id)}
                         disabled={!canManage || busySave}
                       >
-                        {busySave ? 'Saving…' : provider.hasCredential ? 'Update' : 'Save'}
+                        {busySave
+                          ? 'Saving…'
+                          : provider.hasCredential
+                            ? 'Update'
+                            : 'Save'}
                       </button>
                       {provider.hasCredential ? (
                         <button
@@ -973,7 +1071,8 @@ export function AiAgentsPage({
             <div>
               <h3>Back to Talk</h3>
               <p className="talk-llm-meta">
-                After updating Claude or provider keys, return to your talk and invite additional agents there.
+                After updating Claude or provider keys, return to your talk and
+                invite additional agents there.
               </p>
             </div>
           </div>

--- a/webapp/src/pages/TalkDetailPage.test.tsx
+++ b/webapp/src/pages/TalkDetailPage.test.tsx
@@ -47,7 +47,10 @@ describe('TalkDetailPage', () => {
   beforeEach(() => {
     document.cookie = 'cr_csrf_token=test-csrf-token';
     streamInput = null;
-    vi.stubGlobal('confirm', vi.fn(() => true));
+    vi.stubGlobal(
+      'confirm',
+      vi.fn(() => true),
+    );
     openTalkStreamMock.mockImplementation((input) => {
       streamInput = input;
       return {
@@ -74,17 +77,23 @@ describe('TalkDetailPage', () => {
     expect(screen.getByLabelText('Talk timeline')).toBeTruthy();
     expect(screen.queryByRole('heading', { name: 'Agents' })).toBeNull();
     const statusPills = screen.getByRole('list', { name: 'Talk agent status' });
-    expect(within(statusPills).getByText('Claude Sonnet 4.6 (General)')).toBeTruthy();
+    expect(
+      within(statusPills).getByText('Claude Sonnet 4.6 (General)'),
+    ).toBeTruthy();
     expect(within(statusPills).getByText('GPT-5 Mini (Critic)')).toBeTruthy();
     expect(within(statusPills).getByText('Primary')).toBeTruthy();
     expect(
-      within(statusPills).getByText('Claude Sonnet 4.6 (General)').parentElement?.className,
+      within(statusPills).getByText('Claude Sonnet 4.6 (General)').parentElement
+        ?.className,
     ).toContain('talk-status-pill-ready');
     expect(
-      within(statusPills).getByText('GPT-5 Mini (Critic)').parentElement?.className,
+      within(statusPills).getByText('GPT-5 Mini (Critic)').parentElement
+        ?.className,
     ).toContain('talk-status-pill-invalid');
 
-    const tabs = within(screen.getByRole('navigation', { name: 'Talk sections' }));
+    const tabs = within(
+      screen.getByRole('navigation', { name: 'Talk sections' }),
+    );
     await user.click(tabs.getByRole('link', { name: 'Agents' }));
     await screen.findByRole('heading', { name: 'Agents' });
     expect(screen.getByLabelText('Talk agents')).toBeTruthy();
@@ -113,7 +122,11 @@ describe('TalkDetailPage', () => {
 
     await screen.findByRole('heading', { name: 'Tools' });
     expect(screen.getByText('This Talk can search the web')).toBeTruthy();
-    expect(screen.getByText('Google Drive unavailable — bind a file or folder to enable')).toBeTruthy();
+    expect(
+      screen.getByText(
+        'Google Drive unavailable — bind a file or folder to enable',
+      ),
+    ).toBeTruthy();
     expect(screen.getByText('Claude Sonnet 4.6')).toBeTruthy();
     expect(screen.getByText(/Web Search: Available/i)).toBeTruthy();
 
@@ -190,33 +203,50 @@ describe('TalkDetailPage', () => {
     await screen.findByRole('heading', { name: 'Channels' });
 
     expect(screen.getByText('Cal Football Chat')).toBeTruthy();
-    expect(screen.getByText('Dropped after waiting too long for the talk to become idle')).toBeTruthy();
+    expect(
+      screen.getByText(
+        'Dropped after waiting too long for the talk to become idle',
+      ),
+    ).toBeTruthy();
     expect(screen.getByText('Delivery retries exhausted')).toBeTruthy();
 
-    const bindingCard = screen.getByRole('heading', { name: 'Cal Football Chat' }).closest('article');
+    const bindingCard = screen
+      .getByRole('heading', { name: 'Cal Football Chat' })
+      .closest('article');
     if (!bindingCard) {
       throw new Error('Expected binding card');
     }
     const bindingView = within(bindingCard);
 
     await user.clear(bindingView.getByLabelText('Display Name'));
-    await user.type(bindingView.getByLabelText('Display Name'), 'Cal Strategy Room');
+    await user.type(
+      bindingView.getByLabelText('Display Name'),
+      'Cal Strategy Room',
+    );
     await user.selectOptions(bindingView.getByLabelText('Delivery'), 'channel');
     await user.click(bindingView.getByRole('button', { name: 'Save' }));
 
-    expect(await screen.findByText('Saved channel settings for Cal Football Chat.')).toBeTruthy();
+    expect(
+      await screen.findByText('Saved channel settings for Cal Football Chat.'),
+    ).toBeTruthy();
     expect(bindingView.getByDisplayValue('Cal Strategy Room')).toBeTruthy();
 
     await user.click(bindingView.getByRole('button', { name: 'Test Send' }));
-    expect(await screen.findByText('Sent a test message to Cal Strategy Room.')).toBeTruthy();
+    expect(
+      await screen.findByText('Sent a test message to Cal Strategy Room.'),
+    ).toBeTruthy();
 
     await user.click(bindingView.getAllByRole('button', { name: 'Retry' })[0]);
     expect(await screen.findByText('Ingress failure retried.')).toBeTruthy();
     expect(screen.queryByText('Coach')).toBeNull();
 
-    await user.click(bindingView.getAllByRole('button', { name: 'Dismiss' })[0]);
+    await user.click(
+      bindingView.getAllByRole('button', { name: 'Dismiss' })[0],
+    );
     expect(await screen.findByText('Delivery failure dismissed.')).toBeTruthy();
-    expect(screen.queryByText('Telegram delivery exhausted retries.')).toBeNull();
+    expect(
+      screen.queryByText('Telegram delivery exhausted retries.'),
+    ).toBeNull();
   });
 
   it('updates nicknames in auto and custom modes and saves talk agents from the Agents tab', async () => {
@@ -240,7 +270,9 @@ describe('TalkDetailPage', () => {
     const modelSelects = screen.getAllByLabelText('Model');
     await user.selectOptions(modelSelects[0], 'claude-opus-4-6');
 
-    const nicknameInputs = screen.getAllByLabelText('Nickname') as HTMLInputElement[];
+    const nicknameInputs = screen.getAllByLabelText(
+      'Nickname',
+    ) as HTMLInputElement[];
     expect(nicknameInputs[0].value).toBe('Claude Opus 4.6');
 
     await user.clear(nicknameInputs[0]);
@@ -277,83 +309,79 @@ describe('TalkDetailPage', () => {
     });
   });
 
-  it(
-    'shows source failures and refreshes URL source status after retry',
-    async () => {
-      const user = userEvent.setup();
-      let currentContext = buildTalkContext({
-        sources: [
-          buildContextSource({
-            id: 'source-failed',
-            title: 'Gamemakers Substack',
-            sourceUrl: 'https://example.substack.com/p/post',
-            status: 'failed',
-            extractionError:
-              'fetch_http_error: HTTP 403 from https://example.substack.com/p/post',
-          }),
-        ],
-      });
-      let pollCount = 0;
+  it('shows source failures and refreshes URL source status after retry', async () => {
+    const user = userEvent.setup();
+    let currentContext = buildTalkContext({
+      sources: [
+        buildContextSource({
+          id: 'source-failed',
+          title: 'Gamemakers Substack',
+          sourceUrl: 'https://example.substack.com/p/post',
+          status: 'failed',
+          extractionError:
+            'fetch_http_error: HTTP 403 from https://example.substack.com/p/post',
+        }),
+      ],
+    });
+    let pollCount = 0;
 
-      installTalkDetailFetch({
-        context: currentContext,
-        onGetContext: () => {
-          if (
-            currentContext.sources[0]?.status === 'pending' &&
-            pollCount++ >= 0
-          ) {
-            currentContext = buildTalkContext({
-              sources: [
-                buildContextSource({
-                  id: 'source-failed',
-                  title: 'Gamemakers Substack',
-                  sourceUrl: 'https://example.substack.com/p/post',
-                  status: 'ready',
-                  extractionError: null,
-                  fetchStrategy: 'browser',
-                  lastFetchedAt: '2026-03-06T00:05:00.000Z',
-                  extractedTextLength: 1200,
-                }),
-              ],
-            });
-          }
-          return currentContext;
-        },
-        onRetryContextSource: (sourceId) => {
-          pollCount = 0;
-          const updated = buildContextSource({
-            id: sourceId,
-            title: 'Gamemakers Substack',
-            sourceUrl: 'https://example.substack.com/p/post',
-            status: 'pending',
-            extractionError: null,
+    installTalkDetailFetch({
+      context: currentContext,
+      onGetContext: () => {
+        if (
+          currentContext.sources[0]?.status === 'pending' &&
+          pollCount++ >= 0
+        ) {
+          currentContext = buildTalkContext({
+            sources: [
+              buildContextSource({
+                id: 'source-failed',
+                title: 'Gamemakers Substack',
+                sourceUrl: 'https://example.substack.com/p/post',
+                status: 'ready',
+                extractionError: null,
+                fetchStrategy: 'browser',
+                lastFetchedAt: '2026-03-06T00:05:00.000Z',
+                extractedTextLength: 1200,
+              }),
+            ],
           });
-          currentContext = buildTalkContext({ sources: [updated] });
-          return updated;
-        },
-      });
+        }
+        return currentContext;
+      },
+      onRetryContextSource: (sourceId) => {
+        pollCount = 0;
+        const updated = buildContextSource({
+          id: sourceId,
+          title: 'Gamemakers Substack',
+          sourceUrl: 'https://example.substack.com/p/post',
+          status: 'pending',
+          extractionError: null,
+        });
+        currentContext = buildTalkContext({ sources: [updated] });
+        return updated;
+      },
+    });
 
-      renderDetailPage('/app/talks/talk-1/context');
+    renderDetailPage('/app/talks/talk-1/context');
 
-      expect(await screen.findByText('Gamemakers Substack')).toBeTruthy();
-      expect(
-        screen.getByText(
-          'fetch_http_error: HTTP 403 from https://example.substack.com/p/post',
-        ),
-      ).toBeTruthy();
+    expect(await screen.findByText('Gamemakers Substack')).toBeTruthy();
+    expect(
+      screen.getByText(
+        'fetch_http_error: HTTP 403 from https://example.substack.com/p/post',
+      ),
+    ).toBeTruthy();
 
-      await user.click(screen.getByRole('button', { name: 'Retry' }));
-      expect(screen.getByText('pending')).toBeTruthy();
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(screen.getByText('pending')).toBeTruthy();
 
-      await act(async () => {
-        await new Promise((resolve) => window.setTimeout(resolve, 2200));
-      });
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 2200));
+    });
 
-      await waitFor(() => expect(screen.getByText('ready')).toBeTruthy());
-      expect(screen.getByText('via browser')).toBeTruthy();
-    },
-    10000,
-  );
+    await waitFor(() => expect(screen.getByText('ready')).toBeTruthy());
+    expect(screen.getByText('via browser')).toBeTruthy();
+  }, 10000);
 
   it('shows unsaved draft agents in the Talk tab and blocks send until agent changes are saved', async () => {
     const user = userEvent.setup();
@@ -385,29 +413,39 @@ describe('TalkDetailPage', () => {
     await user.selectOptions(screen.getAllByLabelText('Role')[1], 'critic');
     await user.click(screen.getByRole('button', { name: 'Add Agent' }));
 
-    const tabs = within(screen.getByRole('navigation', { name: 'Talk sections' }));
+    const tabs = within(
+      screen.getByRole('navigation', { name: 'Talk sections' }),
+    );
     await user.click(tabs.getByRole('link', { name: 'Talk' }));
     await screen.findByLabelText('Talk timeline');
 
     const statusPills = screen.getByRole('list', { name: 'Talk agent status' });
-    expect(within(statusPills).getByText('Claude Sonnet 4.6 (General)')).toBeTruthy();
+    expect(
+      within(statusPills).getByText('Claude Sonnet 4.6 (General)'),
+    ).toBeTruthy();
     expect(within(statusPills).getByText('GPT-5 Mini (Critic)')).toBeTruthy();
 
     const targetGroup = screen.getByRole('group', { name: 'Selected agents' });
     expect(
-      within(targetGroup).getByRole('button', { name: /Claude Sonnet 4\.6 \(General\)/i }),
+      within(targetGroup).getByRole('button', {
+        name: /Claude Sonnet 4\.6 \(General\)/i,
+      }),
     ).toBeTruthy();
     expect(
-      within(targetGroup).getByRole('button', { name: /GPT-5 Mini \(Critic\)/i }),
+      within(targetGroup).getByRole('button', {
+        name: /GPT-5 Mini \(Critic\)/i,
+      }),
     ).toBeTruthy();
 
     expect(
       screen.getByText('Save agent changes before sending a message.'),
     ).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Send' })).toHaveAttribute('disabled');
-    expect(screen.getByPlaceholderText('Send a message to this talk')).toHaveAttribute(
+    expect(screen.getByRole('button', { name: 'Send' })).toHaveAttribute(
       'disabled',
     );
+    expect(
+      screen.getByPlaceholderText('Send a message to this talk'),
+    ).toHaveAttribute('disabled');
   });
 
   it('uses primary-target chips by default and sends plural targetAgentIds', async () => {
@@ -439,9 +477,7 @@ describe('TalkDetailPage', () => {
             triggerMessageId: 'msg-posted',
             targetAgentId: agentId,
             targetAgentNickname:
-              agentId === 'agent-claude'
-                ? 'Claude Sonnet 4.6'
-                : 'GPT-5 Mini',
+              agentId === 'agent-claude' ? 'Claude Sonnet 4.6' : 'GPT-5 Mini',
             errorCode: null,
             errorMessage: null,
             executorAlias: null,
@@ -488,9 +524,9 @@ describe('TalkDetailPage', () => {
         'Wait for the current round to finish or cancel it before sending another message.',
       ),
     ).toBeTruthy();
-    expect(screen.getByPlaceholderText('Send a message to this talk')).toHaveAttribute(
-      'disabled',
-    );
+    expect(
+      screen.getByPlaceholderText('Send a message to this talk'),
+    ).toHaveAttribute('disabled');
   });
 
   it('submits on Enter and keeps Shift+Enter for a newline in the composer', async () => {
@@ -519,7 +555,9 @@ describe('TalkDetailPage', () => {
     });
 
     renderDetailPage('/app/talks/talk-1');
-    const composer = await screen.findByPlaceholderText('Send a message to this talk');
+    const composer = await screen.findByPlaceholderText(
+      'Send a message to this talk',
+    );
 
     await user.type(composer, 'Line 1');
     await user.keyboard('{Shift>}{Enter}{/Shift}Line 2');
@@ -581,7 +619,9 @@ describe('TalkDetailPage', () => {
     });
 
     renderDetailPage('/app/talks/talk-1');
-    const composer = await screen.findByPlaceholderText('Send a message to this talk');
+    const composer = await screen.findByPlaceholderText(
+      'Send a message to this talk',
+    );
     const workspace = composer.closest('.talk-workspace');
     if (!workspace) {
       throw new Error('Expected talk workspace wrapper');
@@ -683,8 +723,90 @@ describe('TalkDetailPage', () => {
 
     expect(screen.getByText('Claude reply')).toBeTruthy();
     expect(screen.getByText('OpenAI reply')).toBeTruthy();
-    expect(screen.getAllByText('Claude Sonnet 4.6 (General)').length).toBeGreaterThanOrEqual(2);
-    expect(screen.getAllByText('GPT-5 Mini (Critic)').length).toBeGreaterThanOrEqual(2);
+    expect(
+      screen.getAllByText('Claude Sonnet 4.6 (General)').length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(
+      screen.getAllByText('GPT-5 Mini (Critic)').length,
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it('strips internal tags from live streamed assistant responses', async () => {
+    installTalkDetailFetch();
+
+    renderDetailPage('/app/talks/talk-1');
+    await screen.findByRole('heading', { name: /Cal Football/i });
+
+    if (!streamInput) {
+      throw new Error('Expected talk stream input');
+    }
+    const stream = streamInput;
+
+    await act(async () => {
+      stream.onResponseStarted?.({
+        talkId: 'talk-1',
+        runId: 'run-claude',
+        agentId: 'agent-claude',
+        agentNickname: 'Claude Sonnet 4.6',
+        providerId: 'provider.anthropic',
+        modelId: 'claude-sonnet-4-6',
+      });
+      stream.onResponseDelta?.({
+        talkId: 'talk-1',
+        runId: 'run-claude',
+        agentId: 'agent-claude',
+        agentNickname: 'Claude Sonnet 4.6',
+        deltaText: '<internal>Thinking',
+        providerId: 'provider.anthropic',
+        modelId: 'claude-sonnet-4-6',
+      });
+      stream.onResponseDelta?.({
+        talkId: 'talk-1',
+        runId: 'run-claude',
+        agentId: 'agent-claude',
+        agentNickname: 'Claude Sonnet 4.6',
+        deltaText: ' through it</internal>Visible',
+        providerId: 'provider.anthropic',
+        modelId: 'claude-sonnet-4-6',
+      });
+      stream.onResponseDelta?.({
+        talkId: 'talk-1',
+        runId: 'run-claude',
+        agentId: 'agent-claude',
+        agentNickname: 'Claude Sonnet 4.6',
+        deltaText: ' answer',
+        providerId: 'provider.anthropic',
+        modelId: 'claude-sonnet-4-6',
+      });
+    });
+
+    expect(screen.queryByText(/<internal>/)).toBeNull();
+    expect(screen.getByText('Visible answer')).toBeTruthy();
+  });
+
+  it('strips internal tags from persisted assistant messages', async () => {
+    installTalkDetailFetch({
+      messages: [
+        buildMessage({
+          id: 'msg-1',
+          role: 'user',
+          content: 'What do you think?',
+          createdAt: '2026-03-06T00:00:00.000Z',
+        }),
+        buildMessage({
+          id: 'msg-2',
+          role: 'assistant',
+          content: '<internal>Think first</internal>The visible answer',
+          createdAt: '2026-03-06T00:00:10.000Z',
+        }),
+      ],
+    });
+
+    renderDetailPage('/app/talks/talk-1');
+    await screen.findByRole('heading', { name: /Cal Football/i });
+
+    expect(screen.queryByText(/<internal>/)).toBeNull();
+    expect(screen.getByText('The visible answer')).toBeTruthy();
   });
 
   it('keeps failed live responses in chronological order in the timeline', async () => {
@@ -714,7 +836,8 @@ describe('TalkDetailPage', () => {
           targetAgentId: 'agent-claude',
           targetAgentNickname: 'Claude Sonnet 4.6',
           errorCode: 'tool_capability',
-          errorMessage: 'Attached data connectors require a tool-capable model.',
+          errorMessage:
+            'Attached data connectors require a tool-capable model.',
         }),
       ],
     });
@@ -754,9 +877,15 @@ describe('TalkDetailPage', () => {
       });
     });
 
-    const userArticle = screen.getByText('Can we pull retention data?').closest('article');
-    const failedArticle = screen.getByText('Failed attempt preview').closest('article');
-    const persistedArticle = screen.getByText('Later persisted answer').closest('article');
+    const userArticle = screen
+      .getByText('Can we pull retention data?')
+      .closest('article');
+    const failedArticle = screen
+      .getByText('Failed attempt preview')
+      .closest('article');
+    const persistedArticle = screen
+      .getByText('Later persisted answer')
+      .closest('article');
 
     expect(userArticle).toBeTruthy();
     expect(failedArticle).toBeTruthy();
@@ -764,9 +893,9 @@ describe('TalkDetailPage', () => {
     expect(userArticle?.compareDocumentPosition(failedArticle as Node)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
-    expect(failedArticle?.compareDocumentPosition(persistedArticle as Node)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
+    expect(
+      failedArticle?.compareDocumentPosition(persistedArticle as Node),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
   it('detaches and re-attaches connectors from the Data Connectors tab', async () => {
@@ -784,7 +913,10 @@ describe('TalkDetailPage', () => {
     ).toBeTruthy();
     expect(screen.queryByRole('heading', { name: 'FTUE PostHog' })).toBeNull();
 
-    await user.selectOptions(screen.getByLabelText('Connector'), 'connector-sheet');
+    await user.selectOptions(
+      screen.getByLabelText('Connector'),
+      'connector-sheet',
+    );
     await user.click(screen.getByRole('button', { name: 'Attach Connector' }));
     expect(
       await screen.findByText('Economy Sheet attached to this talk.'),
@@ -820,14 +952,20 @@ describe('TalkDetailPage', () => {
     });
 
     renderDetailPage('/app/talks/talk-1');
-    const composer = await screen.findByPlaceholderText('Send a message to this talk');
+    const composer = await screen.findByPlaceholderText(
+      'Send a message to this talk',
+    );
 
     await user.type(composer, '/edit');
     await user.keyboard('{Enter}');
 
-    expect(await screen.findByRole('dialog', { name: 'Edit history' })).toBeTruthy();
+    expect(
+      await screen.findByRole('dialog', { name: 'Edit history' }),
+    ).toBeTruthy();
     const removeOldUser = screen.getByLabelText(/You.*Old user prompt/i);
-    const removeOldAssistant = screen.getByLabelText(/Assistant.*Old assistant answer/i);
+    const removeOldAssistant = screen.getByLabelText(
+      /Assistant.*Old assistant answer/i,
+    );
     await user.click(removeOldUser);
     await user.click(removeOldAssistant);
     await user.click(screen.getByRole('button', { name: 'Delete selected' }));
@@ -835,7 +973,9 @@ describe('TalkDetailPage', () => {
     await waitFor(() =>
       expect(screen.queryByRole('dialog', { name: 'Edit history' })).toBeNull(),
     );
-    expect(await screen.findByText('Deleted 2 messages from this Talk history.')).toBeTruthy();
+    expect(
+      await screen.findByText('Deleted 2 messages from this Talk history.'),
+    ).toBeTruthy();
     expect(screen.queryByText('Old user prompt')).toBeNull();
     expect(screen.queryByText('Old assistant answer')).toBeNull();
     expect(screen.getByText('Keep this latest note')).toBeTruthy();
@@ -959,7 +1099,9 @@ function buildTalkTools(): TalkTools {
   };
 }
 
-function buildTalkAgent(input: Partial<TalkAgent> & Pick<TalkAgent, 'id' | 'nickname'>): TalkAgent {
+function buildTalkAgent(
+  input: Partial<TalkAgent> & Pick<TalkAgent, 'id' | 'nickname'>,
+): TalkAgent {
   return {
     id: input.id,
     nickname: input.nickname,
@@ -1045,19 +1187,15 @@ function createFileDataTransfer(files: File[]): DataTransfer {
   } as unknown as DataTransfer;
 }
 
-function buildDataConnector(
-  input: Partial<DataConnector> = {},
-): DataConnector {
+function buildDataConnector(input: Partial<DataConnector> = {}): DataConnector {
   return {
     id: input.id ?? 'connector-1',
     name: input.name ?? 'FTUE PostHog',
     connectorKind: input.connectorKind ?? 'posthog',
-    config:
-      input.config ??
-      {
-        hostUrl: 'https://us.posthog.com',
-        projectId: '12345',
-      },
+    config: input.config ?? {
+      hostUrl: 'https://us.posthog.com',
+      projectId: '12345',
+    },
     discovered: input.discovered ?? null,
     enabled: input.enabled ?? true,
     hasCredential: input.hasCredential ?? false,
@@ -1121,7 +1259,8 @@ function buildTalkChannelBinding(
     talkId: input.talkId ?? 'talk-1',
     connectionId: input.connectionId ?? 'channel-conn:telegram:system',
     platform: input.platform ?? 'telegram',
-    connectionDisplayName: input.connectionDisplayName ?? 'Telegram (System Managed)',
+    connectionDisplayName:
+      input.connectionDisplayName ?? 'Telegram (System Managed)',
     targetKind: input.targetKind ?? 'chat',
     targetId: input.targetId ?? 'tg:group:123',
     displayName: input.displayName ?? 'Cal Football Chat',
@@ -1269,99 +1408,86 @@ function installTalkDetailFetch(input?: {
   }) => { talkId: string; message: TalkMessage; runs: TalkRun[] };
 }) {
   const talk = input?.talk ?? buildTalk();
-  let messages =
-    input?.messages ??
-    [
-      buildMessage({
-        id: 'msg-1',
-        role: 'user',
-        content: 'How will Cal do next season?',
-        createdAt: '2026-03-06T00:00:00.000Z',
-      }),
-    ];
-  const runs =
-    input?.runs ??
-    [
-      buildRun({
-        id: 'run-1',
-        status: 'completed',
-        createdAt: '2026-03-06T00:00:01.000Z',
-        completedAt: '2026-03-06T00:00:03.000Z',
-        triggerMessageId: 'msg-1',
-        targetAgentId: 'agent-openai',
-        targetAgentNickname: 'GPT-5 Mini',
-      }),
-    ];
-  const talkAgents =
-    input?.talkAgents ??
-    [
-      buildTalkAgent({
-        id: 'agent-claude',
-        nickname: 'Claude Sonnet 4.6',
-        sourceKind: 'claude_default',
-        role: 'assistant',
-        isPrimary: true,
-        displayOrder: 0,
-        health: 'ready',
-        providerId: null,
-        modelId: 'claude-sonnet-4-6',
-        modelDisplayName: 'Claude Sonnet 4.6',
-      }),
-      buildTalkAgent({
-        id: 'agent-openai',
-        nickname: 'GPT-5 Mini',
-        sourceKind: 'provider',
-        role: 'critic',
-        isPrimary: false,
-        displayOrder: 1,
-        health: 'invalid',
-        providerId: 'provider.openai',
-        modelId: 'gpt-5-mini',
-        modelDisplayName: 'GPT-5 Mini',
-      }),
-    ];
-  const dataConnectors =
-    input?.dataConnectors ??
-    [
-      buildDataConnector({
-        id: 'connector-posthog',
-        name: 'FTUE PostHog',
-        connectorKind: 'posthog',
-        hasCredential: true,
-        verificationStatus: 'not_verified',
-        attachedTalkCount: 1,
-      }),
-      buildDataConnector({
-        id: 'connector-sheet',
-        name: 'Economy Sheet',
-        connectorKind: 'google_sheets',
-      }),
-    ];
-  let talkDataConnectors =
-    input?.talkDataConnectors ??
-    [
-      buildTalkDataConnector({
-        ...dataConnectors[0],
-        attachedAt: '2026-03-06T00:00:10.000Z',
-      }),
-    ];
+  let messages = input?.messages ?? [
+    buildMessage({
+      id: 'msg-1',
+      role: 'user',
+      content: 'How will Cal do next season?',
+      createdAt: '2026-03-06T00:00:00.000Z',
+    }),
+  ];
+  const runs = input?.runs ?? [
+    buildRun({
+      id: 'run-1',
+      status: 'completed',
+      createdAt: '2026-03-06T00:00:01.000Z',
+      completedAt: '2026-03-06T00:00:03.000Z',
+      triggerMessageId: 'msg-1',
+      targetAgentId: 'agent-openai',
+      targetAgentNickname: 'GPT-5 Mini',
+    }),
+  ];
+  const talkAgents = input?.talkAgents ?? [
+    buildTalkAgent({
+      id: 'agent-claude',
+      nickname: 'Claude Sonnet 4.6',
+      sourceKind: 'claude_default',
+      role: 'assistant',
+      isPrimary: true,
+      displayOrder: 0,
+      health: 'ready',
+      providerId: null,
+      modelId: 'claude-sonnet-4-6',
+      modelDisplayName: 'Claude Sonnet 4.6',
+    }),
+    buildTalkAgent({
+      id: 'agent-openai',
+      nickname: 'GPT-5 Mini',
+      sourceKind: 'provider',
+      role: 'critic',
+      isPrimary: false,
+      displayOrder: 1,
+      health: 'invalid',
+      providerId: 'provider.openai',
+      modelId: 'gpt-5-mini',
+      modelDisplayName: 'GPT-5 Mini',
+    }),
+  ];
+  const dataConnectors = input?.dataConnectors ?? [
+    buildDataConnector({
+      id: 'connector-posthog',
+      name: 'FTUE PostHog',
+      connectorKind: 'posthog',
+      hasCredential: true,
+      verificationStatus: 'not_verified',
+      attachedTalkCount: 1,
+    }),
+    buildDataConnector({
+      id: 'connector-sheet',
+      name: 'Economy Sheet',
+      connectorKind: 'google_sheets',
+    }),
+  ];
+  let talkDataConnectors = input?.talkDataConnectors ?? [
+    buildTalkDataConnector({
+      ...dataConnectors[0],
+      attachedAt: '2026-03-06T00:00:10.000Z',
+    }),
+  ];
   let context = input?.context ?? buildTalkContext();
-  const channelConnections =
-    input?.channelConnections ?? [buildChannelConnection()];
-  const channelTargets =
-    input?.channelTargets ?? [buildChannelTarget()];
+  const channelConnections = input?.channelConnections ?? [
+    buildChannelConnection(),
+  ];
+  const channelTargets = input?.channelTargets ?? [buildChannelTarget()];
   let talkChannels = input?.talkChannels ?? [buildTalkChannelBinding()];
-  let ingressFailures =
-    input?.ingressFailures ?? [buildChannelQueueFailure()];
-  let deliveryFailures =
-    input?.deliveryFailures ??
-    [
-      buildChannelQueueFailure({
-        id: 'failure-delivery-1',
-        reasonCode: 'delivery_retries_exhausted',
-        reasonDetail: 'Telegram delivery exhausted retries.',
-      }),
-    ];
+  let ingressFailures = input?.ingressFailures ?? [buildChannelQueueFailure()];
+  let deliveryFailures = input?.deliveryFailures ?? [
+    buildChannelQueueFailure({
+      id: 'failure-delivery-1',
+      reasonCode: 'delivery_retries_exhausted',
+      reasonDetail: 'Telegram delivery exhausted retries.',
+    }),
+  ];
   let talkTools = input?.talkTools ?? buildTalkTools();
   const aiAgents = input?.aiAgents ?? buildAiAgentsData();
 
@@ -1393,11 +1519,16 @@ function installTalkDetailFetch(input?: {
         });
       }
 
-      if (url.endsWith('/api/v1/talks/talk-1/messages/delete') && method === 'POST') {
+      if (
+        url.endsWith('/api/v1/talks/talk-1/messages/delete') &&
+        method === 'POST'
+      ) {
         const body = JSON.parse(String(init?.body || '{}')) as {
           messageIds?: string[];
         };
-        const deletedMessageIds = Array.isArray(body.messageIds) ? body.messageIds : [];
+        const deletedMessageIds = Array.isArray(body.messageIds)
+          ? body.messageIds
+          : [];
         messages = messages.filter(
           (message) => !deletedMessageIds.includes(message.id),
         );
@@ -1411,7 +1542,10 @@ function installTalkDetailFetch(input?: {
         });
       }
 
-      if (url.endsWith('/api/v1/talks/talk-1/attachments') && method === 'POST') {
+      if (
+        url.endsWith('/api/v1/talks/talk-1/attachments') &&
+        method === 'POST'
+      ) {
         if (!(init?.body instanceof FormData)) {
           throw new Error('Expected attachment uploads to use FormData');
         }
@@ -1476,7 +1610,9 @@ function installTalkDetailFetch(input?: {
           talkTools = {
             ...talkTools,
             grants: talkTools.grants.map((grant) => {
-              const update = body.grants?.find((entry) => entry.toolId === grant.toolId);
+              const update = body.grants?.find(
+                (entry) => entry.toolId === grant.toolId,
+              );
               return update ? { ...grant, enabled: update.enabled } : grant;
             }),
           };
@@ -1494,7 +1630,10 @@ function installTalkDetailFetch(input?: {
         });
       }
 
-      if (url.endsWith('/api/v1/me/google-account/connect') && method === 'POST') {
+      if (
+        url.endsWith('/api/v1/me/google-account/connect') &&
+        method === 'POST'
+      ) {
         talkTools = {
           ...talkTools,
           googleAccount: {
@@ -1575,7 +1714,9 @@ function installTalkDetailFetch(input?: {
         const resourceId = url.split('/').pop() || '';
         talkTools = {
           ...talkTools,
-          bindings: talkTools.bindings.filter((binding) => binding.id !== resourceId),
+          bindings: talkTools.bindings.filter(
+            (binding) => binding.id !== resourceId,
+          ),
         };
         return jsonResponse(200, {
           ok: true,
@@ -1609,25 +1750,41 @@ function installTalkDetailFetch(input?: {
       }
 
       if (url.endsWith('/api/v1/talks/talk-1/channels') && method === 'POST') {
-        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>;
+        const body = JSON.parse(String(init?.body || '{}')) as Record<
+          string,
+          unknown
+        >;
         const created = buildTalkChannelBinding({
           id: `binding-${talkChannels.length + 1}`,
           talkId: 'talk-1',
-          connectionId: String(body.connectionId || 'channel-conn:telegram:system'),
+          connectionId: String(
+            body.connectionId || 'channel-conn:telegram:system',
+          ),
           targetKind: String(body.targetKind || 'chat'),
-          targetId: String(body.targetId || `tg:group:${talkChannels.length + 100}`),
+          targetId: String(
+            body.targetId || `tg:group:${talkChannels.length + 100}`,
+          ),
           displayName: String(body.displayName || 'New Telegram Binding'),
           responseMode:
-            (body.responseMode as TalkChannelBinding['responseMode']) ?? 'mentions',
+            (body.responseMode as TalkChannelBinding['responseMode']) ??
+            'mentions',
           responderMode:
-            (body.responderMode as TalkChannelBinding['responderMode']) ?? 'primary',
+            (body.responderMode as TalkChannelBinding['responderMode']) ??
+            'primary',
           responderAgentId:
-            body.responderAgentId == null ? null : String(body.responderAgentId),
+            body.responderAgentId == null
+              ? null
+              : String(body.responderAgentId),
           deliveryMode:
-            (body.deliveryMode as TalkChannelBinding['deliveryMode']) ?? 'reply',
+            (body.deliveryMode as TalkChannelBinding['deliveryMode']) ??
+            'reply',
           channelContextNote:
-            body.channelContextNote == null ? null : String(body.channelContextNote),
-          inboundRateLimitPerMinute: Number(body.inboundRateLimitPerMinute || 10),
+            body.channelContextNote == null
+              ? null
+              : String(body.channelContextNote),
+          inboundRateLimitPerMinute: Number(
+            body.inboundRateLimitPerMinute || 10,
+          ),
           maxPendingEvents: Number(body.maxPendingEvents || 20),
           overflowPolicy:
             (body.overflowPolicy as TalkChannelBinding['overflowPolicy']) ??
@@ -1667,8 +1824,12 @@ function installTalkDetailFetch(input?: {
         method === 'DELETE'
       ) {
         const bindingId = url.split('/api/v1/talks/talk-1/channels/')[1];
-        talkChannels = talkChannels.filter((binding) => binding.id !== bindingId);
-        ingressFailures = ingressFailures.filter((failure) => failure.bindingId !== bindingId);
+        talkChannels = talkChannels.filter(
+          (binding) => binding.id !== bindingId,
+        );
+        ingressFailures = ingressFailures.filter(
+          (failure) => failure.bindingId !== bindingId,
+        );
         deliveryFailures = deliveryFailures.filter(
           (failure) => failure.bindingId !== bindingId,
         );
@@ -1689,37 +1850,53 @@ function installTalkDetailFetch(input?: {
       }
 
       if (
-        /\/api\/v1\/talks\/talk-1\/channels\/[^/]+\/ingress-failures$/.test(url) &&
+        /\/api\/v1\/talks\/talk-1\/channels\/[^/]+\/ingress-failures$/.test(
+          url,
+        ) &&
         method === 'GET'
       ) {
-        const bindingId = url.split('/api/v1/talks/talk-1/channels/')[1].split('/')[0];
+        const bindingId = url
+          .split('/api/v1/talks/talk-1/channels/')[1]
+          .split('/')[0];
         return jsonResponse(200, {
           ok: true,
           data: {
-            failures: ingressFailures.filter((failure) => failure.bindingId === bindingId),
+            failures: ingressFailures.filter(
+              (failure) => failure.bindingId === bindingId,
+            ),
           },
         });
       }
 
       if (
-        /\/api\/v1\/talks\/talk-1\/channels\/[^/]+\/delivery-failures$/.test(url) &&
+        /\/api\/v1\/talks\/talk-1\/channels\/[^/]+\/delivery-failures$/.test(
+          url,
+        ) &&
         method === 'GET'
       ) {
-        const bindingId = url.split('/api/v1/talks/talk-1/channels/')[1].split('/')[0];
+        const bindingId = url
+          .split('/api/v1/talks/talk-1/channels/')[1]
+          .split('/')[0];
         return jsonResponse(200, {
           ok: true,
           data: {
-            failures: deliveryFailures.filter((failure) => failure.bindingId === bindingId),
+            failures: deliveryFailures.filter(
+              (failure) => failure.bindingId === bindingId,
+            ),
           },
         });
       }
 
       if (
-        /\/api\/v1\/talks\/talk-1\/channels\/[^/]+\/ingress-failures\/[^/]+\/retry$/.test(url) &&
+        /\/api\/v1\/talks\/talk-1\/channels\/[^/]+\/ingress-failures\/[^/]+\/retry$/.test(
+          url,
+        ) &&
         method === 'POST'
       ) {
         const rowId = url.split('/ingress-failures/')[1].split('/')[0];
-        ingressFailures = ingressFailures.filter((failure) => failure.id !== rowId);
+        ingressFailures = ingressFailures.filter(
+          (failure) => failure.id !== rowId,
+        );
         return jsonResponse(200, {
           ok: true,
           data: { retried: true },
@@ -1727,11 +1904,15 @@ function installTalkDetailFetch(input?: {
       }
 
       if (
-        /\/api\/v1\/talks\/talk-1\/channels\/[^/]+\/delivery-failures\/[^/]+\/retry$/.test(url) &&
+        /\/api\/v1\/talks\/talk-1\/channels\/[^/]+\/delivery-failures\/[^/]+\/retry$/.test(
+          url,
+        ) &&
         method === 'POST'
       ) {
         const rowId = url.split('/delivery-failures/')[1].split('/')[0];
-        deliveryFailures = deliveryFailures.filter((failure) => failure.id !== rowId);
+        deliveryFailures = deliveryFailures.filter(
+          (failure) => failure.id !== rowId,
+        );
         return jsonResponse(200, {
           ok: true,
           data: { retried: true },
@@ -1739,11 +1920,15 @@ function installTalkDetailFetch(input?: {
       }
 
       if (
-        /\/api\/v1\/talks\/talk-1\/channels\/[^/]+\/ingress-failures\/[^/]+$/.test(url) &&
+        /\/api\/v1\/talks\/talk-1\/channels\/[^/]+\/ingress-failures\/[^/]+$/.test(
+          url,
+        ) &&
         method === 'DELETE'
       ) {
         const rowId = url.split('/ingress-failures/')[1];
-        ingressFailures = ingressFailures.filter((failure) => failure.id !== rowId);
+        ingressFailures = ingressFailures.filter(
+          (failure) => failure.id !== rowId,
+        );
         return jsonResponse(200, {
           ok: true,
           data: { deleted: true },
@@ -1751,29 +1936,41 @@ function installTalkDetailFetch(input?: {
       }
 
       if (
-        /\/api\/v1\/talks\/talk-1\/channels\/[^/]+\/delivery-failures\/[^/]+$/.test(url) &&
+        /\/api\/v1\/talks\/talk-1\/channels\/[^/]+\/delivery-failures\/[^/]+$/.test(
+          url,
+        ) &&
         method === 'DELETE'
       ) {
         const rowId = url.split('/delivery-failures/')[1];
-        deliveryFailures = deliveryFailures.filter((failure) => failure.id !== rowId);
+        deliveryFailures = deliveryFailures.filter(
+          (failure) => failure.id !== rowId,
+        );
         return jsonResponse(200, {
           ok: true,
           data: { deleted: true },
         });
       }
 
-      if (url.endsWith('/api/v1/talks/talk-1/data-connectors') && method === 'GET') {
+      if (
+        url.endsWith('/api/v1/talks/talk-1/data-connectors') &&
+        method === 'GET'
+      ) {
         return jsonResponse(200, {
           ok: true,
           data: { talkId: 'talk-1', connectors: talkDataConnectors },
         });
       }
 
-      if (url.endsWith('/api/v1/talks/talk-1/data-connectors') && method === 'POST') {
+      if (
+        url.endsWith('/api/v1/talks/talk-1/data-connectors') &&
+        method === 'POST'
+      ) {
         const body = JSON.parse(String(init?.body || '{}')) as {
           connectorId: string;
         };
-        const source = dataConnectors.find((connector) => connector.id === body.connectorId);
+        const source = dataConnectors.find(
+          (connector) => connector.id === body.connectorId,
+        );
         if (!source) {
           return jsonResponse(404, {
             ok: false,
@@ -1795,7 +1992,9 @@ function installTalkDetailFetch(input?: {
         url.includes('/api/v1/talks/talk-1/data-connectors/') &&
         method === 'DELETE'
       ) {
-        const connectorId = url.split('/api/v1/talks/talk-1/data-connectors/')[1];
+        const connectorId = url.split(
+          '/api/v1/talks/talk-1/data-connectors/',
+        )[1];
         talkDataConnectors = talkDataConnectors.filter(
           (connector) => connector.id !== connectorId,
         );
@@ -1817,7 +2016,9 @@ function installTalkDetailFetch(input?: {
       }
 
       if (url.endsWith('/api/v1/talks/talk-1/agents') && method === 'PUT') {
-        const body = JSON.parse(String(init?.body || '{}')) as SavedTalkAgentRequest;
+        const body = JSON.parse(
+          String(init?.body || '{}'),
+        ) as SavedTalkAgentRequest;
         const saved =
           input?.onPutAgents?.(body) ??
           body.agents.map((agent, index) => ({
@@ -1841,34 +2042,33 @@ function installTalkDetailFetch(input?: {
           content: string;
           targetAgentIds: string[];
         };
-        const payload =
-          input?.onSendMessage?.(body) ??
-          ({
-            talkId: 'talk-1',
-            message: buildMessage({
-              id: 'msg-posted',
-              role: 'user',
-              content: body.content,
-              createdAt: '2026-03-06T00:00:05.000Z',
+        const payload = input?.onSendMessage?.(body) ?? {
+          talkId: 'talk-1',
+          message: buildMessage({
+            id: 'msg-posted',
+            role: 'user',
+            content: body.content,
+            createdAt: '2026-03-06T00:00:05.000Z',
+          }),
+          runs: body.targetAgentIds.map((agentId, index) =>
+            buildRun({
+              id: `run-${index + 10}`,
+              status: 'queued',
+              createdAt: `2026-03-06T00:00:0${index + 6}.000Z`,
+              triggerMessageId: 'msg-posted',
+              targetAgentId: agentId,
+              targetAgentNickname:
+                agentId === 'agent-claude' ? 'Claude Sonnet 4.6' : 'GPT-5 Mini',
             }),
-            runs: body.targetAgentIds.map((agentId, index) =>
-              buildRun({
-                id: `run-${index + 10}`,
-                status: 'queued',
-                createdAt: `2026-03-06T00:00:0${index + 6}.000Z`,
-                triggerMessageId: 'msg-posted',
-                targetAgentId: agentId,
-                targetAgentNickname:
-                  agentId === 'agent-claude'
-                    ? 'Claude Sonnet 4.6'
-                    : 'GPT-5 Mini',
-              }),
-            ),
-          });
+          ),
+        };
         return jsonResponse(200, { ok: true, data: payload });
       }
 
-      if (url.endsWith('/api/v1/talks/talk-1/chat/cancel') && method === 'POST') {
+      if (
+        url.endsWith('/api/v1/talks/talk-1/chat/cancel') &&
+        method === 'POST'
+      ) {
         return jsonResponse(200, {
           ok: true,
           data: { talkId: 'talk-1', cancelledRuns: 2 },

--- a/webapp/src/pages/TalkDetailPage.tsx
+++ b/webapp/src/pages/TalkDetailPage.tsx
@@ -73,6 +73,7 @@ import {
   UnauthorizedError,
 } from '../lib/api';
 import { TalkHistoryEditor } from '../components/TalkHistoryEditor';
+import { stripInternalAssistantText } from '../lib/assistantText';
 import { openTalkStream } from '../lib/talkStream';
 import type {
   MessageAppendedEvent,
@@ -103,6 +104,7 @@ type RunView = TalkRun & {
 
 type LiveResponseView = {
   runId: string;
+  rawText: string;
   text: string;
   agentId?: string | null;
   agentNickname?: string | null;
@@ -323,7 +325,9 @@ function mapRunsById(runs: TalkRun[]): Record<string, RunView> {
   }, {});
 }
 
-function hasFileTransfer(dataTransfer: DataTransfer | null | undefined): boolean {
+function hasFileTransfer(
+  dataTransfer: DataTransfer | null | undefined,
+): boolean {
   if (!dataTransfer) return false;
   if (dataTransfer.files.length > 0) return true;
 
@@ -510,6 +514,7 @@ function detailReducer(state: DetailState, action: DetailAction): DetailState {
           ...state.liveResponsesByRunId,
           [action.runId]: {
             runId: action.runId,
+            rawText: existing?.rawText || '',
             text: existing?.text || '',
             agentId: existing?.agentId,
             agentNickname: existing?.agentNickname,
@@ -570,6 +575,7 @@ function detailReducer(state: DetailState, action: DetailAction): DetailState {
           ...state.liveResponsesByRunId,
           [action.event.runId]: {
             runId: action.event.runId,
+            rawText: '',
             text: '',
             agentId: action.event.agentId,
             agentNickname: action.event.agentNickname,
@@ -582,13 +588,15 @@ function detailReducer(state: DetailState, action: DetailAction): DetailState {
     case 'RESPONSE_DELTA': {
       if (state.kind !== 'ready') return state;
       const existing = state.liveResponsesByRunId[action.event.runId];
+      const rawText = `${existing?.rawText || ''}${action.event.deltaText}`;
       return {
         ...state,
         liveResponsesByRunId: {
           ...state.liveResponsesByRunId,
           [action.event.runId]: {
             runId: action.event.runId,
-            text: `${existing?.text || ''}${action.event.deltaText}`,
+            rawText,
+            text: stripInternalAssistantText(rawText),
             agentId: action.event.agentId,
             agentNickname: action.event.agentNickname,
             providerId: action.event.providerId,
@@ -611,6 +619,7 @@ function detailReducer(state: DetailState, action: DetailAction): DetailState {
           ...state.liveResponsesByRunId,
           [action.event.runId]: {
             runId: action.event.runId,
+            rawText: existing?.rawText || '',
             text: existing?.text || '',
             agentId: action.event.agentId,
             agentNickname: action.event.agentNickname,
@@ -1139,9 +1148,9 @@ export function TalkDetailPage({
     message?: string;
   }>({ status: 'idle' });
   const [talkTools, setTalkTools] = useState<TalkTools | null>(null);
-  const [toolGrantDrafts, setToolGrantDrafts] = useState<Record<string, boolean>>(
-    {},
-  );
+  const [toolGrantDrafts, setToolGrantDrafts] = useState<
+    Record<string, boolean>
+  >({});
   const [toolStatus, setToolStatus] = useState<{
     status: 'idle' | 'loading' | 'saving' | 'error' | 'success';
     message?: string;
@@ -1767,9 +1776,7 @@ export function TalkDetailPage({
           setToolStatus({
             status: 'error',
             message:
-              err instanceof Error
-                ? err.message
-                : 'Failed to load Talk tools.',
+              err instanceof Error ? err.message : 'Failed to load Talk tools.',
           });
         }
       }
@@ -2739,7 +2746,11 @@ export function TalkDetailPage({
     window.addEventListener('drop', preventWindowFileNavigation, true);
 
     return () => {
-      window.removeEventListener('dragenter', preventWindowFileNavigation, true);
+      window.removeEventListener(
+        'dragenter',
+        preventWindowFileNavigation,
+        true,
+      );
       window.removeEventListener('dragover', preventWindowFileNavigation, true);
       window.removeEventListener('drop', preventWindowFileNavigation, true);
     };
@@ -3012,7 +3023,8 @@ export function TalkDetailPage({
       }
       setToolStatus({
         status: 'error',
-        message: err instanceof Error ? err.message : 'Failed to save Talk tools.',
+        message:
+          err instanceof Error ? err.message : 'Failed to save Talk tools.',
       });
     }
   };
@@ -3034,7 +3046,9 @@ export function TalkDetailPage({
       setToolStatus({
         status: 'error',
         message:
-          err instanceof Error ? err.message : 'Failed to connect Google account.',
+          err instanceof Error
+            ? err.message
+            : 'Failed to connect Google account.',
       });
     }
   };
@@ -3077,7 +3091,10 @@ export function TalkDetailPage({
 
   const handleAddDriveBinding = async () => {
     if (!canEditAgents) return;
-    if (!driveBindingDraft.externalId.trim() || !driveBindingDraft.displayName.trim()) {
+    if (
+      !driveBindingDraft.externalId.trim() ||
+      !driveBindingDraft.displayName.trim()
+    ) {
       setToolStatus({
         status: 'error',
         message: 'Drive bindings require both a display name and resource id.',
@@ -3110,7 +3127,8 @@ export function TalkDetailPage({
       }
       setToolStatus({
         status: 'error',
-        message: err instanceof Error ? err.message : 'Failed to add Drive binding.',
+        message:
+          err instanceof Error ? err.message : 'Failed to add Drive binding.',
       });
     }
   };
@@ -3134,7 +3152,9 @@ export function TalkDetailPage({
       setToolStatus({
         status: 'error',
         message:
-          err instanceof Error ? err.message : 'Failed to remove Drive binding.',
+          err instanceof Error
+            ? err.message
+            : 'Failed to remove Drive binding.',
       });
     }
   };
@@ -4176,7 +4196,9 @@ export function TalkDetailPage({
                         ))}
                       </ul>
                     ) : (
-                      <p className="page-state">No Talk tools are enabled yet.</p>
+                      <p className="page-state">
+                        No Talk tools are enabled yet.
+                      </p>
                     )}
                     {talkTools.warnings.map((warning) => (
                       <div
@@ -4246,7 +4268,8 @@ export function TalkDetailPage({
                     <div
                       style={{
                         display: 'grid',
-                        gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+                        gridTemplateColumns:
+                          'repeat(auto-fit, minmax(220px, 1fr))',
                         gap: '0.75rem',
                       }}
                     >
@@ -4267,8 +4290,11 @@ export function TalkDetailPage({
                             <strong>{entry.displayName}</strong>
                             <input
                               type="checkbox"
+                              aria-label={entry.displayName}
                               checked={toolGrantDrafts[entry.id] ?? false}
-                              disabled={!canEditAgents || toolStatus.status === 'saving'}
+                              disabled={
+                                !canEditAgents || toolStatus.status === 'saving'
+                              }
                               onChange={(event) =>
                                 setToolGrantDrafts((current) => ({
                                   ...current,
@@ -4277,23 +4303,32 @@ export function TalkDetailPage({
                               }
                             />
                           </div>
-                          <p className="talk-llm-meta" style={{ marginBottom: 0 }}>
+                          <p
+                            className="talk-llm-meta"
+                            style={{ marginBottom: 0 }}
+                          >
                             {entry.description}
                           </p>
                         </label>
                       ))}
                     </div>
                     {canEditAgents ? (
-                      <div className="settings-button-row" style={{ marginTop: '0.75rem' }}>
+                      <div
+                        className="settings-button-row"
+                        style={{ marginTop: '0.75rem' }}
+                      >
                         <button
                           type="button"
                           className="secondary-btn"
                           onClick={() => void handleSaveTalkTools()}
                           disabled={
-                            toolStatus.status === 'saving' || !hasUnsavedToolChanges
+                            toolStatus.status === 'saving' ||
+                            !hasUnsavedToolChanges
                           }
                         >
-                          {toolStatus.status === 'saving' ? 'Saving…' : 'Save Tool Grants'}
+                          {toolStatus.status === 'saving'
+                            ? 'Saving…'
+                            : 'Save Tool Grants'}
                         </button>
                       </div>
                     ) : null}
@@ -4335,13 +4370,17 @@ export function TalkDetailPage({
                                   ? 'File'
                                   : binding.bindingKind}
                             </span>
-                            <strong style={{ flex: 1 }}>{binding.displayName}</strong>
+                            <strong style={{ flex: 1 }}>
+                              {binding.displayName}
+                            </strong>
                             <code>{binding.externalId}</code>
                             {canEditAgents ? (
                               <button
                                 type="button"
                                 className="secondary-btn"
-                                onClick={() => void handleDeleteDriveBinding(binding.id)}
+                                onClick={() =>
+                                  void handleDeleteDriveBinding(binding.id)
+                                }
                                 disabled={toolStatus.status === 'saving'}
                               >
                                 Remove
@@ -4372,7 +4411,9 @@ export function TalkDetailPage({
                               }
                               disabled={toolStatus.status === 'saving'}
                             >
-                              <option value="google_drive_folder">Folder</option>
+                              <option value="google_drive_folder">
+                                Folder
+                              </option>
                               <option value="google_drive_file">File</option>
                             </select>
                           </label>
@@ -4393,7 +4434,9 @@ export function TalkDetailPage({
                             />
                           </label>
                         </div>
-                        <label style={{ display: 'block', marginTop: '0.5rem' }}>
+                        <label
+                          style={{ display: 'block', marginTop: '0.5rem' }}
+                        >
                           <span className="settings-label">Resource ID</span>
                           <input
                             type="text"
@@ -4409,7 +4452,10 @@ export function TalkDetailPage({
                             disabled={toolStatus.status === 'saving'}
                           />
                         </label>
-                        <div className="settings-button-row" style={{ marginTop: '0.75rem' }}>
+                        <div
+                          className="settings-button-row"
+                          style={{ marginTop: '0.75rem' }}
+                        >
                           <button
                             type="button"
                             className="secondary-btn"
@@ -4462,7 +4508,8 @@ export function TalkDetailPage({
                                   className="talk-agent-chip"
                                   title={tool.toolId}
                                 >
-                                  {entry.displayName}: {formatToolAccessState(tool.state)}
+                                  {entry.displayName}:{' '}
+                                  {formatToolAccessState(tool.state)}
                                 </span>
                               );
                             })}
@@ -4473,7 +4520,10 @@ export function TalkDetailPage({
                   </div>
 
                   {toolStatus.status === 'success' ? (
-                    <div className="inline-banner inline-banner-success" role="status">
+                    <div
+                      className="inline-banner inline-banner-success"
+                      role="status"
+                    >
                       {toolStatus.message}
                     </div>
                   ) : null}
@@ -5570,7 +5620,11 @@ export function TalkDetailPage({
                             {new Date(message.createdAt).toLocaleString()}
                           </time>
                         </header>
-                        <p>{message.content}</p>
+                        <p>
+                          {message.role === 'assistant'
+                            ? stripInternalAssistantText(message.content)
+                            : message.content}
+                        </p>
                         {message.attachments &&
                         message.attachments.length > 0 ? (
                           <div className="message-attachments">


### PR DESCRIPTION
## Summary
- sanitize `<internal>...</internal>` content from streamed and persisted Talk assistant output
- improve Claude subscription setup UX when host import is unavailable by preferring the manual token flow and auto-verifying on save
- add regression coverage for backend stream sanitization and the AI Agents / Talk UI flows

## Testing
- npm -C . test -- --run src/clawrocket/talks/run-worker.test.ts
- npm -C webapp run test -- --run src/pages/AiAgentsPage.test.tsx src/pages/TalkDetailPage.test.tsx
- npm -C . run typecheck
- npm -C webapp run typecheck