### PR TITLE
feat: editorial-room v0 Batch 2 — per-Piece artifacts

### DIFF
--- a/docs/contracts/editorial-room/v0/discussion_session.schema.json
+++ b/docs/contracts/editorial-room/v0/discussion_session.schema.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/discussion_session.schema.json",
+  "title": "DiscussionSession",
+  "description": "Editorial-scoped LLM Discussion. talk_kind='editorial_scoped'; hidden from normal Panel Talk lists. See EDITORIAL_ROOM_CONTRACT.md §4.4.",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "AgentResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "agent_profile_id",
+        "provider_id",
+        "model_id",
+        "text",
+        "citations",
+        "cost_usd",
+        "latency_ms",
+        "status",
+        "error_message"
+      ],
+      "properties": {
+        "agent_profile_id": { "type": "string", "minLength": 1 },
+        "provider_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "e.g., 'anthropic'."
+        },
+        "model_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "e.g., 'claude-opus-4-7'."
+        },
+        "text": {
+          "type": "string",
+          "maxLength": 204800,
+          "description": "Markdown body. §7 cap: 200 KB."
+        },
+        "citations": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Optional source URLs the model emitted."
+        },
+        "cost_usd": { "type": "number", "minimum": 0 },
+        "latency_ms": { "type": "number", "minimum": 0 },
+        "status": {
+          "type": "string",
+          "enum": ["completed", "errored", "timed_out"]
+        },
+        "error_message": {
+          "anyOf": [{ "type": "null" }, { "type": "string" }]
+        }
+      }
+    },
+    "DiscussionTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "user_message",
+        "initiator",
+        "initiated_action",
+        "agent_responses",
+        "proposals",
+        "retained_for_session",
+        "cost_usd",
+        "latency_ms",
+        "partial_provider_failures",
+        "created_at"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "user_message": {
+          "anyOf": [{ "type": "null" }, { "type": "string" }],
+          "description": "Null when system-initiated (e.g., user clicked a proposal button)."
+        },
+        "initiator": { "type": "string", "enum": ["user", "system"] },
+        "initiated_action": {
+          "anyOf": [
+            { "type": "null" },
+            {
+              "type": "string",
+              "enum": [
+                "create_theme",
+                "create_topic",
+                "create_point",
+                "edit_topic",
+                "edit_point",
+                "merge_points",
+                "park_point",
+                "promote_note_to_point",
+                "improve_toward_score",
+                "research_point",
+                "outline_section",
+                "outline_section_swap",
+                "outline_hook_choice"
+              ]
+            }
+          ],
+          "description": "ProposalActionKind per §4.5; aliased to ProposalKind."
+        },
+        "agent_responses": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/AgentResponse" }
+        },
+        "proposals": {
+          "type": "array",
+          "items": {
+            "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/proposal_card.schema.json"
+          }
+        },
+        "retained_for_session": {
+          "type": "boolean",
+          "description": "User-marked: this turn produced something kept."
+        },
+        "cost_usd": { "type": "number", "minimum": 0 },
+        "latency_ms": { "type": "number", "minimum": 0 },
+        "partial_provider_failures": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Names of providers that failed; turn still completed with others."
+        },
+        "created_at": { "type": "string", "format": "date-time" }
+      }
+    }
+  },
+  "required": [
+    "id",
+    "piece_id",
+    "phase",
+    "active_object_kind",
+    "active_object_ref",
+    "active_object_content_hash",
+    "setup_version",
+    "talk_kind",
+    "agent_profile_ids",
+    "turns",
+    "total_cost_usd",
+    "created_at",
+    "updated_at"
+  ],
+  "properties": {
+    "id": { "type": "string", "minLength": 1, "description": "ULID." },
+    "piece_id": { "type": "string", "minLength": 1 },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "theme_topic",
+        "points",
+        "research",
+        "outline",
+        "draft",
+        "polish"
+      ]
+    },
+    "active_object_kind": {
+      "type": "string",
+      "enum": ["theme", "topic", "point", "draft", "outline"]
+    },
+    "active_object_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Slug or revision_id."
+    },
+    "active_object_content_hash": { "type": "string", "minLength": 1 },
+    "setup_version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Staling key."
+    },
+    "talk_kind": {
+      "const": "editorial_scoped",
+      "description": "Always this value; hidden from Panel Talk lists."
+    },
+    "agent_profile_ids": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "From SetupState.llm_room_agent_profile_ids."
+    },
+    "turns": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/DiscussionTurn" }
+    },
+    "total_cost_usd": { "type": "number", "minimum": 0 },
+    "created_at": { "type": "string", "format": "date-time" },
+    "updated_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/docs/contracts/editorial-room/v0/point_note_block.schema.json
+++ b/docs/contracts/editorial-room/v0/point_note_block.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/point_note_block.schema.json",
+  "title": "PointNoteBlock",
+  "description": "Working notes scoped to a specific point within a Piece. Piece-local until promoted via propose_update. See EDITORIAL_ROOM_CONTRACT.md §4.1. NOTE: §4.1 enum {thought, claim, evidence, question, counterpoint} differs from design/03_points_outline.md (which uses {claim, evidence, thought, question, counter, other}); reconcile in a contract update.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "piece_id",
+    "point_ref",
+    "setup_version",
+    "type",
+    "body_md",
+    "created_at",
+    "updated_at",
+    "created_by_user_id",
+    "promoted_to"
+  ],
+  "properties": {
+    "id": { "type": "string", "minLength": 1, "description": "ULID." },
+    "piece_id": { "type": "string", "minLength": 1 },
+    "point_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Slug of the point this note is about."
+    },
+    "setup_version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Setup version at time of writing (staling key)."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["thought", "claim", "evidence", "question", "counterpoint"]
+    },
+    "body_md": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Freeform Markdown."
+    },
+    "created_at": { "type": "string", "format": "date-time" },
+    "updated_at": { "type": "string", "format": "date-time" },
+    "created_by_user_id": { "type": "string", "minLength": 1 },
+    "promoted_to": {
+      "anyOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "target_slug"],
+          "properties": {
+            "kind": { "type": "string", "enum": ["point", "claim_ledger"] },
+            "target_slug": { "type": "string", "minLength": 1 }
+          }
+        }
+      ],
+      "description": "Set when user promotes the note to a durable point page or claim ledger entry."
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/proposal_card.schema.json
+++ b/docs/contracts/editorial-room/v0/proposal_card.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/proposal_card.schema.json",
+  "title": "ProposalCard",
+  "description": "Discrete unit of agent-proposed change. User accepts/edits/rejects/parks each proposal individually. See EDITORIAL_ROOM_CONTRACT.md §4.5. Per §10 ProposedDiff is described as 'oneOf by target_object.kind' but the contract code-level type is Record<string, unknown>; strict per-kind discrimination is deferred — we ship ProposedDiff as type:object and document the per-kind shape contract in the field description.",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "ProposedDiff": {
+      "type": "object",
+      "description": "Shape varies by parent ProposalCard.target_object.kind:\n- theme: { name?, description?, status? }\n- topic: { working_title?, thesis?, why_now?, status? }\n- point: { claim?, rationale?, evidence_add?, evidence_remove?, conviction?, status? }\n- outline: { sections?, hook_options?, payoff? }\n- draft: see §4.6+§5.\nJSON Schema enforcement is intentionally permissive; runtime validates against the resolved target object."
+    }
+  },
+  "required": [
+    "id",
+    "schema_version",
+    "source_run_id",
+    "source_skill",
+    "proposal_kind",
+    "target_object",
+    "proposed_diff",
+    "rationale",
+    "agent_attribution",
+    "status",
+    "user_edit",
+    "resolved_at",
+    "resolved_by_user_id",
+    "resolution_note"
+  ],
+  "properties": {
+    "id": { "type": "string", "minLength": 1, "description": "ULID." },
+    "schema_version": { "const": "0" },
+    "source_run_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Run that produced this proposal."
+    },
+    "source_skill": {
+      "type": "string",
+      "minLength": 1,
+      "description": "e.g., 'factory_topic_propose', 'factory_point_debate'."
+    },
+    "proposal_kind": {
+      "type": "string",
+      "enum": [
+        "create_theme",
+        "create_topic",
+        "create_point",
+        "edit_topic",
+        "edit_point",
+        "merge_points",
+        "park_point",
+        "promote_note_to_point",
+        "improve_toward_score",
+        "research_point",
+        "outline_section",
+        "outline_section_swap",
+        "outline_hook_choice"
+      ]
+    },
+    "target_object": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "ref"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["theme", "topic", "point", "outline", "draft"]
+        },
+        "ref": {
+          "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+          "description": "Slug of the target object; null for create_* proposals."
+        }
+      }
+    },
+    "proposed_diff": { "$ref": "#/definitions/ProposedDiff" },
+    "rationale": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096,
+      "description": "Why the proposal makes sense. §7 cap: 4 KB."
+    },
+    "agent_attribution": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Which agent profile_ids contributed."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pending", "accepted", "edited", "rejected", "parked"]
+    },
+    "user_edit": {
+      "anyOf": [{ "type": "null" }, { "$ref": "#/definitions/ProposedDiff" }],
+      "description": "Populated if status == 'edited'."
+    },
+    "resolved_at": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "format": "date-time" }]
+    },
+    "resolved_by_user_id": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }]
+    },
+    "resolution_note": {
+      "anyOf": [{ "type": "null" }, { "type": "string" }]
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/score_result.schema.json
+++ b/docs/contracts/editorial-room/v0/score_result.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/score_result.schema.json",
+  "title": "ScoreResult",
+  "description": "Returned by the factory_score Skill family. Embedded inside ScoreSnapshot.result. See EDITORIAL_ROOM_CONTRACT.md §4.3.",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "ScorerOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scorer_id",
+        "role",
+        "passed_gate",
+        "raw_score",
+        "scale",
+        "notes"
+      ],
+      "properties": {
+        "scorer_id": { "type": "string", "minLength": 1 },
+        "role": { "type": "string", "enum": ["gate", "score", "diagnostic"] },
+        "passed_gate": {
+          "anyOf": [{ "type": "null" }, { "type": "boolean" }]
+        },
+        "raw_score": {
+          "anyOf": [{ "type": "null" }, { "type": "number" }]
+        },
+        "scale": {
+          "type": "array",
+          "items": [{ "type": "number" }, { "type": "number" }],
+          "minItems": 2,
+          "maxItems": 2,
+          "additionalItems": false
+        },
+        "notes": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  },
+  "required": [
+    "schema_version",
+    "scoring_pipeline_slug",
+    "aggregate_score",
+    "score_scale",
+    "score_direction",
+    "per_dimension",
+    "per_persona",
+    "confidence",
+    "notes",
+    "per_scorer_breakdown",
+    "metadata"
+  ],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "scoring_pipeline_slug": { "type": "string", "minLength": 1 },
+    "aggregate_score": {
+      "anyOf": [{ "type": "null" }, { "type": "number" }],
+      "description": "Null if scorer is diagnostic-only or gated out."
+    },
+    "score_scale": {
+      "type": "array",
+      "items": [{ "type": "number" }, { "type": "number" }],
+      "minItems": 2,
+      "maxItems": 2,
+      "additionalItems": false,
+      "description": "e.g., [0, 10] or [1, 5]."
+    },
+    "score_direction": {
+      "type": "string",
+      "enum": ["higher_better", "lower_better"]
+    },
+    "per_dimension": {
+      "type": "object",
+      "additionalProperties": { "type": "number" },
+      "description": "e.g., { voice_match: 8.2, hook: 7.5 }."
+    },
+    "per_persona": {
+      "anyOf": [
+        { "type": "null" },
+        { "type": "object", "additionalProperties": { "type": "number" } }
+      ],
+      "description": "e.g., { 'persona/ankit-indie-dev': 4.1 }."
+    },
+    "confidence": {
+      "type": "string",
+      "enum": ["absolute", "relative-only", "experimental"]
+    },
+    "notes": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Diagnostic strings."
+    },
+    "per_scorer_breakdown": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/ScorerOutput" }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cost_usd", "latency_ms", "models_used"],
+      "properties": {
+        "cost_usd": { "type": "number", "minimum": 0 },
+        "latency_ms": { "type": "number", "minimum": 0 },
+        "models_used": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/score_snapshot.schema.json
+++ b/docs/contracts/editorial-room/v0/score_snapshot.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/score_snapshot.schema.json",
+  "title": "ScoreSnapshot",
+  "description": "Cached score result for a theme/topic/point within a Piece. Stale flag set when setup_version or content_hash diverges. See EDITORIAL_ROOM_CONTRACT.md §4.2.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "piece_id",
+    "setup_version",
+    "object_kind",
+    "object_ref",
+    "object_content_hash",
+    "scoring_pipeline_slug",
+    "selected_persona_slugs",
+    "result",
+    "computed_at",
+    "cost_usd",
+    "is_stale"
+  ],
+  "properties": {
+    "id": { "type": "string", "minLength": 1, "description": "ULID." },
+    "piece_id": { "type": "string", "minLength": 1 },
+    "setup_version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Staling key."
+    },
+    "object_kind": {
+      "type": "string",
+      "enum": ["theme", "topic", "point"]
+    },
+    "object_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Slug of the scored object."
+    },
+    "object_content_hash": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Hash of the object's compiled_truth at score time."
+    },
+    "scoring_pipeline_slug": { "type": "string", "minLength": 1 },
+    "selected_persona_slugs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "From SetupState.audience_persona_slugs at score time."
+    },
+    "result": {
+      "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/score_result.schema.json"
+    },
+    "computed_at": { "type": "string", "format": "date-time" },
+    "cost_usd": {
+      "anyOf": [{ "type": "null" }, { "type": "number", "minimum": 0 }]
+    },
+    "is_stale": {
+      "type": "boolean",
+      "description": "True if setup_version or content_hash diverges from current."
+    }
+  }
+}

