### PR TITLE
fix: harden Talk agent routing and attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to NanoClaw will be documented in this file.
 
+## [1.2.7](https://github.com/jokim1/clawrocket/compare/v1.2.6...v1.2.7)
+
+- Fixed direct Talk provider runs so they honor each model's configured output
+  budget instead of silently falling back to a 1024-token cap, which was
+  truncating long Kimi and Gemini responses.
+- Added Talk nickname mention routing, so typed mentions like `@kimi` and
+  `@gem` target the matching assigned agents instead of being ignored.
+- Persisted and recovered Talk agent attribution for assistant messages, and
+  updated the Talk UI to show agent nicknames directly instead of ambiguous
+  generic `assistant` labels when the actor is known.
+
 ## [1.2.6](https://github.com/jokim1/clawrocket/compare/v1.2.5...v1.2.6)
 
 - Allowed ordered Talk rounds to continue after an earlier agent fails, instead

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoclaw",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Personal Claude assistant. Lightweight, secure, customizable.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/clawrocket/agents/agent-registry.ts
+++ b/src/clawrocket/agents/agent-registry.ts
@@ -111,6 +111,7 @@ export interface TalkAgentAssignment {
   assignmentId: string;
   agentId: string;
   agentName: string;
+  nickname: string;
   personaRole: string | null;
   isPrimary: boolean;
   sortOrder: number;
@@ -128,6 +129,7 @@ export function listTalkAgents(talkId: string): TalkAgentAssignment[] {
       ta.id AS assignment_id,
       ta.registered_agent_id AS agent_id,
       ra.name AS agent_name,
+      COALESCE(ta.nickname, ra.name, 'Agent') AS nickname,
       ta.persona_role,
       ta.is_primary,
       ta.sort_order
@@ -142,6 +144,7 @@ export function listTalkAgents(talkId: string): TalkAgentAssignment[] {
     assignment_id: string;
     agent_id: string;
     agent_name: string;
+    nickname: string;
     persona_role: string | null;
     is_primary: number;
     sort_order: number;
@@ -150,6 +153,7 @@ export function listTalkAgents(talkId: string): TalkAgentAssignment[] {
     assignmentId: row.assignment_id,
     agentId: row.agent_id,
     agentName: row.agent_name,
+    nickname: row.nickname,
     personaRole: row.persona_role,
     isPrimary: !!row.is_primary,
     sortOrder: row.sort_order,
@@ -197,14 +201,93 @@ export function resolveAgentByName(
     FROM talk_agents ta
     JOIN registered_agents ra ON ra.id = ta.registered_agent_id
     WHERE ta.talk_id = ?
-      AND LOWER(ra.name) = LOWER(?)
+      AND (
+        LOWER(COALESCE(ta.nickname, '')) = LOWER(?)
+        OR LOWER(ra.name) = LOWER(?)
+      )
       AND ra.enabled = 1
     LIMIT 1
   `,
     )
-    .get(talkId, agentName) as RegisteredAgentRecord | undefined;
+    .get(talkId, agentName, agentName) as RegisteredAgentRecord | undefined;
 
   return row;
+}
+
+function normalizeMentionAlias(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function buildMentionAliases(value: string | null | undefined): string[] {
+  if (!value) return [];
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+
+  const aliases = new Set<string>();
+  const normalized = normalizeMentionAlias(trimmed);
+  if (normalized.length >= 2) {
+    aliases.add(normalized);
+  }
+
+  const firstToken = trimmed
+    .toLowerCase()
+    .split(/[^a-z0-9]+/g)
+    .find((token) => token.length >= 2);
+  if (firstToken) {
+    aliases.add(firstToken);
+  }
+
+  return [...aliases];
+}
+
+function extractMentionTokens(content: string): string[] {
+  const mentions: string[] = [];
+  const pattern = /(^|[\s([{"'`])@([A-Za-z0-9][A-Za-z0-9._-]*)/g;
+  for (const match of content.matchAll(pattern)) {
+    const token = normalizeMentionAlias(match[2] || '');
+    if (token.length >= 2) {
+      mentions.push(token);
+    }
+  }
+  return mentions;
+}
+
+export function resolveTalkAgentMentions(
+  talkId: string,
+  content: string,
+): TalkAgentAssignment[] {
+  const mentionTokens = extractMentionTokens(content);
+  if (mentionTokens.length === 0) return [];
+
+  const talkAgents = listTalkAgents(talkId);
+  if (talkAgents.length === 0) return [];
+
+  const aliasToAgentIds = new Map<string, Set<string>>();
+  for (const agent of talkAgents) {
+    const aliases = new Set<string>([
+      ...buildMentionAliases(agent.nickname),
+      ...buildMentionAliases(agent.agentName),
+    ]);
+    for (const alias of aliases) {
+      const next = aliasToAgentIds.get(alias) || new Set<string>();
+      next.add(agent.agentId);
+      aliasToAgentIds.set(alias, next);
+    }
+  }
+
+  const matchedAgentIds = new Set<string>();
+  for (const token of mentionTokens) {
+    const matches = aliasToAgentIds.get(token);
+    if (matches && matches.size === 1) {
+      matchedAgentIds.add([...matches][0]!);
+    }
+  }
+
+  if (matchedAgentIds.size === 0) {
+    return [];
+  }
+
+  return talkAgents.filter((agent) => matchedAgentIds.has(agent.agentId));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/clawrocket/agents/agent-router.test.ts
+++ b/src/clawrocket/agents/agent-router.test.ts
@@ -92,4 +92,33 @@ describe('agent-router', () => {
     });
     expect(events.some((event) => event.type === 'completed')).toBe(false);
   });
+
+  it('passes the model default output budget through to the direct HTTP client', async () => {
+    vi.mocked(resolveExecution).mockReturnValue({
+      providerConfig: {
+        providerId: 'provider.openai',
+        baseUrl: 'https://api.openai.com/v1',
+        apiFormat: 'openai_chat_completions',
+        authScheme: 'bearer',
+      },
+      secret: {
+        apiKey: 'sk-test',
+      },
+      defaultMaxOutputTokens: 8192,
+    } as never);
+    vi.mocked(streamLlmResponse).mockImplementation(
+      async function* (_provider, _secret, _modelId, _messages, options) {
+        expect(options?.maxOutputTokens).toBe(8192);
+        yield { type: 'text_delta', text: 'Ready.' };
+        yield { type: 'done', stopReason: 'stop' };
+      } as typeof streamLlmResponse,
+    );
+
+    const result = await executeWithAgent('agent-1', null, 'Review both docs', {
+      runId: 'run-2',
+      userId: 'owner-1',
+    });
+
+    expect(result.content).toBe('Ready.');
+  });
 });

