### PR TITLE
feat: scaffold editorial-room v0 contract validation pipeline

### DIFF
--- a/docs/contracts/editorial-room/v0/setup_state.schema.json
+++ b/docs/contracts/editorial-room/v0/setup_state.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/setup_state.schema.json",
+  "title": "SetupState",
+  "description": "EditorialPiece.setup_state — load-bearing context for downstream phases. See docs/EDITORIAL_ROOM_CONTRACT.md §2. Owned by clawrocket.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "setup_version",
+    "deliverable_type",
+    "voice_page_slug",
+    "length_target",
+    "destination",
+    "audience_persona_slugs",
+    "llm_room_agent_profile_ids",
+    "scoring_pipeline_slug",
+    "updated_at",
+    "updated_by_user_id"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "0",
+      "description": "Contract version. Always '0' until first production deployment per §8."
+    },
+    "setup_version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Monotonic; increments on any field change. Used as staling key for downstream score_snapshots, discussion_sessions, etc. (per §1, §2.2)."
+    },
+    "deliverable_type": {
+      "type": "string",
+      "enum": ["longform_post", "podcast_script", "book_chapter", "social_post", "memo"]
+    },
+    "voice_page_slug": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Ref to rocketorchestra voice page (e.g., 'voice/gamemakers-2026')."
+    },
+    "length_target": {
+      "anyOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["min_words", "max_words"],
+          "properties": {
+            "min_words": { "type": "integer", "minimum": 1 },
+            "max_words": { "type": "integer", "minimum": 1 }
+          }
+        }
+      ],
+      "description": "null = no target. Runtime invariant (not encoded here): min_words <= max_words."
+    },
+    "destination": {
+      "type": "string",
+      "enum": ["substack_md", "google_doc", "plain_md", "youtube_script", "other"]
+    },
+    "audience_persona_slugs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "maxItems": 3,
+      "description": "Ordered. Min 1, max 3 initially per §2.1. Each element is a rocketorchestra persona page slug."
+    },
+    "llm_room_agent_profile_ids": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 2,
+      "maxItems": 6,
+      "description": "Ordered. Min 2, max 6 initially per §2.1. Each element is a clawrocket agent profile id."
+    },
+    "scoring_pipeline_slug": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Ref to rocketorchestra scoring_pipeline page."
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp."
+    },
+    "updated_by_user_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "auth.users.id (Supabase Auth in production; local fixture identity in 0p)."
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nanoclaw",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nanoclaw",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "dependencies": {
         "@hono/node-server": "^1.19.10",
         "better-sqlite3": "^11.8.1",
@@ -27,6 +27,8 @@
         "@types/node": "^24.12.0",
         "@types/pdf-parse": "^1.1.5",
         "@vitest/coverage-v8": "^4.0.18",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "husky": "^9.1.7",
         "prettier": "^3.8.1",
         "tsx": "^4.19.0",
@@ -1393,6 +1395,41 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/archiver": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
@@ -2005,11 +2042,35 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2294,6 +2355,13 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -3055,6 +3123,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "@types/node": "^24.12.0",
     "@types/pdf-parse": "^1.1.5",
     "@vitest/coverage-v8": "^4.0.18",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "husky": "^9.1.7",
     "prettier": "^3.8.1",
     "tsx": "^4.19.0",

--- a/src/clawrocket/contracts/editorial-room.test.ts
+++ b/src/clawrocket/contracts/editorial-room.test.ts
@@ -1,0 +1,169 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Ajv } from 'ajv';
+import type { AnySchemaObject, ValidateFunction } from 'ajv';
+import _addFormats from 'ajv-formats';
+import type { FormatsPluginOptions } from 'ajv-formats';
+import { describe, expect, it } from 'vitest';
+
+// ajv-formats is CJS with only a default export; under module: "NodeNext"
+// TypeScript can't see the synthesized default as callable. Cast through
+// unknown to its real call signature. ajv exposes `Ajv` as a named export
+// too, so we use that directly and avoid the same gotcha there.
+const addFormats = _addFormats as unknown as (
+  ajv: InstanceType<typeof Ajv>,
+  options?: FormatsPluginOptions,
+) => InstanceType<typeof Ajv>;
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..', '..');
+const schemaDir = resolve(repoRoot, 'docs/contracts/editorial-room/v0');
+const fixtureDir = resolve(repoRoot, 'tests/fixtures/editorial-room/v0');
+
+const ajv = new Ajv({ allErrors: true, strict: true });
+addFormats(ajv);
+
+function loadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+function compile(schemaFile: string): ValidateFunction {
+  return ajv.compile(
+    loadJson(resolve(schemaDir, schemaFile)) as AnySchemaObject,
+  );
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value !== null && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      sorted[key] = sortKeys((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+function canonical(value: unknown): string {
+  return JSON.stringify(sortKeys(value));
+}
+
+function expectValid(
+  validate: ValidateFunction,
+  fixture: unknown,
+  label: string,
+): void {
+  const ok = validate(fixture);
+  if (!ok) {
+    throw new Error(
+      `Validation failed for ${label}:\n${JSON.stringify(validate.errors, null, 2)}`,
+    );
+  }
+  expect(ok).toBe(true);
+}
+
+describe('editorial-room v0 — SetupState contract', () => {
+  const validateSetupState = compile('setup_state.schema.json');
+
+  describe('schema validation', () => {
+    it.each([['setup_state.minimal.json'], ['setup_state.full.json']])(
+      '%s validates against the schema',
+      (filename) => {
+        const fixture = loadJson(resolve(fixtureDir, filename));
+        expectValid(validateSetupState, fixture, filename);
+      },
+    );
+  });
+
+  describe('round-trip under key-sort normalization', () => {
+    it.each([['setup_state.minimal.json'], ['setup_state.full.json']])(
+      '%s round-trips byte-equivalent',
+      (filename) => {
+        const original = loadJson(resolve(fixtureDir, filename));
+        const roundTripped = JSON.parse(JSON.stringify(original));
+        expect(canonical(roundTripped)).toBe(canonical(original));
+      },
+    );
+  });
+
+  describe('schema rejects malformed input', () => {
+    function baseValid(): Record<string, unknown> {
+      return {
+        schema_version: '0',
+        setup_version: 1,
+        deliverable_type: 'longform_post',
+        voice_page_slug: 'voice/gamemakers-2026',
+        length_target: null,
+        destination: 'plain_md',
+        audience_persona_slugs: ['persona/ankit-indie-dev'],
+        llm_room_agent_profile_ids: ['agent/argus', 'agent/scribe'],
+        scoring_pipeline_slug: 'scoring_pipeline/gamemakers_default',
+        updated_at: '2026-04-30T00:00:00.000Z',
+        updated_by_user_id: 'user_local_joseph',
+      };
+    }
+
+    it('baseline: baseValid() validates (sanity check)', () => {
+      expectValid(validateSetupState, baseValid(), 'baseValid');
+    });
+
+    it('rejects missing required field (setup_version)', () => {
+      const invalid = baseValid();
+      delete invalid.setup_version;
+      expect(validateSetupState(invalid)).toBe(false);
+    });
+
+    it('rejects unknown deliverable_type', () => {
+      const invalid = { ...baseValid(), deliverable_type: 'epic_novel' };
+      expect(validateSetupState(invalid)).toBe(false);
+    });
+
+    it('rejects schema_version other than "0"', () => {
+      const invalid = { ...baseValid(), schema_version: '1' };
+      expect(validateSetupState(invalid)).toBe(false);
+    });
+
+    it('rejects audience_persona_slugs > 3 (max cap)', () => {
+      const invalid = {
+        ...baseValid(),
+        audience_persona_slugs: ['p1', 'p2', 'p3', 'p4'],
+      };
+      expect(validateSetupState(invalid)).toBe(false);
+    });
+
+    it('rejects empty audience_persona_slugs (min cap)', () => {
+      const invalid = { ...baseValid(), audience_persona_slugs: [] };
+      expect(validateSetupState(invalid)).toBe(false);
+    });
+
+    it('rejects llm_room_agent_profile_ids < 2 (min cap)', () => {
+      const invalid = {
+        ...baseValid(),
+        llm_room_agent_profile_ids: ['agent/argus'],
+      };
+      expect(validateSetupState(invalid)).toBe(false);
+    });
+
+    it('rejects unknown additional property', () => {
+      const invalid = { ...baseValid(), surprise_field: 'nope' };
+      expect(validateSetupState(invalid)).toBe(false);
+    });
+
+    it('rejects non-integer setup_version', () => {
+      const invalid = { ...baseValid(), setup_version: 1.5 };
+      expect(validateSetupState(invalid)).toBe(false);
+    });
+
+    it('rejects malformed updated_at (not ISO date-time)', () => {
+      const invalid = { ...baseValid(), updated_at: 'yesterday' };
+      expect(validateSetupState(invalid)).toBe(false);
+    });
+
+    it('rejects length_target with min_words missing', () => {
+      const invalid = { ...baseValid(), length_target: { max_words: 2500 } };
+      expect(validateSetupState(invalid)).toBe(false);
+    });
+  });
+});

--- a/tests/fixtures/editorial-room/v0/setup_state.full.json
+++ b/tests/fixtures/editorial-room/v0/setup_state.full.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "0",
+  "setup_version": 7,
+  "deliverable_type": "longform_post",
+  "voice_page_slug": "voice/gamemakers-2026",
+  "length_target": {
+    "min_words": 2000,
+    "max_words": 2500
+  },
+  "destination": "substack_md",
+  "audience_persona_slugs": [
+    "persona/ankit-indie-dev",
+    "persona/ravi-studio-lead",
+    "persona/mei-publisher"
+  ],
+  "llm_room_agent_profile_ids": [
+    "agent/argus",
+    "agent/scribe",
+    "agent/mei-cohort"
+  ],
+  "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default",
+  "updated_at": "2026-04-30T11:42:18.123Z",
+  "updated_by_user_id": "user_local_joseph"
+}

--- a/tests/fixtures/editorial-room/v0/setup_state.minimal.json
+++ b/tests/fixtures/editorial-room/v0/setup_state.minimal.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "0",
+  "setup_version": 1,
+  "deliverable_type": "longform_post",
+  "voice_page_slug": "voice/gamemakers-2026",
+  "length_target": null,
+  "destination": "plain_md",
+  "audience_persona_slugs": ["persona/ankit-indie-dev"],
+  "llm_room_agent_profile_ids": ["agent/argus", "agent/scribe"],
+  "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default",
+  "updated_at": "2026-04-30T00:00:00.000Z",
+  "updated_by_user_id": "user_local_joseph"
+}


### PR DESCRIPTION
## Summary
- Adds the executable contract scaffold that 0p-1 requires before any Editorial Room implementation work can start.
- First JSON Schema (SetupState per `EDITORIAL_ROOM_CONTRACT.md` §2.1), two fixtures (minimal + full), and a vitest harness with ajv validation, round-trip-under-key-sort, and 11 negative tests.
- `ajv` + `ajv-formats` added to devDependencies.
- Pipeline proven end-to-end: 15/15 tests pass, typecheck clean.
- Remaining 30 schemas / ~32 fixtures will land in thematic batches (page types → per-Piece artifacts → editor primitives → RPC envelope → optimization loop).

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test -- src/clawrocket/contracts/editorial-room.test.ts` → 15/15 pass
- [x] `npm run format:check` clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)