--- a/src/clawrocket/contracts/editorial-room.test.ts
+++ b/src/clawrocket/contracts/editorial-room.test.ts
@@ -53,11 +53,19 @@ function validatorFor(schemaFile: string): ValidateFunction {
 // `<base>.schema.json`. e.g., `theme.derived_from_pcp.json` →
 // `theme.schema.json`; `setup_state.minimal.json` → `setup_state.schema.json`.
 // A few fixtures in EDITORIAL_ROOM_CONTRACT.md §9.1 use a different shape
-// (e.g., `point_with_evidence.example.json` for the `point` schema); those
-// are listed in `FIXTURE_SCHEMA_OVERRIDES`.
+// (e.g., `point_with_evidence.example.json` for the `point` schema, or
+// `point_note_blocks.example.json` plural-named for the singular schema);
+// those are listed in `FIXTURE_SCHEMA_OVERRIDES`.
 const FIXTURE_SCHEMA_OVERRIDES: Record<string, string> = {
   'point_with_evidence.example.json': 'point.schema.json',
+  'point_note_blocks.example.json': 'point_note_block.schema.json',
 };
+
+// Fixtures whose top-level value is an array of <schema> rather than a single
+// <schema>. We validate each element separately.
+const FIXTURES_AS_ARRAY: ReadonlySet<string> = new Set([
+  'point_note_blocks.example.json',
+]);
 
 function schemaFileForFixture(fixtureFile: string): string {
   if (fixtureFile in FIXTURE_SCHEMA_OVERRIDES) {
@@ -106,7 +114,18 @@ describe('editorial-room v0 contracts', () => {
       (fixtureFile, schemaFile) => {
         const validate = validatorFor(schemaFile);
         const fixture = loadJson(resolve(fixtureDir, fixtureFile));
-        expectValid(validate, fixture, fixtureFile);
+        if (FIXTURES_AS_ARRAY.has(fixtureFile)) {
+          if (!Array.isArray(fixture)) {
+            throw new Error(
+              `${fixtureFile} expected to be a JSON array (FIXTURES_AS_ARRAY)`,
+            );
+          }
+          fixture.forEach((elem, idx) => {
+            expectValid(validate, elem, `${fixtureFile}[${idx}]`);
+          });
+        } else {
+          expectValid(validate, fixture, fixtureFile);
+        }
       },
     );
   });

--- a/tests/fixtures/editorial-room/v0/discussion_session.example.json
+++ b/tests/fixtures/editorial-room/v0/discussion_session.example.json
@@ -1,0 +1,111 @@
+{
+  "id": "01HXYZDISC001AAAAAAAAAAAAAA",
+  "piece_id": "piece_01HXYZ789ABC",
+  "phase": "theme_topic",
+  "active_object_kind": "topic",
+  "active_object_ref": "topic/ai-impact-on-game-dev-how-embracers-writedown-changed-indie-publishing-terms",
+  "active_object_content_hash": "sha256:abc123def456789aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "setup_version": 7,
+  "talk_kind": "editorial_scoped",
+  "agent_profile_ids": ["agent/argus", "agent/scribe", "agent/mei-cohort"],
+  "turns": [
+    {
+      "id": "01HXYZTURN001AAAAAAAAAAAAAA",
+      "user_message": "Where should the angle land — deal-shape or accounting?",
+      "initiator": "user",
+      "initiated_action": null,
+      "agent_responses": [
+        {
+          "agent_profile_id": "agent/argus",
+          "provider_id": "anthropic",
+          "model_id": "claude-opus-4-7",
+          "text": "The accounting reclassification is the load-bearing piece — without it the deal shape doesn't lock. Lead with the reclassification.",
+          "citations": [],
+          "cost_usd": 0.018,
+          "latency_ms": 4210,
+          "status": "completed",
+          "error_message": null
+        },
+        {
+          "agent_profile_id": "agent/scribe",
+          "provider_id": "anthropic",
+          "model_id": "claude-sonnet-4-6",
+          "text": "Pushing back: a person needs to land in §2. The reclassification is correct but bloodless. Use the Annapurna note.",
+          "citations": [],
+          "cost_usd": 0.006,
+          "latency_ms": 3120,
+          "status": "completed",
+          "error_message": null
+        },
+        {
+          "agent_profile_id": "agent/mei-cohort",
+          "provider_id": "google",
+          "model_id": "gemini-2.5-pro",
+          "text": "",
+          "citations": [],
+          "cost_usd": 0,
+          "latency_ms": 9999,
+          "status": "timed_out",
+          "error_message": "provider timeout after 10000ms"
+        }
+      ],
+      "proposals": [
+        {
+          "id": "01HXYZPROP001AAAAAAAAAAAAAA",
+          "schema_version": "0",
+          "source_run_id": "01HXYZRUN001AAAAAAAAAAAAAA",
+          "source_skill": "factory_topic_debate",
+          "proposal_kind": "promote_note_to_point",
+          "target_object": {
+            "kind": "topic",
+            "ref": "topic/ai-impact-on-game-dev-how-embracers-writedown-changed-indie-publishing-terms"
+          },
+          "proposed_diff": {
+            "promote_note_id": "01HXYZNOTE003CCCCCCCCCCCCC",
+            "as_point_kind": "counter"
+          },
+          "rationale": "The Annapurna counter is a real falsifier — promote it to a Counter-Point so it's argued explicitly in the outline.",
+          "agent_attribution": ["agent/argus", "agent/scribe"],
+          "status": "pending",
+          "user_edit": null,
+          "resolved_at": null,
+          "resolved_by_user_id": null,
+          "resolution_note": null
+        }
+      ],
+      "retained_for_session": false,
+      "cost_usd": 0.024,
+      "latency_ms": 10100,
+      "partial_provider_failures": ["google"],
+      "created_at": "2026-04-30T11:42:00.000Z"
+    },
+    {
+      "id": "01HXYZTURN002BBBBBBBBBBBBBB",
+      "user_message": null,
+      "initiator": "system",
+      "initiated_action": "promote_note_to_point",
+      "agent_responses": [
+        {
+          "agent_profile_id": "agent/argus",
+          "provider_id": "anthropic",
+          "model_id": "claude-opus-4-7",
+          "text": "Promotion confirmed. Counter-Point seeded with the Annapurna note; flagged for verification before draft.",
+          "citations": [],
+          "cost_usd": 0.012,
+          "latency_ms": 2800,
+          "status": "completed",
+          "error_message": null
+        }
+      ],
+      "proposals": [],
+      "retained_for_session": true,
+      "cost_usd": 0.012,
+      "latency_ms": 2800,
+      "partial_provider_failures": [],
+      "created_at": "2026-04-30T11:43:00.000Z"
+    }
+  ],
+  "total_cost_usd": 0.036,
+  "created_at": "2026-04-30T11:42:00.000Z",
+  "updated_at": "2026-04-30T11:43:00.000Z"
+}

--- a/tests/fixtures/editorial-room/v0/point_note_blocks.example.json
+++ b/tests/fixtures/editorial-room/v0/point_note_blocks.example.json
@@ -1,0 +1,41 @@
+[
+  {
+    "id": "01HXYZNOTE001AAAAAAAAAAAAA",
+    "piece_id": "piece_01HXYZ789ABC",
+    "point_ref": "point/embracer-mg-reclassification-load-bearing",
+    "setup_version": 7,
+    "type": "claim",
+    "body_md": "MG itself is now reclassified as a conditional liability under the post-Embracer accounting framework. That's the structural change, not the writedown itself.",
+    "created_at": "2026-04-30T11:32:00.000Z",
+    "updated_at": "2026-04-30T11:32:00.000Z",
+    "created_by_user_id": "user_local_joseph",
+    "promoted_to": null
+  },
+  {
+    "id": "01HXYZNOTE002BBBBBBBBBBBBB",
+    "piece_id": "piece_01HXYZ789ABC",
+    "point_ref": "point/embracer-mg-reclassification-load-bearing",
+    "setup_version": 7,
+    "type": "evidence",
+    "body_md": "Embracer Q3 8-K, pp. 14-16: explicit reclassification language. Devolver Q4 prelim $5 echoes the change. Take-Two K-1 silent (different acct treatment).",
+    "created_at": "2026-04-30T11:38:00.000Z",
+    "updated_at": "2026-04-30T11:38:00.000Z",
+    "created_by_user_id": "user_local_joseph",
+    "promoted_to": {
+      "kind": "claim_ledger",
+      "target_slug": "claims_ledger/embracer-mg-reclassified-q3-2025"
+    }
+  },
+  {
+    "id": "01HXYZNOTE003CCCCCCCCCCCCC",
+    "piece_id": "piece_01HXYZ789ABC",
+    "point_ref": "point/embracer-mg-reclassification-load-bearing",
+    "setup_version": 7,
+    "type": "counterpoint",
+    "body_md": "Annapurna staffer (background): this is overstated — they're still signing pre-Embracer-shape deals at unchanged MG ratios. The reclassification may not be universal.",
+    "created_at": "2026-04-30T11:41:00.000Z",
+    "updated_at": "2026-04-30T11:41:00.000Z",
+    "created_by_user_id": "user_local_joseph",
+    "promoted_to": null
+  }
+]

--- a/tests/fixtures/editorial-room/v0/proposal_card.create_topic.json
+++ b/tests/fixtures/editorial-room/v0/proposal_card.create_topic.json
@@ -1,0 +1,25 @@
+{
+  "id": "01HXYZPROP100AAAAAAAAAAAAAA",
+  "schema_version": "0",
+  "source_run_id": "01HXYZRUN100AAAAAAAAAAAAAA",
+  "source_skill": "factory_topic_propose_optimize",
+  "proposal_kind": "create_topic",
+  "target_object": {
+    "kind": "topic",
+    "ref": null
+  },
+  "proposed_diff": {
+    "parent_theme_slug": "theme/ai-impact-on-game-dev",
+    "working_title": "How Embracer's writedown changed indie publishing terms",
+    "thesis": "Surviving studios are signing 2022-rate deals to keep going — Embracer's writedown shifted bargaining power away from devs in a way locked in for 18+ months.",
+    "why_now": "Embracer's Q3 8-K reclassified MGs as conditional liabilities; Devolver's prelim Q4 echoed the change.",
+    "status": "active"
+  },
+  "rationale": "Topic-optimize round 01HXYZABC456PQR789STUVWXYZ ranked this top-K rank 1 by composite (rubric 7.6 + SSR mean 8.0 + novelty bonus 0.15). The reclassification angle is the load-bearing element — the deal shape can't lock without it.",
+  "agent_attribution": ["agent/argus", "agent/scribe", "agent/mei-cohort"],
+  "status": "pending",
+  "user_edit": null,
+  "resolved_at": null,
+  "resolved_by_user_id": null,
+  "resolution_note": null
+}

--- a/tests/fixtures/editorial-room/v0/proposal_card.improve_toward_score.json
+++ b/tests/fixtures/editorial-room/v0/proposal_card.improve_toward_score.json
@@ -1,0 +1,32 @@
+{
+  "id": "01HXYZPROP200BBBBBBBBBBBBBB",
+  "schema_version": "0",
+  "source_run_id": "01HXYZRUN200BBBBBBBBBBBBBB",
+  "source_skill": "factory_point_improve_toward_score",
+  "proposal_kind": "improve_toward_score",
+  "target_object": {
+    "kind": "point",
+    "ref": "point/embracer-mg-reclassification-load-bearing"
+  },
+  "proposed_diff": {
+    "claim": "MG-as-conditional-liability is the load-bearing accounting change — without it the deal-shape lockdown collapses inside one quarter.",
+    "rationale": "Tightens the causal chain between the accounting change and the deal-shape persistence. Adds a falsifiable temporal claim ('inside one quarter').",
+    "evidence_add": [
+      {
+        "kind": "back_catalog_ref",
+        "url": null,
+        "ref_slug": "back_catalog/2025-08-publisher-power-shift",
+        "quote_text": null,
+        "quote_source": null,
+        "notes": "Predicts the structural shift; this Point names the mechanism."
+      }
+    ]
+  },
+  "rationale": "Point currently scores SSR likelihood mean 0.62 (just under 0.65 gate for primary personas). Tightening the causal chain and adding the back-catalog reference projects to ~0.74 based on rubric judge sensitivity analysis. Recommended accept.",
+  "agent_attribution": ["agent/argus"],
+  "status": "pending",
+  "user_edit": null,
+  "resolved_at": null,
+  "resolved_by_user_id": null,
+  "resolution_note": null
+}

--- a/tests/fixtures/editorial-room/v0/score_snapshot.example.json
+++ b/tests/fixtures/editorial-room/v0/score_snapshot.example.json
@@ -1,0 +1,79 @@
+{
+  "id": "01HXYZSCRSNAP001AAAAAAAAAA",
+  "piece_id": "piece_01HXYZ789ABC",
+  "setup_version": 7,
+  "object_kind": "topic",
+  "object_ref": "topic/ai-impact-on-game-dev-how-embracers-writedown-changed-indie-publishing-terms",
+  "object_content_hash": "sha256:abc123def456789aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default",
+  "selected_persona_slugs": [
+    "persona/ankit-indie-dev",
+    "persona/ravi-studio-lead",
+    "persona/mei-publisher"
+  ],
+  "result": {
+    "schema_version": "0",
+    "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default",
+    "aggregate_score": 7.8,
+    "score_scale": [0, 10],
+    "score_direction": "higher_better",
+    "per_dimension": {
+      "specificity": 8.2,
+      "disputability": 7.5,
+      "novelty": 8.0,
+      "voice_match": 7.6
+    },
+    "per_persona": {
+      "persona/ankit-indie-dev": 9.0,
+      "persona/ravi-studio-lead": 9.0,
+      "persona/mei-publisher": 7.0
+    },
+    "confidence": "absolute",
+    "notes": [
+      "All hard gates pass.",
+      "SSR likelihood mean across primary personas: 0.78."
+    ],
+    "per_scorer_breakdown": [
+      {
+        "scorer_id": "rubric_judge_opus",
+        "role": "score",
+        "passed_gate": null,
+        "raw_score": 7.6,
+        "scale": [0, 10],
+        "notes": ["Strong on specificity; weakest on hook freshness."]
+      },
+      {
+        "scorer_id": "ssr_core_local",
+        "role": "score",
+        "passed_gate": null,
+        "raw_score": 8.0,
+        "scale": [0, 10],
+        "notes": []
+      },
+      {
+        "scorer_id": "voice_drift",
+        "role": "score",
+        "passed_gate": null,
+        "raw_score": 7.8,
+        "scale": [0, 10],
+        "notes": []
+      },
+      {
+        "scorer_id": "specificity_gate",
+        "role": "gate",
+        "passed_gate": true,
+        "raw_score": null,
+        "scale": [0, 10],
+        "notes": []
+      }
+    ],
+    "metadata": {
+      "cost_usd": 0.064,
+      "latency_ms": 11420,
+      "models_used": ["claude-opus-4-7", "claude-sonnet-4-6"]
+    }
+  },
+  "computed_at": "2026-04-30T11:47:00.000Z",
+  "cost_usd": 0.064,
+  "is_stale": false
+}


### PR DESCRIPTION
## Summary
- 5 schemas + 5 fixtures covering clawrocket-owned per-Piece artifacts (Batch 2 of 5).
- 49/49 tests pass (was 39, +10 from new fixtures × validation+round-trip), typecheck clean, prettier clean.

## What's in this batch
**Schemas** (`docs/contracts/editorial-room/v0/`):
- `point_note_block.schema.json` (§4.1)
- `score_snapshot.schema.json` (§4.2; `result` field `$ref`s score_result)
- `score_result.schema.json` + `ScorerOutput` (§4.3)
- `discussion_session.schema.json` + `DiscussionTurn` + `AgentResponse` (§4.4; `proposals[]` `$ref`s proposal_card)
- `proposal_card.schema.json` + `ProposedDiff` (§4.5)

**Fixtures** (`tests/fixtures/editorial-room/v0/`):
- `point_note_blocks.example.json` (3 notes as a JSON array — see naming note)
- `score_snapshot.example.json` (topic-scoped, all gates pass, full per-scorer breakdown)
- `discussion_session.example.json` (2 turns, 1 proposal, includes a partial-provider timeout)
- `proposal_card.create_topic.json`
- `proposal_card.improve_toward_score.json`

## Test runner changes
- `FIXTURE_SCHEMA_OVERRIDES`: `point_note_blocks.example.json` (plural) → `point_note_block.schema.json` (singular).
- `FIXTURES_AS_ARRAY`: a fixture whose top-level value is a JSON array is validated element-by-element (currently only `point_note_blocks.example.json`).

## Contract gaps surfaced
1. **§4.1 PointNoteBlock.type vs design.** Contract enum is `{thought, claim, evidence, question, counterpoint}`. `design/03_points_outline.md` uses `{claim, evidence, thought, question, counter, other}`. Schema follows the contract; flagged in schema description for reconciliation.
2. **§4.4 DiscussionSession.initiated_action vs §4.5 ProposalKind.** §4.4 references `ProposalActionKind` with "see 4.5" but §4.5 defines `ProposalKind`. Treated as alias; encoded with `ProposalKind` enum.
3. **§10 vs §4.5 ProposedDiff strictness.** §10 says "oneOf by target_object.kind" but §4.5 code-level type is `Record<string, unknown>`. Strict per-kind discrimination deferred — schema ships permissive `type: object` with the per-kind contract documented in the field description.

## Out-of-batch deferral
`talk_output_revision` (§4.6) and `talk_output_suggestion` (§4.8) depend on `markdown_source_map` + `suggestion` primitives. Both moved to Batch 3 (editor primitives) to avoid placeholder `$ref`s. Schema count for Batch 3 grows from 2 → 4.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test -- src/clawrocket/contracts/editorial-room.test.ts` → 49/49 pass
- [x] `npm run format:check` clean
- [ ] CI green

## Up next (Batch 3 — editor primitives)
`markdown_source_map` (+ `SourceMapBlock` + `SourceMapSpan`), `suggestion` (+ `SourceMapRef`), plus the deferred `talk_output_revision` and `talk_output_suggestion`. 4 schemas, 4 fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)