### PR TITLE
feat: editorial-room v0 Batch 1 — page types + provenance

### DIFF
--- a/docs/contracts/editorial-room/v0/claims_ledger.schema.json
+++ b/docs/contracts/editorial-room/v0/claims_ledger.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/claims_ledger.schema.json",
+  "title": "ClaimsLedgerCompiledTruth",
+  "description": "Per-Piece claims ledger: sourced facts, model inferences, counterarguments, open questions, unsupported claims, and quotes. See EDITORIAL_ROOM_CONTRACT.md §3.8.",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "EvidenceLogEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ts", "actor", "action", "note"],
+      "properties": {
+        "ts": { "type": "string", "format": "date-time" },
+        "actor": { "type": "string", "enum": ["user", "agent"] },
+        "action": {
+          "type": "string",
+          "enum": ["added", "approved", "rejected", "verified", "edited"]
+        },
+        "note": {
+          "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }]
+        }
+      }
+    },
+    "ClaimEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "statement",
+        "source_url",
+        "source_doc_ref",
+        "quote",
+        "timestamp",
+        "confidence",
+        "approval_status",
+        "evidence_log",
+        "last_verified_at"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "ULID."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "sourced_fact",
+            "model_inference",
+            "counterargument",
+            "open_question",
+            "unsupported_claim",
+            "quote"
+          ]
+        },
+        "statement": { "type": "string", "minLength": 1 },
+        "source_url": {
+          "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }]
+        },
+        "source_doc_ref": {
+          "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }]
+        },
+        "quote": {
+          "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }]
+        },
+        "timestamp": {
+          "anyOf": [{ "type": "null" }, { "type": "string", "format": "date-time" }],
+          "description": "When the source was published if applicable."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": ["low", "medium", "high"]
+        },
+        "approval_status": {
+          "type": "string",
+          "enum": ["pending", "approved", "rejected"]
+        },
+        "evidence_log": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/EvidenceLogEntry" }
+        },
+        "last_verified_at": {
+          "anyOf": [{ "type": "null" }, { "type": "string", "format": "date-time" }]
+        }
+      }
+    }
+  },
+  "required": ["schema_version", "piece_id", "claims"],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "piece_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Owning Piece (clawrocket FK)."
+    },
+    "claims": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/ClaimEntry" }
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/iteration_config.schema.json
+++ b/docs/contracts/editorial-room/v0/iteration_config.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/iteration_config.schema.json",
+  "title": "IterationConfigCompiledTruth",
+  "description": "Iteration loop configuration page (max attempts, plateau handling, cost cap). See EDITORIAL_ROOM_CONTRACT.md §3.7.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "slug",
+    "max_attempts",
+    "acceptance_criterion",
+    "plateau_check",
+    "on_plateau",
+    "on_max_attempts",
+    "cost_cap_usd"
+  ],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "slug": {
+      "type": "string",
+      "minLength": 1,
+      "description": "e.g., 'newsletter_balanced'."
+    },
+    "max_attempts": { "type": "integer", "minimum": 1 },
+    "acceptance_criterion": {
+      "type": "string",
+      "minLength": 1,
+      "description": "e.g., 'aggregate_score >= 4.0'."
+    },
+    "plateau_check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["after_min_cycles", "delta_threshold"],
+      "properties": {
+        "after_min_cycles": { "type": "integer", "minimum": 1 },
+        "delta_threshold": { "type": "number" }
+      }
+    },
+    "on_plateau": {
+      "type": "string",
+      "enum": ["keep_best_so_far", "discard"]
+    },
+    "on_max_attempts": {
+      "type": "string",
+      "enum": ["keep_best_so_far", "discard"]
+    },
+    "cost_cap_usd": {
+      "anyOf": [{ "type": "null" }, { "type": "number", "minimum": 0 }]
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/panel_provenance.schema.json
+++ b/docs/contracts/editorial-room/v0/panel_provenance.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/panel_provenance.schema.json",
+  "title": "PanelProvenance",
+  "description": "Provenance for theme/topic/point pages derived from Panel Talk seeds. See EDITORIAL_ROOM_CONTRACT.md §3.9.2. NOTE: §10 of the contract does not list this schema explicitly but §3.9.2 defines the shape and the page schemas reference it; we ship it as a sibling of pcp_provenance to mirror the pattern.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "derived_at",
+    "source_skill",
+    "source_run_id",
+    "source_panel_id",
+    "source_turn_ids",
+    "source_talking_point_ids",
+    "source_dialectic_result_ids",
+    "seed_summary",
+    "user_promoted_at",
+    "user_promoted_by_user_id"
+  ],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "derived_at": { "type": "string", "format": "date-time" },
+    "source_skill": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Typically 'factory_panel_dialectic' or factory_*_optimize when invoked with panel_seed."
+    },
+    "source_run_id": { "type": "string", "minLength": 1 },
+    "source_panel_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The Panel Talk panel that produced the seeds."
+    },
+    "source_turn_ids": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "maxItems": 20
+    },
+    "source_talking_point_ids": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "maxItems": 10
+    },
+    "source_dialectic_result_ids": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "maxItems": 5
+    },
+    "seed_summary": {
+      "type": "string",
+      "maxLength": 500,
+      "description": "Summary of what was promoted (synthesis text, talking-point claim, or dialectic new_question). Raw turn content lives in clawrocket panel storage."
+    },
+    "user_promoted_at": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "format": "date-time" }]
+    },
+    "user_promoted_by_user_id": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }]
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/pcp_provenance.schema.json
+++ b/docs/contracts/editorial-room/v0/pcp_provenance.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/pcp_provenance.schema.json",
+  "title": "PcpProvenance",
+  "description": "Provenance for theme/topic/point pages derived from PCP (personal-context primitive) seeds. See EDITORIAL_ROOM_CONTRACT.md §3.9.1.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "derived_at",
+    "source_skill",
+    "source_run_id",
+    "source_optimization_round_id",
+    "pcp_window",
+    "pcp_types_used",
+    "seed_events",
+    "user_promoted_at",
+    "user_promoted_by_user_id"
+  ],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "derived_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO timestamp the PCP context was sampled."
+    },
+    "source_skill": {
+      "type": "string",
+      "minLength": 1,
+      "description": "e.g., 'factory_theme_propose_optimize'."
+    },
+    "source_run_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "ULID of the run."
+    },
+    "source_optimization_round_id": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+      "description": "ULID of the round when the run was wrapped in run_optimization."
+    },
+    "pcp_window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "to"],
+      "properties": {
+        "from": { "type": "string", "format": "date-time" },
+        "to": { "type": "string", "format": "date-time" }
+      },
+      "description": "ISO interval the PCP context covered. Runtime invariant: from <= to."
+    },
+    "pcp_types_used": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "description": "Subset of the PCP types consumed (e.g., ['calendar', 'linear', 'work_this_week'])."
+    },
+    "seed_events": {
+      "type": "array",
+      "maxItems": 10,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["pcp_type", "event_id", "timestamp", "summary", "contributed_to"],
+        "properties": {
+          "pcp_type": { "type": "string", "minLength": 1 },
+          "event_id": { "type": "string", "minLength": 1 },
+          "timestamp": { "type": "string", "format": "date-time" },
+          "summary": {
+            "type": "string",
+            "maxLength": 200,
+            "description": "Human-readable summary surfaced in the ProposalCard. Raw PCP body content is NOT carried here."
+          },
+          "contributed_to": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "description": "Which artifact-attributes this seed influenced (e.g., ['theme.description'])."
+          }
+        }
+      }
+    },
+    "user_promoted_at": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "format": "date-time" }],
+      "description": "Set when user promotes from scope:personal to scope:organization|global."
+    },
+    "user_promoted_by_user_id": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }]
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/persona.schema.json
+++ b/docs/contracts/editorial-room/v0/persona.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/persona.schema.json",
+  "title": "PersonaCompiledTruth",
+  "description": "Constructed audience target. See EDITORIAL_ROOM_CONTRACT.md §3.5 and SCHEMA_DEFINITION.md for canonical detailed_profile spec.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "name",
+    "detailed_profile",
+    "cared_about_criteria",
+    "triggers_to_close",
+    "triggers_to_share",
+    "trust_signals",
+    "voice_calibration",
+    "archetype",
+    "game_type_preference"
+  ],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "e.g., 'Ankit — solo indie dev'."
+    },
+    "detailed_profile": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096,
+      "description": "150–300 words, second-person, behavioral. THIS is the binding SSR contract — only persona field SSR generation injects into the LLM prompt. §7 cap: 4 KB."
+    },
+    "cared_about_criteria": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "triggers_to_close": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "triggers_to_share": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "trust_signals": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "voice_calibration": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+      "description": "How this persona reacts to prose style."
+    },
+    "archetype": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+      "description": "Optional structured metadata (e.g., 'indie-dev-anxious')."
+    },
+    "game_type_preference": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }]
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/point.schema.json
+++ b/docs/contracts/editorial-room/v0/point.schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/point.schema.json",
+  "title": "PointCompiledTruth",
+  "description": "Layer-3 page: specific claim/argument within a topic. See EDITORIAL_ROOM_CONTRACT.md §3.3.",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "PointEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "url",
+        "ref_slug",
+        "quote_text",
+        "quote_source",
+        "notes"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["source_url", "back_catalog_ref", "claim_ledger_ref", "quote"]
+        },
+        "url": {
+          "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+          "description": "External citation URL when kind = source_url."
+        },
+        "ref_slug": {
+          "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+          "description": "For back_catalog_ref / claim_ledger_ref."
+        },
+        "quote_text": {
+          "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+          "description": "Inline quote text when kind = quote."
+        },
+        "quote_source": {
+          "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+          "description": "Attribution for the quote."
+        },
+        "notes": {
+          "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }]
+        }
+      }
+    }
+  },
+  "required": [
+    "schema_version",
+    "parent_topic_slug",
+    "claim",
+    "rationale",
+    "evidence",
+    "status",
+    "conviction",
+    "derived_from_pcp",
+    "pcp_provenance",
+    "derived_from_panel",
+    "panel_provenance",
+    "optimization_round_id",
+    "last_activity_at"
+  ],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "parent_topic_slug": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Single parent initially; multi-parent deferred."
+    },
+    "claim": {
+      "type": "string",
+      "minLength": 1,
+      "description": "One-line ('PMs become builders')."
+    },
+    "rationale": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+      "description": "Free text; why this claim is true/interesting."
+    },
+    "evidence": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/PointEvidence" }
+    },
+    "status": {
+      "type": "string",
+      "enum": ["active", "parked", "merged", "rejected"]
+    },
+    "conviction": {
+      "type": "string",
+      "enum": ["low", "medium", "high"],
+      "description": "User's own confidence."
+    },
+    "derived_from_pcp": { "type": "boolean" },
+    "pcp_provenance": {
+      "anyOf": [
+        { "type": "null" },
+        { "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/pcp_provenance.schema.json" }
+      ]
+    },
+    "derived_from_panel": { "type": "boolean" },
+    "panel_provenance": {
+      "anyOf": [
+        { "type": "null" },
+        { "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/panel_provenance.schema.json" }
+      ]
+    },
+    "optimization_round_id": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }]
+    },
+    "last_activity_at": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "format": "date-time" }]
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/scoring_pipeline.schema.json
+++ b/docs/contracts/editorial-room/v0/scoring_pipeline.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/scoring_pipeline.schema.json",
+  "title": "ScoringPipelineCompiledTruth",
+  "description": "Scoring pipeline page; references scorer ids and weights. See EDITORIAL_ROOM_CONTRACT.md §3.6.",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "ScorerInPipeline": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scorer_id", "role", "weight", "threshold", "params"],
+      "properties": {
+        "scorer_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "e.g., 'autonovel_mechanical' | 'autonovel_judge' | 'ssr_core_local' | …"
+        },
+        "role": {
+          "type": "string",
+          "enum": ["gate", "score", "diagnostic"]
+        },
+        "weight": {
+          "anyOf": [{ "type": "null" }, { "type": "number" }],
+          "description": "For weighted_mean aggregation. Null when role != 'score'."
+        },
+        "threshold": {
+          "anyOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["score", "direction"],
+              "properties": {
+                "score": { "type": "string", "minLength": 1 },
+                "direction": { "type": "string", "enum": ["score", "penalty"] }
+              }
+            }
+          ],
+          "description": "For gates."
+        },
+        "params": {
+          "type": "object",
+          "description": "Scorer-specific; see scorer_config schema (deferred)."
+        }
+      }
+    }
+  },
+  "required": [
+    "schema_version",
+    "slug",
+    "name",
+    "description",
+    "scorers",
+    "aggregation_rule",
+    "on_gate_fail"
+  ],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "slug": {
+      "type": "string",
+      "minLength": 1,
+      "description": "e.g., 'scoring_pipeline/gamemakers_default'."
+    },
+    "name": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "scorers": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/ScorerInPipeline" }
+    },
+    "aggregation_rule": {
+      "type": "string",
+      "enum": ["weighted_mean", "min", "max", "first", "custom"]
+    },
+    "on_gate_fail": {
+      "type": "string",
+      "enum": ["short_circuit_with_diagnostic", "continue_with_warning"]
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/theme.schema.json
+++ b/docs/contracts/editorial-room/v0/theme.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/theme.schema.json",
+  "title": "ThemeCompiledTruth",
+  "description": "Layer-1 page: durable subject area within the publication. See EDITORIAL_ROOM_CONTRACT.md §3.1.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "name",
+    "description",
+    "status",
+    "pinned",
+    "derived_from_pcp",
+    "pcp_provenance",
+    "derived_from_panel",
+    "panel_provenance",
+    "topic_count",
+    "last_activity_at"
+  ],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "name": { "type": "string", "minLength": 1 },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "1–3 sentence prose."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["active", "parked", "archived"]
+    },
+    "pinned": {
+      "type": "boolean",
+      "description": "For Theme Library sorting."
+    },
+    "derived_from_pcp": { "type": "boolean" },
+    "pcp_provenance": {
+      "anyOf": [
+        { "type": "null" },
+        { "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/pcp_provenance.schema.json" }
+      ]
+    },
+    "derived_from_panel": { "type": "boolean" },
+    "panel_provenance": {
+      "anyOf": [
+        { "type": "null" },
+        { "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/panel_provenance.schema.json" }
+      ]
+    },
+    "topic_count": {
+      "anyOf": [{ "type": "null" }, { "type": "integer", "minimum": 0 }],
+      "description": "Computed; null if not yet computed."
+    },
+    "last_activity_at": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "format": "date-time" }],
+      "description": "Computed; ISO timestamp of most recent topic update."
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/topic.schema.json
+++ b/docs/contracts/editorial-room/v0/topic.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/topic.schema.json",
+  "title": "TopicCompiledTruth",
+  "description": "Layer-2 page: specific angle within a theme. See EDITORIAL_ROOM_CONTRACT.md §3.2.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "parent_theme_slug",
+    "working_title",
+    "thesis",
+    "why_now",
+    "status",
+    "novelty_score",
+    "novelty_score_basis",
+    "derived_from_pcp",
+    "pcp_provenance",
+    "derived_from_panel",
+    "panel_provenance",
+    "optimization_round_id",
+    "point_count",
+    "last_activity_at"
+  ],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "parent_theme_slug": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Defaults to 'theme/misc' if user doesn't pick."
+    },
+    "working_title": { "type": "string", "minLength": 1 },
+    "thesis": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "description": "One-line thesis (≤200 chars)."
+    },
+    "why_now": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+      "description": "Optional: what makes this timely."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["active", "parked", "used", "rejected"]
+    },
+    "novelty_score": {
+      "anyOf": [
+        { "type": "null" },
+        { "type": "number", "minimum": 0, "maximum": 1 }
+      ],
+      "description": "0–1, computed against back_catalog."
+    },
+    "novelty_score_basis": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }]
+    },
+    "derived_from_pcp": { "type": "boolean" },
+    "pcp_provenance": {
+      "anyOf": [
+        { "type": "null" },
+        { "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/pcp_provenance.schema.json" }
+      ]
+    },
+    "derived_from_panel": { "type": "boolean" },
+    "panel_provenance": {
+      "anyOf": [
+        { "type": "null" },
+        { "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/panel_provenance.schema.json" }
+      ]
+    },
+    "optimization_round_id": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+      "description": "ULID of the optimization round that produced this topic, if any."
+    },
+    "point_count": {
+      "anyOf": [{ "type": "null" }, { "type": "integer", "minimum": 0 }]
+    },
+    "last_activity_at": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "format": "date-time" }]
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/voice.schema.json
+++ b/docs/contracts/editorial-room/v0/voice.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/voice.schema.json",
+  "title": "VoicePageCompiledTruth",
+  "description": "Voice page compiled_truth (loose). See EDITORIAL_ROOM_CONTRACT.md §3.4. The contract requires only that the page exists at the slug referenced in SetupState.voice_page_slug; what matters is the prose content (loaded as system context for every Skill call). Schema is intentionally permissive — we lock down the slug + body fields and allow forward-compatible additions.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["schema_version", "slug", "name", "body_md"],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "slug": {
+      "type": "string",
+      "minLength": 1,
+      "description": "e.g., 'voice/gamemakers-2026'."
+    },
+    "name": { "type": "string", "minLength": 1 },
+    "body_md": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 16384,
+      "description": "Prose voice spec in Markdown. §7 cap: 16 KB."
+    }
+  }
+}