--- a/src/clawrocket/agents/agent-router.test.ts
+++ b/src/clawrocket/agents/agent-router.test.ts
@@ -106,13 +106,17 @@ describe('agent-router', () => {
       },
       defaultMaxOutputTokens: 8192,
     } as never);
-    vi.mocked(streamLlmResponse).mockImplementation(
-      async function* (_provider, _secret, _modelId, _messages, options) {
-        expect(options?.maxOutputTokens).toBe(8192);
-        yield { type: 'text_delta', text: 'Ready.' };
-        yield { type: 'done', stopReason: 'stop' };
-      } as typeof streamLlmResponse,
-    );
+    vi.mocked(streamLlmResponse).mockImplementation(async function* (
+      _provider,
+      _secret,
+      _modelId,
+      _messages,
+      options,
+    ) {
+      expect(options?.maxOutputTokens).toBe(8192);
+      yield { type: 'text_delta', text: 'Ready.' };
+      yield { type: 'done', stopReason: 'stop' };
+    } as typeof streamLlmResponse);
 
     const result = await executeWithAgent('agent-1', null, 'Review both docs', {
       runId: 'run-2',

--- a/src/clawrocket/agents/agent-router.ts
+++ b/src/clawrocket/agents/agent-router.ts
@@ -258,11 +258,13 @@ export async function executeWithAgent(
   // -----------
   let providerConfig: LlmProviderConfig;
   let secret: LlmSecret;
+  let defaultMaxOutputTokens: number | undefined;
 
   try {
     const binding = resolveExecution(agent);
     providerConfig = binding.providerConfig;
     secret = binding.secret;
+    defaultMaxOutputTokens = binding.defaultMaxOutputTokens;
   } catch (err) {
     if (err instanceof ExecutionResolverError) {
       emit({ type: 'failed', errorCode: err.code, errorMessage: err.message });
@@ -404,6 +406,7 @@ export async function executeWithAgent(
         messages,
         {
           tools,
+          maxOutputTokens: defaultMaxOutputTokens,
           signal: options.signal,
         },
       );

--- a/src/clawrocket/agents/execution-resolver.ts
+++ b/src/clawrocket/agents/execution-resolver.ts
@@ -48,6 +48,8 @@ export interface ExecutionBinding {
   providerConfig: LlmProviderConfig;
   /** Credential to send with the request. */
   secret: LlmSecret;
+  /** Default output budget configured for this provider/model pair. */
+  defaultMaxOutputTokens?: number;
 }
 
 export class ExecutionResolverError extends Error {
@@ -110,7 +112,24 @@ export function resolveExecution(
     absoluteTimeoutMs: providerRecord.absolute_timeout_ms ?? undefined,
   };
 
-  return { providerConfig, secret };
+  const modelRecord = db
+    .prepare(
+      `
+        SELECT default_max_output_tokens
+        FROM llm_provider_models
+        WHERE provider_id = ? AND model_id = ?
+        LIMIT 1
+      `,
+    )
+    .get(agent.provider_id, agent.model_id) as
+    | { default_max_output_tokens: number }
+    | undefined;
+
+  return {
+    providerConfig,
+    secret,
+    defaultMaxOutputTokens: modelRecord?.default_max_output_tokens,
+  };
 }
 
 /**

--- a/src/clawrocket/db/accessors.ts
+++ b/src/clawrocket/db/accessors.ts
@@ -3756,15 +3756,11 @@ export function appendAssistantMessageWithOutbox(input: {
     const parsedMetadata = parseMessageMetadataJson(txInput.metadataJson);
     const mergedMetadata: Record<string, unknown> | null =
       parsedMetadata ||
-      (!txInput.metadataJson &&
-      (txInput.agentId || txInput.agentNickname)
+      (!txInput.metadataJson && (txInput.agentId || txInput.agentNickname)
         ? {}
         : null);
     if (mergedMetadata) {
-      if (
-        txInput.agentId &&
-        typeof mergedMetadata.agentId !== 'string'
-      ) {
+      if (txInput.agentId && typeof mergedMetadata.agentId !== 'string') {
         mergedMetadata.agentId = txInput.agentId;
       }
       if (

--- a/src/clawrocket/db/accessors.ts
+++ b/src/clawrocket/db/accessors.ts
@@ -3707,7 +3707,19 @@ export function listTalkRunsForTalk(
   return getDb()
     .prepare(
       `
-      SELECT r.*, ra.name AS target_agent_nickname
+      SELECT
+        r.*,
+        COALESCE(
+          (
+            SELECT ta.nickname
+            FROM talk_agents ta
+            WHERE ta.talk_id = r.talk_id
+              AND ta.registered_agent_id = r.target_agent_id
+            ORDER BY ta.sort_order ASC, ta.created_at ASC
+            LIMIT 1
+          ),
+          ra.name
+        ) AS target_agent_nickname
       FROM talk_runs r
       LEFT JOIN registered_agents ra ON ra.id = r.target_agent_id
       WHERE r.talk_id = ?
@@ -3741,7 +3753,31 @@ export function appendAssistantMessageWithOutbox(input: {
 }): TalkMessageRecord {
   const tx = getDb().transaction((txInput: typeof input): TalkMessageRecord => {
     const createdAt = txInput.createdAt || new Date().toISOString();
-    const metadata = parseMessageMetadataJson(txInput.metadataJson);
+    const parsedMetadata = parseMessageMetadataJson(txInput.metadataJson);
+    const mergedMetadata: Record<string, unknown> | null =
+      parsedMetadata ||
+      (!txInput.metadataJson &&
+      (txInput.agentId || txInput.agentNickname)
+        ? {}
+        : null);
+    if (mergedMetadata) {
+      if (
+        txInput.agentId &&
+        typeof mergedMetadata.agentId !== 'string'
+      ) {
+        mergedMetadata.agentId = txInput.agentId;
+      }
+      if (
+        txInput.agentNickname &&
+        typeof mergedMetadata.agentNickname !== 'string'
+      ) {
+        mergedMetadata.agentNickname = txInput.agentNickname;
+      }
+    }
+    const metadataJson =
+      mergedMetadata && Object.keys(mergedMetadata).length > 0
+        ? JSON.stringify(mergedMetadata)
+        : txInput.metadataJson || null;
     const message: TalkMessageRecord = {
       id: txInput.messageId,
       talk_id: txInput.talkId,
@@ -3751,7 +3787,7 @@ export function appendAssistantMessageWithOutbox(input: {
       created_by: null,
       created_at: createdAt,
       run_id: txInput.runId,
-      metadata_json: txInput.metadataJson || null,
+      metadata_json: metadataJson,
       sequence_in_run: txInput.sequenceInRun ?? null,
     };
 
@@ -3783,7 +3819,7 @@ export function appendAssistantMessageWithOutbox(input: {
         createdAt,
         agentId: txInput.agentId || null,
         agentNickname: txInput.agentNickname || null,
-        metadata,
+        metadata: mergedMetadata,
       }),
     });
 

--- a/src/clawrocket/talks/executor.ts
+++ b/src/clawrocket/talks/executor.ts
@@ -109,6 +109,7 @@ export type TalkExecutionEvent =
       talkId: string;
       threadId?: string | null;
       agentId?: string | null;
+      agentNickname?: string | null;
       responseGroupId?: string | null;
       sequenceIndex?: number | null;
       routeStepPosition?: number | null;

--- a/src/clawrocket/talks/new-executor.test.ts
+++ b/src/clawrocket/talks/new-executor.test.ts
@@ -378,6 +378,102 @@ describe('CleanTalkExecutor', () => {
     });
   });
 
+  it('injects a multi-agent routing note and keeps the Talk nickname for grouped direct runs', async () => {
+    const kimiAgent = createRegisteredAgent({
+      name: 'Moonshot Kimi',
+      providerId: 'provider.nvidia',
+      modelId: 'moonshotai/kimi-k2.5',
+      toolPermissionsJson: '{}',
+    });
+    const gemAgent = createRegisteredAgent({
+      name: 'Gemini Flash',
+      providerId: 'provider.gemini',
+      modelId: 'gemini-2.5-flash',
+      toolPermissionsJson: '{}',
+    });
+    getDb()
+      .prepare(
+        `
+      INSERT INTO talk_agents (id, talk_id, registered_agent_id, nickname, is_primary, sort_order, created_at, updated_at)
+      VALUES (?, ?, ?, ?, 1, 0, datetime('now'), datetime('now'))
+    `,
+      )
+      .run('ta-kimi', TALK_ID, kimiAgent.id, 'Kimi');
+    getDb()
+      .prepare(
+        `
+      INSERT INTO talk_agents (id, talk_id, registered_agent_id, nickname, is_primary, sort_order, created_at, updated_at)
+      VALUES (?, ?, ?, ?, 0, 1, datetime('now'), datetime('now'))
+    `,
+      )
+      .run('ta-gem', TALK_ID, gemAgent.id, 'Gem');
+    createTalkMessage({
+      id: 'msg-user-grouped',
+      talkId: TALK_ID,
+      threadId: THREAD_ID,
+      role: 'user',
+      content: '@kimi and @gem please review this.',
+      createdBy: 'owner-1',
+      createdAt: '2026-03-27T00:00:00.000Z',
+    });
+    createTalkRun({
+      id: 'run-grouped-kimi',
+      talk_id: TALK_ID,
+      thread_id: THREAD_ID,
+      requested_by: 'owner-1',
+      status: 'running',
+      trigger_message_id: 'msg-user-grouped',
+      target_agent_id: kimiAgent.id,
+      idempotency_key: null,
+      response_group_id: 'group-kimi-gem',
+      sequence_index: 0,
+      executor_alias: null,
+      executor_model: null,
+      source_binding_id: null,
+      source_external_message_id: null,
+      source_thread_key: null,
+      created_at: '2026-03-27T00:00:00.100Z',
+      started_at: '2026-03-27T00:00:00.100Z',
+      ended_at: null,
+      cancel_reason: null,
+    });
+
+    vi.mocked(executeWithAgent).mockImplementation(
+      async (agentId, context, userMessage) => {
+        expect(agentId).toBe(kimiAgent.id);
+        expect(userMessage).toBe('@kimi and @gem please review this.');
+        expect(context?.systemPrompt).toContain('Multi-agent routing note:');
+        expect(context?.systemPrompt).toContain('You are Kimi.');
+        expect(context?.systemPrompt).toContain(
+          'Do not say you cannot invoke the other agents',
+        );
+        return {
+          content: 'I will handle only my own perspective.',
+          agentId: kimiAgent.id,
+          providerId: 'provider.nvidia',
+          modelId: 'moonshotai/kimi-k2.5',
+        };
+      },
+    );
+
+    const result = await new CleanTalkExecutor().execute(
+      {
+        runId: 'run-grouped-kimi',
+        talkId: TALK_ID,
+        threadId: THREAD_ID,
+        requestedBy: 'owner-1',
+        triggerMessageId: 'msg-user-grouped',
+        triggerContent: '@kimi and @gem please review this.',
+        targetAgentId: kimiAgent.id,
+        responseGroupId: 'group-kimi-gem',
+        sequenceIndex: 0,
+      },
+      new AbortController().signal,
+    );
+
+    expect(result.agentNickname).toBe('Kimi');
+  });
+
   it('injects channel context and recent Slack history for channel-triggered runs', async () => {
     const now = new Date().toISOString();
     const agent = createRegisteredAgent({

--- a/src/clawrocket/talks/new-executor.ts
+++ b/src/clawrocket/talks/new-executor.ts
@@ -86,21 +86,26 @@ import {
   type TalkExecutorOutput,
 } from './executor.js';
 
+type ResolvedTalkAgentExecution = {
+  agent: RegisteredAgentRecord;
+  nickname: string;
+};
+
 function mapExecutionEvent(
   event: ExecutionEvent,
   input: TalkExecutorInput,
-  agent: RegisteredAgentRecord,
+  resolved: ResolvedTalkAgentExecution,
 ): TalkExecutionEvent | null {
   const shared = {
     runId: input.runId,
     talkId: input.talkId,
     threadId: input.threadId,
-    agentId: agent.id,
-    agentNickname: agent.name,
+    agentId: resolved.agent.id,
+    agentNickname: resolved.nickname,
     responseGroupId: input.responseGroupId ?? null,
     sequenceIndex: input.sequenceIndex ?? null,
-    providerId: agent.provider_id,
-    modelId: agent.model_id,
+    providerId: resolved.agent.provider_id,
+    modelId: resolved.agent.model_id,
   };
 
   switch (event.type) {
@@ -931,15 +936,45 @@ function filterEffectiveToolsForJob(
 function resolveTalkAgent(
   talkId: string,
   targetAgentId?: string | null,
-): RegisteredAgentRecord {
-  const targeted = targetAgentId ? getRegisteredAgent(targetAgentId) : null;
-  if (targeted) return targeted;
+): ResolvedTalkAgentExecution {
+  const assignments = listTalkAgents(talkId);
+  if (targetAgentId) {
+    const targetedAssignment = assignments.find(
+      (assignment) => assignment.agentId === targetAgentId,
+    );
+    const targetedAgent = getRegisteredAgent(targetAgentId);
+    if (targetedAssignment && targetedAgent) {
+      return {
+        agent: targetedAgent,
+        nickname: targetedAssignment.nickname || targetedAssignment.agentName,
+      };
+    }
+    if (targetedAgent) {
+      return { agent: targetedAgent, nickname: targetedAgent.name };
+    }
+  }
+
+  const primaryAssignment =
+    assignments.find((assignment) => assignment.isPrimary) || assignments[0];
+  if (primaryAssignment) {
+    const primaryAgent = getRegisteredAgent(primaryAssignment.agentId);
+    if (primaryAgent) {
+      return {
+        agent: primaryAgent,
+        nickname: primaryAssignment.nickname || primaryAssignment.agentName,
+      };
+    }
+  }
 
   const primary = resolvePrimaryAgent(talkId);
-  if (primary) return primary;
+  if (primary) {
+    return { agent: primary, nickname: primary.name };
+  }
 
   const main = getMainAgent();
-  if (main) return main;
+  if (main) {
+    return { agent: main, nickname: main.name };
+  }
 
   throw new TalkExecutorError(
     'NO_AGENT_AVAILABLE',
@@ -962,6 +997,23 @@ function getModelContextWindow(agent: RegisteredAgentRecord): number {
     | undefined;
 
   return row?.context_window_tokens || 128000;
+}
+
+function buildMultiAgentExecutionNote(input: {
+  responseGroupId?: string | null;
+  currentAgentNickname: string;
+}): string {
+  if (!input.responseGroupId) {
+    return '';
+  }
+
+  return [
+    'Multi-agent routing note:',
+    `You are ${input.currentAgentNickname}.`,
+    'The system is routing each selected agent separately.',
+    'If the user mentions other agent nicknames with @mentions, treat that as addressing/routing context only.',
+    "Do not say you cannot invoke the other agents, and do not present another agent's work as your own previous turn.",
+  ].join(' ');
 }
 
 const CHARS_TO_TOKENS = 0.25;
@@ -1022,7 +1074,18 @@ function listPriorOrderedOutputs(
       SELECT
         r.sequence_index AS sequenceIndex,
         r.target_agent_id AS agentId,
-        COALESCE(ra.name, 'Agent') AS agentNickname,
+        COALESCE(
+          (
+            SELECT ta.nickname
+            FROM talk_agents ta
+            WHERE ta.talk_id = r.talk_id
+              AND ta.registered_agent_id = r.target_agent_id
+            ORDER BY ta.sort_order ASC, ta.created_at ASC
+            LIMIT 1
+          ),
+          ra.name,
+          'Agent'
+        ) AS agentNickname,
         ao.content AS content
       FROM talk_runs r
       JOIN assistant_outputs ao ON ao.run_id = r.id
@@ -1047,7 +1110,18 @@ function listPriorOrderedGaps(
       SELECT
         r.sequence_index AS sequenceIndex,
         r.target_agent_id AS agentId,
-        COALESCE(ra.name, 'Agent') AS agentNickname,
+        COALESCE(
+          (
+            SELECT ta.nickname
+            FROM talk_agents ta
+            WHERE ta.talk_id = r.talk_id
+              AND ta.registered_agent_id = r.target_agent_id
+            ORDER BY ta.sort_order ASC, ta.created_at ASC
+            LIMIT 1
+          ),
+          ra.name,
+          'Agent'
+        ) AS agentNickname,
         r.status AS status
       FROM talk_runs r
       LEFT JOIN registered_agents ra ON ra.id = r.target_agent_id
@@ -1188,6 +1262,7 @@ function buildOrderedUserMessage(input: {
         'Identify areas of agreement, resolve tensions between differing viewpoints,',
         'and produce a unified recommendation that captures the strongest insights from each perspective.',
         "Treat the prior analyses as other agents' work, not as your own previous statements.",
+        'Even if a prior excerpt resembles your provider or a generic assistant label, it still belongs to the cited agent label above, not to you.',
         'Do not assume every earlier ordered step is represented if some analyses are marked unavailable.',
       ].join(' '),
     );
@@ -1196,6 +1271,7 @@ function buildOrderedUserMessage(input: {
       [
         'Provide your own analysis from your role and perspective.',
         'Use the prior analyses as context from other agents, not as your own previous statements.',
+        'Even if a prior excerpt resembles your provider or a generic assistant label, it still belongs to the cited agent label above, not to you.',
         'Do not merely restate them; add your independent reasoning.',
         'Do not assume every earlier ordered step is represented if some analyses are marked unavailable.',
       ].join(' '),
@@ -1776,7 +1852,7 @@ export class CleanTalkExecutor implements TalkExecutor {
   ): Promise<TalkExecutorOutput> {
     const emitEvent = emit || (() => {});
     let failureEmitted = false;
-    let resolvedAgent: RegisteredAgentRecord | null = null;
+    let resolvedAgent: ResolvedTalkAgentExecution | null = null;
 
     const emitTalkEvent = (event: TalkExecutionEvent) => {
       if (event.type === 'talk_response_failed') {
@@ -1797,9 +1873,14 @@ export class CleanTalkExecutor implements TalkExecutor {
       });
 
       resolvedAgent = resolveTalkAgent(input.talkId, input.targetAgentId);
-      const modelContextWindow = getModelContextWindow(resolvedAgent);
+      const activeAgent = resolvedAgent.agent;
+      const modelContextWindow = getModelContextWindow(activeAgent);
       const jobPolicy = buildTalkJobExecutionPolicy(input.jobId);
-      const plan = planExecution(resolvedAgent, input.requestedBy);
+      const plan = planExecution(activeAgent, input.requestedBy);
+      const multiAgentExecutionNote = buildMultiAgentExecutionNote({
+        responseGroupId: input.responseGroupId,
+        currentAgentNickname: resolvedAgent.nickname,
+      });
       const channelExecutionContext = await loadChannelExecutionContext({
         trigger: channelTriggerContext.trigger,
         binding: channelTriggerContext.binding,
@@ -1815,7 +1896,7 @@ export class CleanTalkExecutor implements TalkExecutor {
         input.triggerMessageId,
         input.requestedBy,
         {
-          personaRole: resolvedAgent.persona_role as TalkPersonaRole | null,
+          personaRole: activeAgent.persona_role as TalkPersonaRole | null,
           retrievalQuery: input.triggerContent,
           jobPolicy,
           effectiveTools: scopedEffectiveTools,
@@ -1827,14 +1908,20 @@ export class CleanTalkExecutor implements TalkExecutor {
         JSON.stringify({
           ...runMetadata,
           ...contextPackage.contextSnapshot,
-          executionDecision: buildExecutionDecision(resolvedAgent, plan),
+          executionDecision: buildExecutionDecision(activeAgent, plan),
         }),
       );
 
       const context: ExecutionContext = {
-        systemPrompt: browserResumeSection
-          ? `${contextPackage.systemPrompt}\n\n# Browser Resume Context\n\n${browserResumeSection}`
-          : contextPackage.systemPrompt,
+        systemPrompt: [
+          contextPackage.systemPrompt,
+          multiAgentExecutionNote,
+          browserResumeSection
+            ? `# Browser Resume Context\n\n${browserResumeSection}`
+            : '',
+        ]
+          .filter(Boolean)
+          .join('\n\n'),
         contextTools: contextPackage.contextTools,
         connectorTools: contextPackage.connectorTools,
         history: contextPackage.history,
@@ -1877,18 +1964,18 @@ export class CleanTalkExecutor implements TalkExecutor {
           runId: input.runId,
           talkId: input.talkId,
           threadId: input.threadId,
-          agentId: resolvedAgent.id,
-          agentNickname: resolvedAgent.name,
+          agentId: activeAgent.id,
+          agentNickname: resolvedAgent.nickname,
           responseGroupId: input.responseGroupId ?? null,
           sequenceIndex: input.sequenceIndex ?? null,
-          providerId: resolvedAgent.provider_id,
-          modelId: resolvedAgent.model_id,
+          providerId: activeAgent.provider_id,
+          modelId: activeAgent.model_id,
         });
 
         const containerResult = await executeContainerAgentTurn({
           runId: input.runId,
           userId: input.requestedBy,
-          agent: resolvedAgent,
+          agent: activeAgent,
           promptLabel: 'talk',
           userMessage: orderedStep.userMessageText,
           signal,
@@ -1898,11 +1985,8 @@ export class CleanTalkExecutor implements TalkExecutor {
           }),
           context: {
             systemPrompt: [
-              contextPackage.systemPrompt,
-              browserResumeSection
-                ? `# Browser Resume Context\n\n${browserResumeSection}`
-                : '',
-              resolvedAgent.system_prompt?.trim() || '',
+              context.systemPrompt,
+              activeAgent.system_prompt?.trim() || '',
             ]
               .filter(Boolean)
               .join('\n\n'),
@@ -1926,25 +2010,25 @@ export class CleanTalkExecutor implements TalkExecutor {
           runId: input.runId,
           talkId: input.talkId,
           threadId: input.threadId,
-          agentId: resolvedAgent.id,
-          agentNickname: resolvedAgent.name,
+          agentId: activeAgent.id,
+          agentNickname: resolvedAgent.nickname,
           responseGroupId: input.responseGroupId ?? null,
           sequenceIndex: input.sequenceIndex ?? null,
-          providerId: resolvedAgent.provider_id,
-          modelId: resolvedAgent.model_id,
+          providerId: activeAgent.provider_id,
+          modelId: activeAgent.model_id,
         });
 
         return {
           content: containerResult.content,
-          agentId: resolvedAgent.id,
-          agentNickname: resolvedAgent.name,
-          providerId: resolvedAgent.provider_id,
-          modelId: resolvedAgent.model_id,
+          agentId: activeAgent.id,
+          agentNickname: resolvedAgent.nickname,
+          providerId: activeAgent.provider_id,
+          modelId: activeAgent.model_id,
           responseSequenceInRun: 1,
           metadataJson: buildResponseMetadataJson({
             runId: input.runId,
-            providerId: resolvedAgent.provider_id,
-            modelId: resolvedAgent.model_id,
+            providerId: activeAgent.provider_id,
+            modelId: activeAgent.model_id,
             estimatedContextTokens: contextPackage.estimatedTokens,
             responseGroupId: input.responseGroupId,
             sequenceIndex: input.sequenceIndex,
@@ -1969,28 +2053,25 @@ export class CleanTalkExecutor implements TalkExecutor {
           runId: input.runId,
           talkId: input.talkId,
           threadId: input.threadId,
-          agentId: resolvedAgent.id,
-          agentNickname: resolvedAgent.name,
+          agentId: activeAgent.id,
+          agentNickname: resolvedAgent.nickname,
           responseGroupId: input.responseGroupId ?? null,
           sequenceIndex: input.sequenceIndex ?? null,
-          providerId: resolvedAgent.provider_id,
-          modelId: resolvedAgent.model_id,
+          providerId: activeAgent.provider_id,
+          modelId: activeAgent.model_id,
         });
 
         const codexResult = await executeCodexAgentTurn({
           runId: input.runId,
           userId: input.requestedBy,
-          agent: resolvedAgent,
+          agent: activeAgent,
           promptLabel: 'talk',
           userMessage: orderedStep.userMessageText,
           signal,
           context: {
             systemPrompt: [
-              contextPackage.systemPrompt,
-              browserResumeSection
-                ? `# Browser Resume Context\n\n${browserResumeSection}`
-                : '',
-              resolvedAgent.system_prompt?.trim() || '',
+              context.systemPrompt,
+              activeAgent.system_prompt?.trim() || '',
             ]
               .filter(Boolean)
               .join('\n\n'),
@@ -2010,18 +2091,18 @@ export class CleanTalkExecutor implements TalkExecutor {
             (tool) => tool.toolFamily === 'browser' && tool.enabled,
           ),
           onProgressUpdate: (message) => {
-            const activeAgent = resolvedAgent!;
+            const currentAgent = resolvedAgent!;
             emitTalkEvent({
               type: 'talk_progress_update',
               runId: input.runId,
               talkId: input.talkId,
               threadId: input.threadId,
-              agentId: activeAgent.id,
-              agentNickname: activeAgent.name,
+              agentId: currentAgent.agent.id,
+              agentNickname: currentAgent.nickname,
               responseGroupId: input.responseGroupId ?? null,
               sequenceIndex: input.sequenceIndex ?? null,
-              providerId: activeAgent.provider_id,
-              modelId: activeAgent.model_id,
+              providerId: currentAgent.agent.provider_id,
+              modelId: currentAgent.agent.model_id,
               message,
             });
           },
@@ -2037,11 +2118,11 @@ export class CleanTalkExecutor implements TalkExecutor {
             runId: input.runId,
             talkId: input.talkId,
             threadId: input.threadId,
-            agentId: resolvedAgent.id,
+            agentId: activeAgent.id,
             responseGroupId: input.responseGroupId ?? null,
             sequenceIndex: input.sequenceIndex ?? null,
-            providerId: resolvedAgent.provider_id,
-            modelId: resolvedAgent.model_id,
+            providerId: activeAgent.provider_id,
+            modelId: activeAgent.model_id,
             usage: {
               inputTokens: codexResult.usage.inputTokens,
               cachedInputTokens: codexResult.usage.cachedInputTokens,
@@ -2055,12 +2136,12 @@ export class CleanTalkExecutor implements TalkExecutor {
           runId: input.runId,
           talkId: input.talkId,
           threadId: input.threadId,
-          agentId: resolvedAgent.id,
-          agentNickname: resolvedAgent.name,
+          agentId: activeAgent.id,
+          agentNickname: resolvedAgent.nickname,
           responseGroupId: input.responseGroupId ?? null,
           sequenceIndex: input.sequenceIndex ?? null,
-          providerId: resolvedAgent.provider_id,
-          modelId: resolvedAgent.model_id,
+          providerId: activeAgent.provider_id,
+          modelId: activeAgent.model_id,
           usage: codexResult.usage
             ? {
                 inputTokens: codexResult.usage.inputTokens,
@@ -2072,10 +2153,10 @@ export class CleanTalkExecutor implements TalkExecutor {
 
         return {
           content: codexResult.content,
-          agentId: resolvedAgent.id,
-          agentNickname: resolvedAgent.name,
-          providerId: resolvedAgent.provider_id,
-          modelId: resolvedAgent.model_id,
+          agentId: activeAgent.id,
+          agentNickname: resolvedAgent.nickname,
+          providerId: activeAgent.provider_id,
+          modelId: activeAgent.model_id,
           usage: codexResult.usage
             ? {
                 inputTokens: codexResult.usage.inputTokens,
@@ -2086,8 +2167,8 @@ export class CleanTalkExecutor implements TalkExecutor {
           responseSequenceInRun: 1,
           metadataJson: buildResponseMetadataJson({
             runId: input.runId,
-            providerId: resolvedAgent.provider_id,
-            modelId: resolvedAgent.model_id,
+            providerId: activeAgent.provider_id,
+            modelId: activeAgent.model_id,
             estimatedContextTokens: contextPackage.estimatedTokens,
             responseGroupId: input.responseGroupId,
             sequenceIndex: input.sequenceIndex,
@@ -2126,7 +2207,7 @@ export class CleanTalkExecutor implements TalkExecutor {
         });
 
       assertVisionSupportForConversationImages({
-        agent: resolvedAgent,
+        agent: activeAgent,
         currentAttachmentRows,
         historyImageMessageIdsToHydrate,
       });
@@ -2147,7 +2228,7 @@ export class CleanTalkExecutor implements TalkExecutor {
         attachmentHeading: 'Current message attachments:',
       });
       const result = await executeWithAgent(
-        resolvedAgent.id,
+        activeAgent.id,
         {
           ...context,
           history: directHistory,
@@ -2170,7 +2251,7 @@ export class CleanTalkExecutor implements TalkExecutor {
       return {
         content: result.content,
         agentId: result.agentId,
-        agentNickname: resolvedAgent.name,
+        agentNickname: resolvedAgent.nickname,
         providerId: result.providerId,
         modelId: result.modelId,
         usage: result.usage
@@ -2209,11 +2290,12 @@ export class CleanTalkExecutor implements TalkExecutor {
           runId: input.runId,
           talkId: input.talkId,
           threadId: input.threadId,
-          agentId: resolvedAgent?.id,
+          agentId: resolvedAgent?.agent.id,
+          agentNickname: resolvedAgent?.nickname,
           responseGroupId: input.responseGroupId ?? null,
           sequenceIndex: input.sequenceIndex ?? null,
-          providerId: resolvedAgent?.provider_id,
-          modelId: resolvedAgent?.model_id,
+          providerId: resolvedAgent?.agent.provider_id,
+          modelId: resolvedAgent?.agent.model_id,
           errorCode,
           errorMessage,
         });

--- a/src/clawrocket/web/routes/talk-tools.ts
+++ b/src/clawrocket/web/routes/talk-tools.ts
@@ -349,7 +349,7 @@ function buildTalkToolsRecord(input: {
     const snapshot = getRegisteredAgentSnapshot(assignment.agentId);
     return {
       agentId: assignment.agentId,
-      nickname: assignment.agentName,
+      nickname: assignment.nickname,
       sourceKind: 'provider' as const,
       providerId: snapshot?.providerId || null,
       modelId: snapshot?.modelId || null,

--- a/src/clawrocket/web/routes/talks.test.ts
+++ b/src/clawrocket/web/routes/talks.test.ts
@@ -1455,6 +1455,68 @@ describe('talk routes', () => {
     expect(wakeCalls).toBe(1);
   });
 
+  it('routes explicit @nickname mentions using Talk nicknames and narrows an over-selected round', async () => {
+    const kimiAgent = createRegisteredAgent({
+      name: 'Moonshot Kimi',
+      providerId: 'provider.nvidia',
+      modelId: 'moonshotai/kimi-k2.5',
+      toolPermissionsJson: '{}',
+    });
+    const gemAgent = createRegisteredAgent({
+      name: 'Gemini Flash',
+      providerId: 'provider.gemini',
+      modelId: 'gemini-2.5-flash',
+      toolPermissionsJson: '{}',
+    });
+    getDb()
+      .prepare(
+        `
+      INSERT INTO talk_agents (id, talk_id, registered_agent_id, nickname, is_primary, sort_order, created_at, updated_at)
+      VALUES (?, ?, ?, ?, 0, 1, datetime('now'), datetime('now'))
+    `,
+      )
+      .run('ta-talk-owner-kimi', 'talk-owner', kimiAgent.id, 'Kimi');
+    getDb()
+      .prepare(
+        `
+      INSERT INTO talk_agents (id, talk_id, registered_agent_id, nickname, is_primary, sort_order, created_at, updated_at)
+      VALUES (?, ?, ?, ?, 0, 2, datetime('now'), datetime('now'))
+    `,
+      )
+      .run('ta-talk-owner-gem', 'talk-owner', gemAgent.id, 'Gem Heavy');
+    const agentsRes = await server.request('/api/v1/talks/talk-owner/agents', {
+      headers: {
+        Authorization: 'Bearer owner-token',
+      },
+    });
+    expect(agentsRes.status).toBe(200);
+    const agentsBody = (await agentsRes.json()) as any;
+    const primaryAgentId = agentsBody.data.agents[0].id;
+
+    const res = await server.request('/api/v1/talks/talk-owner/chat', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer owner-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        content: '@kimi and @gem please review this.',
+        targetAgentIds: [primaryAgentId, kimiAgent.id, gemAgent.id],
+      }),
+    });
+
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as any;
+    expect(body.ok).toBe(true);
+    expect(body.data.runs.map((run: any) => run.targetAgentId)).toEqual([
+      kimiAgent.id,
+      gemAgent.id,
+    ]);
+    expect(
+      body.data.runs.map((run: any) => run.targetAgentNickname),
+    ).toEqual(['Kimi', 'Gem Heavy']);
+  });
+
   it('returns real run error codes and target nicknames in run history', async () => {
     const agentsRes = await server.request('/api/v1/talks/talk-owner/agents', {
       headers: {
@@ -1505,6 +1567,65 @@ describe('talk routes', () => {
     expect(failedRun.errorCode).toBe('trigger_message_missing');
     expect(failedRun.errorMessage).toBe('Trigger message not found');
     expect(failedRun.targetAgentNickname).toBe(targetAgent.nickname);
+  });
+
+  it('falls back to the run target nickname for assistant messages missing actor metadata', async () => {
+    const agentsRes = await server.request('/api/v1/talks/talk-owner/agents', {
+      headers: {
+        Authorization: 'Bearer owner-token',
+      },
+    });
+    expect(agentsRes.status).toBe(200);
+    const agentsBody = (await agentsRes.json()) as any;
+    const targetAgent = agentsBody.data.agents[0];
+
+    createTalkRun({
+      id: 'run-message-fallback',
+      talk_id: 'talk-owner',
+      thread_id: 'thread-talk-owner',
+      requested_by: 'owner-1',
+      status: 'completed',
+      trigger_message_id: null,
+      target_agent_id: targetAgent.id,
+      idempotency_key: null,
+      executor_alias: 'claude',
+      executor_model: 'claude-sonnet-4-6',
+      created_at: '2026-03-07T00:20:00.000Z',
+      started_at: '2026-03-07T00:20:00.500Z',
+      ended_at: '2026-03-07T00:20:01.000Z',
+      cancel_reason: null,
+    });
+    createTalkMessage({
+      id: 'msg-message-fallback',
+      talkId: 'talk-owner',
+      threadId: 'thread-talk-owner',
+      role: 'assistant',
+      content: 'Recovered from the run actor.',
+      createdBy: null,
+      runId: 'run-message-fallback',
+      metadataJson: null,
+      createdAt: '2026-03-07T00:20:01.000Z',
+    });
+
+    const messagesRes = await server.request(
+      '/api/v1/talks/talk-owner/messages',
+      {
+        headers: {
+          Authorization: 'Bearer owner-token',
+        },
+      },
+    );
+    expect(messagesRes.status).toBe(200);
+    const messagesBody = (await messagesRes.json()) as any;
+    const fallbackMessage = messagesBody.data.messages.find(
+      (message: any) => message.id === 'msg-message-fallback',
+    );
+
+    expect(fallbackMessage).toMatchObject({
+      id: 'msg-message-fallback',
+      agentId: targetAgent.id,
+      agentNickname: targetAgent.nickname,
+    });
   });
 
   it('returns the saved context snapshot for a talk run', async () => {

--- a/src/clawrocket/web/routes/talks.test.ts
+++ b/src/clawrocket/web/routes/talks.test.ts
@@ -1512,9 +1512,10 @@ describe('talk routes', () => {
       kimiAgent.id,
       gemAgent.id,
     ]);
-    expect(
-      body.data.runs.map((run: any) => run.targetAgentNickname),
-    ).toEqual(['Kimi', 'Gem Heavy']);
+    expect(body.data.runs.map((run: any) => run.targetAgentNickname)).toEqual([
+      'Kimi',
+      'Gem Heavy',
+    ]);
   });
 
   it('returns real run error codes and target nicknames in run history', async () => {

--- a/src/clawrocket/web/routes/talks.ts
+++ b/src/clawrocket/web/routes/talks.ts
@@ -2094,16 +2094,16 @@ export function enqueueTalkChat(input: {
           nickname: agent.nickname || agent.agentName,
         }))
       : requestedTargetIds.length > 0
-      ? talkAgents
-          .filter((a) => requestedTargetIds.includes(a.agentId))
-          .map((a) => ({
+        ? talkAgents
+            .filter((a) => requestedTargetIds.includes(a.agentId))
+            .map((a) => ({
+              id: a.agentId,
+              nickname: a.nickname || a.agentName,
+            }))
+        : talkAgents.map((a) => ({
             id: a.agentId,
             nickname: a.nickname || a.agentName,
-          }))
-      : talkAgents.map((a) => ({
-          id: a.agentId,
-          nickname: a.nickname || a.agentName,
-        }));
+          }));
   const orderedRunSet =
     talk.orchestration_mode === 'ordered' && selectedAgents.length > 1;
 

--- a/src/clawrocket/web/routes/talks.ts
+++ b/src/clawrocket/web/routes/talks.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 
+import { getDb } from '../../../db.js';
 import { getContainerRuntimeStatus } from '../../../container-runtime.js';
 import {
   AttachmentValidationError,
@@ -51,6 +52,7 @@ import {
   getDefaultTalkAgentId,
   ensureTalkUsesUsableDefaultAgent,
   listTalkAgents,
+  resolveTalkAgentMentions,
   setTalkAgents,
   getTalkAgentRows,
   type TalkAgentInput,
@@ -441,6 +443,44 @@ function toTalkMessageApiRecord(
       }
     } catch {
       // Ignore metadata parse failures for UI response shaping.
+    }
+  }
+  if ((!agentId || !agentNickname) && message.run_id) {
+    const fallback = getDb()
+      .prepare(
+        `
+          SELECT
+            r.target_agent_id AS agent_id,
+            COALESCE(
+              (
+                SELECT ta.nickname
+                FROM talk_agents ta
+                WHERE ta.talk_id = r.talk_id
+                  AND ta.registered_agent_id = r.target_agent_id
+                ORDER BY ta.sort_order ASC, ta.created_at ASC
+                LIMIT 1
+              ),
+              ra.name
+            ) AS agent_nickname
+          FROM talk_runs r
+          LEFT JOIN registered_agents ra ON ra.id = r.target_agent_id
+          WHERE r.id = ?
+          LIMIT 1
+        `,
+      )
+      .get(message.run_id) as
+      | {
+          agent_id: string | null;
+          agent_nickname: string | null;
+        }
+      | undefined;
+    if (fallback) {
+      if (!agentId && typeof fallback.agent_id === 'string') {
+        agentId = fallback.agent_id;
+      }
+      if (!agentNickname && typeof fallback.agent_nickname === 'string') {
+        agentNickname = fallback.agent_nickname;
+      }
     }
   }
 
@@ -2046,12 +2086,24 @@ export function enqueueTalkChat(input: {
     : [];
   ensureTalkUsesUsableDefaultAgent(input.talkId);
   const talkAgents = listTalkAgents(input.talkId);
-  const selectedAgents: Array<{ id: string; name: string }> =
-    requestedTargetIds.length > 0
+  const mentionedAgents = resolveTalkAgentMentions(input.talkId, content);
+  const selectedAgents: Array<{ id: string; nickname: string }> =
+    mentionedAgents.length > 0
+      ? mentionedAgents.map((agent) => ({
+          id: agent.agentId,
+          nickname: agent.nickname || agent.agentName,
+        }))
+      : requestedTargetIds.length > 0
       ? talkAgents
           .filter((a) => requestedTargetIds.includes(a.agentId))
-          .map((a) => ({ id: a.agentId, name: a.agentName }))
-      : talkAgents.map((a) => ({ id: a.agentId, name: a.agentName }));
+          .map((a) => ({
+            id: a.agentId,
+            nickname: a.nickname || a.agentName,
+          }))
+      : talkAgents.map((a) => ({
+          id: a.agentId,
+          nickname: a.nickname || a.agentName,
+        }));
   const orderedRunSet =
     talk.orchestration_mode === 'ordered' && selectedAgents.length > 1;
 
@@ -2157,7 +2209,7 @@ export function enqueueTalkChat(input: {
   }
 
   const agentNicknameById = new Map(
-    selectedAgents.map((agent) => [agent.id, agent.name]),
+    selectedAgents.map((agent) => [agent.id, agent.nickname]),
   );
 
   return {

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -17,9 +17,9 @@ import {
   updateTask,
 } from './db.js';
 import {
-    _initClawrocketTestSchema,
-    appendAssistantMessageWithOutbox,
-    appendRuntimeTalkMessage,
+  _initClawrocketTestSchema,
+  appendAssistantMessageWithOutbox,
+  appendRuntimeTalkMessage,
   appendOutboxEvent,
   canUserEditTalk,
   claimNextChannelDeliveryRow,

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -17,8 +17,9 @@ import {
   updateTask,
 } from './db.js';
 import {
-  _initClawrocketTestSchema,
-  appendRuntimeTalkMessage,
+    _initClawrocketTestSchema,
+    appendAssistantMessageWithOutbox,
+    appendRuntimeTalkMessage,
   appendOutboxEvent,
   canUserEditTalk,
   claimNextChannelDeliveryRow,
@@ -1264,6 +1265,53 @@ describe('phase 0 schema and reliability tables', () => {
     expect(toolEvent?.metadata).toMatchObject({
       kind: 'tool_result',
       toolName: 'connector_posthog__query',
+    });
+  });
+
+  it('persists assistant actor metadata when appending final assistant messages', () => {
+    createTalkRun({
+      id: 'run-assistant-metadata',
+      talk_id: 'talk-1',
+      thread_id: TALK_THREAD_ID,
+      requested_by: 'owner-1',
+      status: 'running',
+      trigger_message_id: null,
+      target_agent_id: 'agent-default',
+      idempotency_key: null,
+      executor_alias: null,
+      executor_model: null,
+      created_at: '2024-01-01T00:00:03.000Z',
+      started_at: '2024-01-01T00:00:03.500Z',
+      ended_at: null,
+      cancel_reason: null,
+    });
+
+    const message = appendAssistantMessageWithOutbox({
+      talkId: 'talk-1',
+      threadId: TALK_THREAD_ID,
+      runId: 'run-assistant-metadata',
+      messageId: 'msg-assistant-metadata',
+      content: 'Final answer',
+      metadataJson: JSON.stringify({ completionStatus: 'complete' }),
+      agentId: 'agent-default',
+      agentNickname: 'Claude Opus 4.6',
+      createdAt: '2024-01-01T00:00:04.000Z',
+    });
+
+    expect(JSON.parse(message.metadata_json || '{}')).toMatchObject({
+      completionStatus: 'complete',
+      agentId: 'agent-default',
+      agentNickname: 'Claude Opus 4.6',
+    });
+    expect(
+      JSON.parse(
+        listTalkMessages({ talkId: 'talk-1', limit: 20 }).find(
+          (candidate) => candidate.id === 'msg-assistant-metadata',
+        )?.metadata_json || '{}',
+      ),
+    ).toMatchObject({
+      agentId: 'agent-default',
+      agentNickname: 'Claude Opus 4.6',
     });
   });
 

--- a/webapp/src/pages/TalkDetailPage.test.tsx
+++ b/webapp/src/pages/TalkDetailPage.test.tsx
@@ -3586,6 +3586,39 @@ describe('TalkDetailPage', () => {
     expect(screen.getByText('Step 2 of 2')).toBeTruthy();
   });
 
+  it('uses the agent nickname as the assistant message header when available', async () => {
+    installTalkDetailFetch({
+      messages: [
+        buildMessage({
+          id: 'msg-1',
+          role: 'user',
+          content: 'Review this.',
+          createdAt: '2026-03-06T00:00:00.000Z',
+        }),
+        buildMessage({
+          id: 'msg-gem',
+          role: 'assistant',
+          content: 'Independent review.',
+          createdAt: '2026-03-06T00:00:03.000Z',
+          runId: 'run-gem',
+          agentId: 'agent-openai',
+          agentNickname: 'Gem',
+        }),
+      ],
+    });
+
+    renderDetailPage('/app/talks/talk-1');
+
+    const messageBody = await screen.findByText('Independent review.');
+    const article = messageBody.closest('article');
+    if (!article) {
+      throw new Error('Expected assistant article wrapper');
+    }
+
+    expect(within(article).getByText('GPT-5 Mini (Critic)')).toBeTruthy();
+    expect(within(article).queryByText(/^assistant$/i)).toBeNull();
+  });
+
   it('strips internal tags from live streamed assistant responses', async () => {
     installTalkDetailFetch();
 

--- a/webapp/src/pages/TalkDetailPage.tsx
+++ b/webapp/src/pages/TalkDetailPage.tsx
@@ -13257,6 +13257,12 @@ export function TalkDetailPage({
                               agentLabelById[message.agentId]) ||
                             message.agentNickname ||
                             null;
+                          const headerActorLabel =
+                            message.role === 'assistant' && agentLabel
+                              ? agentLabel
+                              : agentLabel
+                                ? `${agentLabel} · ${message.role}`
+                                : message.role;
                           return (
                             <article
                               key={entry.key}
@@ -13269,10 +13275,7 @@ export function TalkDetailPage({
                               }`}
                             >
                               <header>
-                                <strong>
-                                  {agentLabel ? `${agentLabel} · ` : ''}
-                                  {message.role}
-                                </strong>
+                                <strong>{headerActorLabel}</strong>
                                 {orderedStepLabel ? (
                                   <span className="message-sequence-badge">
                                     {orderedStepLabel}


### PR DESCRIPTION
## Summary
- pass provider/model default output budgets through the direct Talk execution path so Kimi and Gemini are not truncated at the client fallback cap
- resolve typed @nickname mentions against assigned Talk agents and inject a multi-agent routing note so agents stop misinterpreting mentions as manual cross-agent invocation
- persist and recover assistant actor attribution from Talk runs and render known agent labels directly in the Talk UI
- bump the release to 1.2.7 and document the fix set in the changelog

## Testing
- npx vitest run src/clawrocket/agents/agent-router.test.ts src/clawrocket/web/routes/talks.test.ts src/clawrocket/talks/new-executor.test.ts src/db.test.ts
- npm --prefix webapp test -- --run src/pages/TalkDetailPage.test.tsx
- npm run typecheck
- npm --prefix webapp run typecheck