--- a/src/clawrocket/contracts/editorial-room.test.ts
+++ b/src/clawrocket/contracts/editorial-room.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Ajv } from 'ajv';
@@ -28,10 +28,43 @@ function loadJson(path: string): unknown {
   return JSON.parse(readFileSync(path, 'utf-8'));
 }
 
-function compile(schemaFile: string): ValidateFunction {
-  return ajv.compile(
-    loadJson(resolve(schemaDir, schemaFile)) as AnySchemaObject,
-  );
+// Auto-load all schemas in v0/ so $refs across files resolve at compile time.
+const schemaFilenames = readdirSync(schemaDir).filter((f) =>
+  f.endsWith('.schema.json'),
+);
+for (const file of schemaFilenames) {
+  ajv.addSchema(loadJson(resolve(schemaDir, file)) as AnySchemaObject);
+}
+
+function validatorFor(schemaFile: string): ValidateFunction {
+  const schema = loadJson(resolve(schemaDir, schemaFile)) as AnySchemaObject;
+  const id = schema.$id;
+  if (typeof id !== 'string') {
+    throw new Error(`${schemaFile} is missing $id`);
+  }
+  const validate = ajv.getSchema(id);
+  if (!validate) {
+    throw new Error(`No validator registered for ${schemaFile} (id ${id})`);
+  }
+  return validate;
+}
+
+// Convention: a fixture named `<base>.<variant>.json` validates against
+// `<base>.schema.json`. e.g., `theme.derived_from_pcp.json` →
+// `theme.schema.json`; `setup_state.minimal.json` → `setup_state.schema.json`.
+// A few fixtures in EDITORIAL_ROOM_CONTRACT.md §9.1 use a different shape
+// (e.g., `point_with_evidence.example.json` for the `point` schema); those
+// are listed in `FIXTURE_SCHEMA_OVERRIDES`.
+const FIXTURE_SCHEMA_OVERRIDES: Record<string, string> = {
+  'point_with_evidence.example.json': 'point.schema.json',
+};
+
+function schemaFileForFixture(fixtureFile: string): string {
+  if (fixtureFile in FIXTURE_SCHEMA_OVERRIDES) {
+    return FIXTURE_SCHEMA_OVERRIDES[fixtureFile];
+  }
+  const base = fixtureFile.split('.')[0];
+  return `${base}.schema.json`;
 }
 
 function sortKeys(value: unknown): unknown {
@@ -64,31 +97,31 @@ function expectValid(
   expect(ok).toBe(true);
 }
 
-describe('editorial-room v0 — SetupState contract', () => {
-  const validateSetupState = compile('setup_state.schema.json');
+const ALL_FIXTURES = readdirSync(fixtureDir).filter((f) => f.endsWith('.json'));
 
-  describe('schema validation', () => {
-    it.each([['setup_state.minimal.json'], ['setup_state.full.json']])(
-      '%s validates against the schema',
-      (filename) => {
-        const fixture = loadJson(resolve(fixtureDir, filename));
-        expectValid(validateSetupState, fixture, filename);
+describe('editorial-room v0 contracts', () => {
+  describe('all fixtures validate against their schemas', () => {
+    it.each(ALL_FIXTURES.map((f) => [f, schemaFileForFixture(f)]))(
+      '%s validates against %s',
+      (fixtureFile, schemaFile) => {
+        const validate = validatorFor(schemaFile);
+        const fixture = loadJson(resolve(fixtureDir, fixtureFile));
+        expectValid(validate, fixture, fixtureFile);
       },
     );
   });
 
-  describe('round-trip under key-sort normalization', () => {
-    it.each([['setup_state.minimal.json'], ['setup_state.full.json']])(
-      '%s round-trips byte-equivalent',
-      (filename) => {
-        const original = loadJson(resolve(fixtureDir, filename));
-        const roundTripped = JSON.parse(JSON.stringify(original));
-        expect(canonical(roundTripped)).toBe(canonical(original));
-      },
-    );
+  describe('all fixtures round-trip byte-equivalent under key-sort', () => {
+    it.each(ALL_FIXTURES.map((f) => [f]))('%s', (fixtureFile) => {
+      const original = loadJson(resolve(fixtureDir, fixtureFile));
+      const roundTripped = JSON.parse(JSON.stringify(original));
+      expect(canonical(roundTripped)).toBe(canonical(original));
+    });
   });
 
-  describe('schema rejects malformed input', () => {
+  describe('SetupState — schema rejects malformed input', () => {
+    const validateSetupState = validatorFor('setup_state.schema.json');
+
     function baseValid(): Record<string, unknown> {
       return {
         schema_version: '0',
@@ -164,6 +197,24 @@ describe('editorial-room v0 — SetupState contract', () => {
     it('rejects length_target with min_words missing', () => {
       const invalid = { ...baseValid(), length_target: { max_words: 2500 } };
       expect(validateSetupState(invalid)).toBe(false);
+    });
+  });
+
+  describe('Theme — cross-schema $ref resolution', () => {
+    const validateTheme = validatorFor('theme.schema.json');
+
+    it('rejects malformed pcp_provenance via $ref (missing required field)', () => {
+      const fixture = loadJson(
+        resolve(fixtureDir, 'theme.derived_from_pcp.json'),
+      ) as Record<string, unknown>;
+      const provenance = fixture.pcp_provenance as Record<string, unknown>;
+      delete provenance.derived_at;
+      expect(validateTheme(fixture)).toBe(false);
+    });
+
+    it('accepts theme with both pcp_provenance and panel_provenance null', () => {
+      const fixture = loadJson(resolve(fixtureDir, 'theme.example.json'));
+      expectValid(validateTheme, fixture, 'theme.example.json');
     });
   });
 });

--- a/tests/fixtures/editorial-room/v0/claims_ledger.example.json
+++ b/tests/fixtures/editorial-room/v0/claims_ledger.example.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "0",
+  "piece_id": "piece_01HXYZ789ABC",
+  "claims": [
+    {
+      "id": "01HXYZABC100AAAAAAAAAAAAAA",
+      "kind": "sourced_fact",
+      "statement": "Embracer Q3 2025 8-K reclassified guaranteed minimum advances as conditional liabilities (pp. 14-16).",
+      "source_url": "https://www.sec.gov/Archives/edgar/data/example/embracer-q3-8k.htm",
+      "source_doc_ref": null,
+      "quote": null,
+      "timestamp": "2025-11-12T00:00:00.000Z",
+      "confidence": "high",
+      "approval_status": "approved",
+      "evidence_log": [
+        {
+          "ts": "2026-04-22T15:30:00.000Z",
+          "actor": "agent",
+          "action": "added",
+          "note": "Pulled by factory_claim_research from Embracer 8-K."
+        },
+        {
+          "ts": "2026-04-22T15:33:00.000Z",
+          "actor": "user",
+          "action": "verified",
+          "note": "Confirmed pages 14-16; reclass language matches."
+        },
+        {
+          "ts": "2026-04-22T15:34:00.000Z",
+          "actor": "user",
+          "action": "approved",
+          "note": null
+        }
+      ],
+      "last_verified_at": "2026-04-22T15:33:00.000Z"
+    },
+    {
+      "id": "01HXYZABC200BBBBBBBBBBBBBB",
+      "kind": "model_inference",
+      "statement": "Mid-tier studios will absorb the deal-shape change first; sub-10-person studios get a relative tailwind because publishers will favor cleaner cap tables.",
+      "source_url": null,
+      "source_doc_ref": null,
+      "quote": null,
+      "timestamp": null,
+      "confidence": "medium",
+      "approval_status": "pending",
+      "evidence_log": [
+        {
+          "ts": "2026-04-22T15:35:00.000Z",
+          "actor": "agent",
+          "action": "added",
+          "note": "Generated during topic optimization round 01HXYZABC456PQR789STUVWXYZ."
+        }
+      ],
+      "last_verified_at": null
+    },
+    {
+      "id": "01HXYZABC300CCCCCCCCCCCCCC",
+      "kind": "counterargument",
+      "statement": "Annapurna staffer (background) says they're still signing pre-Embracer-shape deals at unchanged MG ratios — the reclassification may not be universal.",
+      "source_url": null,
+      "source_doc_ref": null,
+      "quote": "Their Q3 filing rewrote the entire MG line. Nobody on our side missed it. But our deals haven't changed.",
+      "timestamp": "2026-04-22T00:00:00.000Z",
+      "confidence": "low",
+      "approval_status": "pending",
+      "evidence_log": [
+        {
+          "ts": "2026-04-22T11:41:00.000Z",
+          "actor": "user",
+          "action": "added",
+          "note": "Background source via Slack DM; flagged for verification before draft."
+        }
+      ],
+      "last_verified_at": null
+    }
+  ]
+}

--- a/tests/fixtures/editorial-room/v0/pcp_provenance.example.json
+++ b/tests/fixtures/editorial-room/v0/pcp_provenance.example.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "0",
+  "derived_at": "2026-04-22T15:30:00.000Z",
+  "source_skill": "factory_theme_propose_optimize",
+  "source_run_id": "01HXYZABC123DEF456GHIJKLMN",
+  "source_optimization_round_id": "01HXYZABC456PQR789STUVWXYZ",
+  "pcp_window": {
+    "from": "2026-04-15T00:00:00.000Z",
+    "to": "2026-04-22T15:30:00.000Z"
+  },
+  "pcp_types_used": ["calendar", "linear", "work_this_week"],
+  "seed_events": [
+    {
+      "pcp_type": "calendar",
+      "event_id": "cal_evt_2026_04_22_hooded_horse",
+      "timestamp": "2026-04-22T14:00:00.000Z",
+      "summary": "2026-04-22: meeting with Hooded Horse re: indie deal terms",
+      "contributed_to": ["theme.description", "theme.name"]
+    },
+    {
+      "pcp_type": "linear",
+      "event_id": "lin_iss_DEAL-142",
+      "timestamp": "2026-04-19T09:15:00.000Z",
+      "summary": "2026-04-19: Linear DEAL-142 'Track post-Embracer MG patterns' moved to In Progress",
+      "contributed_to": ["theme.description"]
+    },
+    {
+      "pcp_type": "work_this_week",
+      "event_id": "wtw_2026_w16_focus_publisher_economics",
+      "timestamp": "2026-04-20T08:00:00.000Z",
+      "summary": "2026-W16: focus area set to 'publisher economics' for the week",
+      "contributed_to": ["theme.name"]
+    }
+  ],
+  "user_promoted_at": null,
+  "user_promoted_by_user_id": null
+}

--- a/tests/fixtures/editorial-room/v0/persona.ankit.json
+++ b/tests/fixtures/editorial-room/v0/persona.ankit.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "0",
+  "name": "Ankit Sharma — solo indie dev",
+  "detailed_profile": "You are a solo developer in Bangalore building a niche strategy game targeted at PC. You have 3 years of full-time indie experience and one prior commercial release. You make ~$3K/month from your back catalog and a part-time consulting gig. You read industry coverage when it directly affects your survival economics — deal terms, store algorithms, taxes, AI tooling for dev productivity. You're skeptical of hype and allergic to LinkedIn-flavored optimism. You make decisions by checking who you trust said it, what the trail of evidence looks like, and whether the writer has skin in the game. You will skim a piece in 90 seconds and either click 'next post' or save to read carefully — there is no middle.",
+  "cared_about_criteria": [
+    "Will this affect my next deal? My current MG?",
+    "Is the writer credible — have they shipped something?",
+    "Are claims sourced or is this vibes?",
+    "Does this surface a tactical move I can run this month?"
+  ],
+  "triggers_to_close": [
+    "First paragraph reads like a press release",
+    "Stat without source",
+    "Author tells me what to feel",
+    "More than one buzzword in the headline"
+  ],
+  "triggers_to_share": [
+    "Concrete deal terms I haven't seen",
+    "A counter-take that holds up under pressure",
+    "A clean 30-second summary I can paste in Discord"
+  ],
+  "trust_signals": [
+    "Specific filings/URLs",
+    "Author has been wrong publicly before and corrected",
+    "Quotes from real people (with caveats about anonymity)",
+    "Counter-evidence treated seriously"
+  ],
+  "voice_calibration": "Direct prose lands. Hedges read as cowardice. Numbers > adjectives. Stories work only when grounded in someone the reader could verify.",
+  "archetype": "indie-dev-anxious-survivor",
+  "game_type_preference": "strategy-pc-niche"
+}

--- a/tests/fixtures/editorial-room/v0/persona.sarah.json
+++ b/tests/fixtures/editorial-room/v0/persona.sarah.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "0",
+  "name": "Sarah Chen — solo journalist",
+  "detailed_profile": "You are an independent games-industry journalist covering deal terms, publisher economics, and developer-side conditions. You spent 4 years at PC Gamer before going independent in 2024 and currently run a paid Substack at ~3K subs. You read everything in your beat — your job is knowing which Topics are real before they're popular. You decide what to engage with based on whether it's news to you, whether the writer cited sources you can verify, and whether the framing matches what your own sources are telling you. You have low tolerance for puff and high tolerance for nuance. You quote pieces in your own writing only when the writer surfaced something you missed.",
+  "cared_about_criteria": [
+    "Did the writer actually find this, or recycle it from Twitter?",
+    "Are sources documented or hand-waved?",
+    "Does the framing hold up against my private sources?",
+    "Is there a quote I'd call to verify?"
+  ],
+  "triggers_to_close": [
+    "Recycled Twitter take dressed up as analysis",
+    "Anonymous sources without 'why anonymous'",
+    "Framing that contradicts something I just heard from a CEO last week"
+  ],
+  "triggers_to_share": [
+    "Cited a primary source I missed",
+    "Surfaced a counter-take I want my readers to see",
+    "Made a clean argument I can push back on without seeming petty"
+  ],
+  "trust_signals": [
+    "Filings, K-1s, S-1s, 8-Ks linked",
+    "Quote attribution is specific even when anonymous",
+    "Writer has been on a beat long enough to be wrong and recover"
+  ],
+  "voice_calibration": "Reporter prose. Drops adjectives, names mechanisms, names people, hedges only when source-level uncertainty deserves a hedge.",
+  "archetype": "journalist-beat-reporter",
+  "game_type_preference": null
+}

--- a/tests/fixtures/editorial-room/v0/point.example.json
+++ b/tests/fixtures/editorial-room/v0/point.example.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "0",
+  "parent_topic_slug": "topic/ai-impact-on-game-dev-how-embracers-writedown-changed-indie-publishing-terms",
+  "claim": "Deal-term lockdown: 2022-rate MGs are now the ceiling, not the floor.",
+  "rationale": "The accounting reclassification means publishers can't recapture upside without restructuring; that locks the new shape for 18+ months.",
+  "evidence": [],
+  "status": "active",
+  "conviction": "high",
+  "derived_from_pcp": false,
+  "pcp_provenance": null,
+  "derived_from_panel": false,
+  "panel_provenance": null,
+  "optimization_round_id": null,
+  "last_activity_at": "2026-04-30T11:32:00.000Z"
+}

--- a/tests/fixtures/editorial-room/v0/point_with_evidence.example.json
+++ b/tests/fixtures/editorial-room/v0/point_with_evidence.example.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "0",
+  "parent_topic_slug": "topic/ai-impact-on-game-dev-how-embracers-writedown-changed-indie-publishing-terms",
+  "claim": "MG-as-conditional-liability is the load-bearing accounting change.",
+  "rationale": "Without the reclassification, the deal-shape lockdown wouldn't hold beyond one quarter.",
+  "evidence": [
+    {
+      "kind": "source_url",
+      "url": "https://www.sec.gov/Archives/edgar/data/example/embracer-q3-8k.htm",
+      "ref_slug": null,
+      "quote_text": null,
+      "quote_source": null,
+      "notes": "Embracer Q3 8-K, pp. 14-16: explicit MG reclassification language."
+    },
+    {
+      "kind": "back_catalog_ref",
+      "url": null,
+      "ref_slug": "back_catalog/2025-08-publisher-power-shift",
+      "quote_text": null,
+      "quote_source": null,
+      "notes": "Predicts the structural shift; this Point names the accounting mechanism."
+    },
+    {
+      "kind": "claim_ledger_ref",
+      "url": null,
+      "ref_slug": "claims_ledger/embracer-mg-reclassified-q3-2025",
+      "quote_text": null,
+      "quote_source": null,
+      "notes": null
+    },
+    {
+      "kind": "quote",
+      "url": null,
+      "ref_slug": null,
+      "quote_text": "Their Q3 filing rewrote the entire MG line. Nobody on our side missed it.",
+      "quote_source": "Annapurna staffer, background, 2026-04-22",
+      "notes": "Anecdotal corroboration; flagged for verification before draft."
+    }
+  ],
+  "status": "active",
+  "conviction": "medium",
+  "derived_from_pcp": false,
+  "pcp_provenance": null,
+  "derived_from_panel": false,
+  "panel_provenance": null,
+  "optimization_round_id": null,
+  "last_activity_at": "2026-04-30T11:38:00.000Z"
+}

--- a/tests/fixtures/editorial-room/v0/scoring_pipeline.gamemakers_default.json
+++ b/tests/fixtures/editorial-room/v0/scoring_pipeline.gamemakers_default.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "0",
+  "slug": "scoring_pipeline/gamemakers_default",
+  "name": "GameMakers Default",
+  "description": "Composite pipeline: rubric judge (Opus, 6 axes) + SSR (3 personas, likelihood family) + voice drift, with counter-audience disabled until Polish.",
+  "scorers": [
+    {
+      "scorer_id": "rubric_judge_opus",
+      "role": "score",
+      "weight": 0.4,
+      "threshold": null,
+      "params": {
+        "model_id": "claude-opus-4-7",
+        "axes": ["stance", "claim", "source", "voice", "risk", "fit"]
+      }
+    },
+    {
+      "scorer_id": "ssr_core_local",
+      "role": "score",
+      "weight": 0.4,
+      "threshold": null,
+      "params": {
+        "personas": [
+          "persona/ankit-indie-dev",
+          "persona/ravi-studio-lead",
+          "persona/mei-publisher"
+        ],
+        "samples_per_persona": 8,
+        "family": "likelihood"
+      }
+    },
+    {
+      "scorer_id": "voice_drift",
+      "role": "score",
+      "weight": 0.2,
+      "threshold": null,
+      "params": {
+        "voice_slug": "voice/gamemakers-2026"
+      }
+    },
+    {
+      "scorer_id": "counter_audience",
+      "role": "diagnostic",
+      "weight": 0.0,
+      "threshold": null,
+      "params": {
+        "enabled_phases": ["polish"]
+      }
+    },
+    {
+      "scorer_id": "specificity_gate",
+      "role": "gate",
+      "weight": null,
+      "threshold": {
+        "score": "3",
+        "direction": "score"
+      },
+      "params": {}
+    }
+  ],
+  "aggregation_rule": "weighted_mean",
+  "on_gate_fail": "short_circuit_with_diagnostic"
+}

--- a/tests/fixtures/editorial-room/v0/theme.derived_from_pcp.json
+++ b/tests/fixtures/editorial-room/v0/theme.derived_from_pcp.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "0",
+  "name": "Indie Publishing Deal Shape",
+  "description": "Post-Embracer deal terms, conditional MGs, and the 18-month lock-in shaping the next round of indie signings.",
+  "status": "active",
+  "pinned": false,
+  "derived_from_pcp": true,
+  "pcp_provenance": {
+    "schema_version": "0",
+    "derived_at": "2026-04-22T15:30:00.000Z",
+    "source_skill": "factory_theme_propose_optimize",
+    "source_run_id": "01HXYZABC123DEF456GHIJKLMN",
+    "source_optimization_round_id": "01HXYZABC456PQR789STUVWXYZ",
+    "pcp_window": {
+      "from": "2026-04-15T00:00:00.000Z",
+      "to": "2026-04-22T15:30:00.000Z"
+    },
+    "pcp_types_used": ["calendar", "linear", "work_this_week"],
+    "seed_events": [
+      {
+        "pcp_type": "calendar",
+        "event_id": "cal_evt_2026_04_22_hooded_horse",
+        "timestamp": "2026-04-22T14:00:00.000Z",
+        "summary": "2026-04-22: meeting with Hooded Horse re: indie deal terms",
+        "contributed_to": ["theme.description", "theme.name"]
+      },
+      {
+        "pcp_type": "linear",
+        "event_id": "lin_iss_DEAL-142",
+        "timestamp": "2026-04-19T09:15:00.000Z",
+        "summary": "2026-04-19: Linear DEAL-142 'Track post-Embracer MG patterns' moved to In Progress",
+        "contributed_to": ["theme.description"]
+      }
+    ],
+    "user_promoted_at": null,
+    "user_promoted_by_user_id": null
+  },
+  "derived_from_panel": false,
+  "panel_provenance": null,
+  "topic_count": 1,
+  "last_activity_at": "2026-04-22T15:35:00.000Z"
+}

--- a/tests/fixtures/editorial-room/v0/theme.example.json
+++ b/tests/fixtures/editorial-room/v0/theme.example.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "0",
+  "name": "AI Impact on Game Dev",
+  "description": "How shipped tools, costs, and dev culture are changing under the LLM era — for game studios building today.",
+  "status": "active",
+  "pinned": true,
+  "derived_from_pcp": false,
+  "pcp_provenance": null,
+  "derived_from_panel": false,
+  "panel_provenance": null,
+  "topic_count": 3,
+  "last_activity_at": "2026-04-30T11:42:18.123Z"
+}

--- a/tests/fixtures/editorial-room/v0/topic.example.json
+++ b/tests/fixtures/editorial-room/v0/topic.example.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "0",
+  "parent_theme_slug": "theme/ai-impact-on-game-dev",
+  "working_title": "How Embracer's writedown changed indie publishing terms",
+  "thesis": "Surviving studios are signing 2022-rate deals to keep going — Embracer's writedown shifted bargaining power away from devs in a way locked in for 18+ months.",
+  "why_now": "Embracer's Q3 8-K reclassified MGs as conditional liabilities; Devolver's prelim Q4 echoed the change; the shape is hardening across mid-tier publishers.",
+  "status": "active",
+  "novelty_score": 0.82,
+  "novelty_score_basis": "Closest prior piece (back_catalog/2025-08-publisher-power-shift) covers Embracer broadly but not the deal-shape implications.",
+  "derived_from_pcp": false,
+  "pcp_provenance": null,
+  "derived_from_panel": false,
+  "panel_provenance": null,
+  "optimization_round_id": null,
+  "point_count": 5,
+  "last_activity_at": "2026-04-30T11:47:00.000Z"
+}

--- a/tests/fixtures/editorial-room/v0/voice.gamemakers.json
+++ b/tests/fixtures/editorial-room/v0/voice.gamemakers.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": "0",
+  "slug": "voice/gamemakers-2026",
+  "name": "GameMakers (2026)",
+  "body_md": "# GameMakers voice\n\nReader: indie devs surviving the Embracer-era platform shifts.\n\n## Signature moves\n- Declarative sentences. No 'I think.'\n- First-person plural sparingly.\n- Numbers > adjectives.\n- Quote primary sources by name.\n- Counter-take in every piece, sourced.\n\n## Anti-patterns\n- Clickbait headlines.\n- Round numbers without provenance.\n- 'As we've previously discussed.'\n- Hedge stacking ('it could be argued that perhaps').\n\n## Cadence\n- Lede ≤ 60 words.\n- Body paragraphs ≤ 4 sentences.\n- Section breaks every ~300 words.\n- Close on a specific forward-looking question.\n"
+}


### PR DESCRIPTION
## Summary
- 10 schemas + 11 fixtures covering rocketorchestra-owned page types and provenance shapes (Batch 1 of 5).
- Test runner now auto-loads all `*.schema.json` in `v0/` so cross-schema `$ref`s resolve, and parametrizes validation + round-trip across every fixture in the fixture dir.
- 39/39 tests pass, typecheck clean, prettier clean.

## What's in this batch
**Schemas** (`docs/contracts/editorial-room/v0/`):
- `theme.schema.json`, `topic.schema.json`, `point.schema.json` — Layer-1/2/3 (§3.1-3.3)
- `voice.schema.json` — loose, body_md is what matters (§3.4)
- `persona.schema.json` — `detailed_profile` capped at 4 KB per §7 (§3.5)
- `scoring_pipeline.schema.json` + `ScorerInPipeline` (§3.6)
- `iteration_config.schema.json` (§3.7)
- `claims_ledger.schema.json` + `ClaimEntry` + `EvidenceLogEntry` (§3.8)
- `pcp_provenance.schema.json` + `PcpSeedEvent` (§3.9.1)
- `panel_provenance.schema.json` (§3.9.2)

**Fixtures** (`tests/fixtures/editorial-room/v0/`) — 11 files matching `EDITORIAL_ROOM_CONTRACT.md` §9.1.

## Test runner changes
- Auto-discover all `*.schema.json` under `v0/` and `addSchema` them for `$ref` resolution.
- Parametrize validation + round-trip across all fixtures (auto-discovered from fixture dir).
- Naming convention: `<base>.<variant>.json` validates against `<base>.schema.json`. Override map for `point_with_evidence.example.json` → `point.schema.json` (preserves contract spelling from §9.1).
- New cross-schema `$ref` test: theme rejects malformed `pcp_provenance` (catches a regression where the `$ref` target wasn't being enforced).

## Contract gap surfaced
`EDITORIAL_ROOM_CONTRACT.md` §10 lists `pcp_provenance.schema.json` but not `panel_provenance.schema.json`, even though §3.9.2 defines the `PanelProvenance` shape and theme/topic/point all reference it. Shipped both as sibling schemas to keep the contract self-consistent. Suggest a §10 update in a doc-only PR.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test -- src/clawrocket/contracts/editorial-room.test.ts` → 39/39 pass
- [x] `npm run format:check` clean
- [ ] CI green

## Up next (Batch 2)
clawrocket-owned per-Piece artifacts: `point_note_block`, `score_snapshot`, `score_result`, `discussion_session`, `proposal_card`, `talk_output_revision`, `talk_output_suggestion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)