### PR TITLE
feat: editorial-room v0 Batch 3 — editor primitives

### DIFF
--- a/docs/contracts/editorial-room/v0/markdown_source_map.schema.json
+++ b/docs/contracts/editorial-room/v0/markdown_source_map.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/markdown_source_map.schema.json",
+  "title": "MarkdownSourceMap",
+  "description": "Anchor primitive for suggestions. Generated alongside the Markdown snapshot for a draft revision; lets Skill-returned suggestions resolve to ProseMirror positions deterministically. See EDITORIAL_ROOM_CONTRACT.md §5.1. §7 cap: 1 MB per revision.",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "PmRange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "to"],
+      "properties": {
+        "from": { "type": "integer", "minimum": 0 },
+        "to": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "MarkdownRange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start", "end"],
+      "properties": {
+        "start": { "type": "integer", "minimum": 0 },
+        "end": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "SourceMapSpan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "span_id",
+        "pm_range",
+        "markdown_range",
+        "normalized_text",
+        "text_hash"
+      ],
+      "properties": {
+        "span_id": { "type": "string", "minLength": 1 },
+        "pm_range": { "$ref": "#/definitions/PmRange" },
+        "markdown_range": { "$ref": "#/definitions/MarkdownRange" },
+        "normalized_text": { "type": "string" },
+        "text_hash": { "type": "string", "minLength": 1 }
+      }
+    },
+    "SourceMapBlock": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "block_id",
+        "node_path",
+        "pm_range",
+        "markdown_range",
+        "normalized_text",
+        "text_hash",
+        "context_before",
+        "context_after"
+      ],
+      "properties": {
+        "block_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable across save-cycles."
+        },
+        "node_path": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 0 },
+          "description": "ProseMirror node path."
+        },
+        "pm_range": { "$ref": "#/definitions/PmRange" },
+        "markdown_range": { "$ref": "#/definitions/MarkdownRange" },
+        "normalized_text": { "type": "string" },
+        "text_hash": { "type": "string", "minLength": 1 },
+        "context_before": {
+          "type": "string",
+          "maxLength": 80,
+          "description": "≤80 chars."
+        },
+        "context_after": {
+          "type": "string",
+          "maxLength": 80,
+          "description": "≤80 chars."
+        },
+        "spans": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/SourceMapSpan" },
+          "description": "Optional initially per §5.1; required when inline-mark suggestion targeting ships."
+        }
+      }
+    }
+  },
+  "required": ["schema_version", "revision_id", "content_hash", "blocks"],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "revision_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "ULID of the revision this map was generated for."
+    },
+    "content_hash": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Hash of the revision's content_md_snapshot."
+    },
+    "blocks": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/SourceMapBlock" },
+      "description": "Block-level coverage required per §5.1 for paragraph, heading, bullet_list, ordered_list, code_block, blockquote, hard_break."
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/suggestion.schema.json
+++ b/docs/contracts/editorial-room/v0/suggestion.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/suggestion.schema.json",
+  "title": "Suggestion",
+  "description": "Wire shape for a Skill-returned suggestion against a draft revision. clawrocket persists these as TalkOutputSuggestion rows. See EDITORIAL_ROOM_CONTRACT.md §5.3. SourceMapRef and SuggestionCategory live in this schema's definitions per §10.",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "SourceMapRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["block_id", "span_id", "text_hash"],
+      "properties": {
+        "block_id": { "type": "string", "minLength": 1 },
+        "span_id": {
+          "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+          "description": "Null = whole block."
+        },
+        "text_hash": {
+          "type": "string",
+          "minLength": 1,
+          "description": "For verification at resolve time."
+        }
+      }
+    },
+    "MarkdownRange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start", "end"],
+      "properties": {
+        "start": { "type": "integer", "minimum": 0 },
+        "end": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "SuggestionCategory": {
+      "type": "string",
+      "enum": [
+        "filler",
+        "repetition",
+        "hedge",
+        "weak_verb",
+        "tangent",
+        "wording",
+        "structure",
+        "voice_drift",
+        "missing_premise",
+        "weak_claim",
+        "unsupported_leap",
+        "would_lose_persona",
+        "evidence_gap",
+        "claim_unbacked",
+        "claim_contradicts_ledger",
+        "other"
+      ]
+    }
+  },
+  "required": [
+    "schema_version",
+    "revision_id",
+    "target_content_hash",
+    "source_map_refs",
+    "markdown_range",
+    "anchor_quote",
+    "anchor_content_hash",
+    "anchor_context_before",
+    "anchor_context_after",
+    "replacement",
+    "rationale",
+    "category",
+    "source_skill",
+    "source_run_id"
+  ],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "revision_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Revision the Skill READ."
+    },
+    "target_content_hash": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Hash of that revision's content_md_snapshot."
+    },
+    "source_map_refs": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/SourceMapRef" }
+    },
+    "markdown_range": { "$ref": "#/definitions/MarkdownRange" },
+    "anchor_quote": {
+      "type": "string",
+      "description": "Exact text the range matched (fallback)."
+    },
+    "anchor_content_hash": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Hash of source Markdown snapshot (fallback)."
+    },
+    "anchor_context_before": {
+      "anyOf": [{ "type": "null" }, { "type": "string" }]
+    },
+    "anchor_context_after": {
+      "anyOf": [{ "type": "null" }, { "type": "string" }]
+    },
+    "replacement": {
+      "anyOf": [{ "type": "null" }, { "type": "string" }],
+      "description": "Null = pure cut."
+    },
+    "rationale": { "type": "string", "minLength": 1 },
+    "category": { "$ref": "#/definitions/SuggestionCategory" },
+    "source_skill": { "type": "string", "minLength": 1 },
+    "source_run_id": { "type": "string", "minLength": 1 }
+  }
+}

--- a/docs/contracts/editorial-room/v0/talk_output_revision.schema.json
+++ b/docs/contracts/editorial-room/v0/talk_output_revision.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/talk_output_revision.schema.json",
+  "title": "TalkOutputRevision",
+  "description": "Per-revision draft record. Tiptap JSON canonical, Markdown snapshot derived, source map alongside for suggestion anchoring. See EDITORIAL_ROOM_CONTRACT.md §4.6 + 01_ARCHITECTURE.md §6.1.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "output_id",
+    "revision_number",
+    "content_json",
+    "content_md_snapshot",
+    "markdown_source_map",
+    "source_skill",
+    "created_by_run_id",
+    "metrics_json",
+    "created_at"
+  ],
+  "properties": {
+    "id": { "type": "string", "minLength": 1, "description": "ULID." },
+    "output_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "FK to talk_outputs.id."
+    },
+    "revision_number": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Monotonic per output_id."
+    },
+    "content_json": {
+      "type": "object",
+      "description": "Canonical Tiptap JSON document. Shape is Tiptap-specific; not formalized in this contract."
+    },
+    "content_md_snapshot": {
+      "type": "string",
+      "maxLength": 512000,
+      "description": "Derived Markdown projection. §7 cap: 500 KB."
+    },
+    "markdown_source_map": {
+      "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/markdown_source_map.schema.json"
+    },
+    "source_skill": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Documented values: manual | draft | adv_cut | reader_panel | opus_review | optimize. Other strings allowed for forward-compat."
+    },
+    "created_by_run_id": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+      "description": "ULID of the Skill run that produced this revision; null for manual edits."
+    },
+    "metrics_json": {
+      "anyOf": [{ "type": "null" }, { "type": "object" }]
+    },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/docs/contracts/editorial-room/v0/talk_output_suggestion.schema.json
+++ b/docs/contracts/editorial-room/v0/talk_output_suggestion.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/talk_output_suggestion.schema.json",
+  "title": "TalkOutputSuggestion",
+  "description": "DB-row shape for a Skill-returned suggestion persisted by clawrocket. See EDITORIAL_ROOM_CONTRACT.md §4.8. Mirrors Suggestion (§5.3) field shapes but adds row identity + status lifecycle. Cross-refs SourceMapRef / MarkdownRange / SuggestionCategory from suggestion.schema.json.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "output_id",
+    "source_run_id",
+    "source_skill",
+    "schema_version",
+    "target_revision_id",
+    "target_content_hash",
+    "source_map_refs",
+    "markdown_range",
+    "anchor_quote",
+    "anchor_content_hash",
+    "anchor_context_before",
+    "anchor_context_after",
+    "replacement_md",
+    "rationale",
+    "category",
+    "status",
+    "resolved_at",
+    "resolved_by_user_id"
+  ],
+  "properties": {
+    "id": { "type": "string", "minLength": 1, "description": "ULID." },
+    "output_id": { "type": "string", "minLength": 1 },
+    "source_run_id": { "type": "string", "minLength": 1 },
+    "source_skill": { "type": "string", "minLength": 1 },
+    "schema_version": { "const": "0" },
+    "target_revision_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Revision the Skill read."
+    },
+    "target_content_hash": { "type": "string", "minLength": 1 },
+    "source_map_refs": {
+      "type": "array",
+      "items": {
+        "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/suggestion.schema.json#/definitions/SourceMapRef"
+      }
+    },
+    "markdown_range": {
+      "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/suggestion.schema.json#/definitions/MarkdownRange"
+    },
+    "anchor_quote": { "type": "string" },
+    "anchor_content_hash": { "type": "string", "minLength": 1 },
+    "anchor_context_before": {
+      "anyOf": [{ "type": "null" }, { "type": "string" }]
+    },
+    "anchor_context_after": {
+      "anyOf": [{ "type": "null" }, { "type": "string" }]
+    },
+    "replacement_md": {
+      "anyOf": [{ "type": "null" }, { "type": "string" }],
+      "description": "Null = pure cut."
+    },
+    "rationale": { "type": "string", "minLength": 1 },
+    "category": {
+      "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/suggestion.schema.json#/definitions/SuggestionCategory"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pending", "accepted", "rejected", "edited", "stale"]
+    },
+    "resolved_at": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "format": "date-time" }]
+    },
+    "resolved_by_user_id": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }]
+    }
+  }
+}

--- a/src/clawrocket/contracts/editorial-room.test.ts
+++ b/src/clawrocket/contracts/editorial-room.test.ts
@@ -59,12 +59,16 @@ function validatorFor(schemaFile: string): ValidateFunction {
 const FIXTURE_SCHEMA_OVERRIDES: Record<string, string> = {
   'point_with_evidence.example.json': 'point.schema.json',
   'point_note_blocks.example.json': 'point_note_block.schema.json',
+  'suggestions.adv_cut.json': 'suggestion.schema.json',
+  'suggestions.opus_review.json': 'suggestion.schema.json',
 };
 
 // Fixtures whose top-level value is an array of <schema> rather than a single
 // <schema>. We validate each element separately.
 const FIXTURES_AS_ARRAY: ReadonlySet<string> = new Set([
   'point_note_blocks.example.json',
+  'suggestions.adv_cut.json',
+  'suggestions.opus_review.json',
 ]);
 
 function schemaFileForFixture(fixtureFile: string): string {

--- a/tests/fixtures/editorial-room/v0/markdown_source_map.lists_tables.json
+++ b/tests/fixtures/editorial-room/v0/markdown_source_map.lists_tables.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "0",
+  "revision_id": "01HXYZREV002BBBBBBBBBBBBBB",
+  "content_hash": "sha256:rev002bbb00000000000000000000000000000000000000000000000000000000",
+  "blocks": [
+    {
+      "block_id": "blk_h_0001",
+      "node_path": [0],
+      "pm_range": { "from": 0, "to": 28 },
+      "markdown_range": { "start": 0, "end": 28 },
+      "normalized_text": "Three structural changes",
+      "text_hash": "sha256:bh0001hash0000000000000000000000000000000000000000000000000000000",
+      "context_before": "",
+      "context_after": "\n\n"
+    },
+    {
+      "block_id": "blk_p_0001",
+      "node_path": [1],
+      "pm_range": { "from": 30, "to": 100 },
+      "markdown_range": { "start": 30, "end": 100 },
+      "normalized_text": "The accounting reclassification has three components, and they compound:",
+      "text_hash": "sha256:bp0001hash0000000000000000000000000000000000000000000000000000000",
+      "context_before": "changes\n\n",
+      "context_after": "\n\n"
+    },
+    {
+      "block_id": "blk_ol_0001",
+      "node_path": [2],
+      "pm_range": { "from": 102, "to": 268 },
+      "markdown_range": { "start": 102, "end": 268 },
+      "normalized_text": "1. MG reclassified as conditional liability\n2. Recoupment terms hardened to 1.4× from 1.0×\n3. Conditional advances default to lower thresholds when structural risk is claimed",
+      "text_hash": "sha256:bo0001hash0000000000000000000000000000000000000000000000000000000",
+      "context_before": "ompound:\n\n",
+      "context_after": "\n\n"
+    },
+    {
+      "block_id": "blk_p_0002",
+      "node_path": [3],
+      "pm_range": { "from": 270, "to": 332 },
+      "markdown_range": { "start": 270, "end": 332 },
+      "normalized_text": "Inside an indie deal table, the differences read like this:",
+      "text_hash": "sha256:bp0002hash0000000000000000000000000000000000000000000000000000000",
+      "context_before": "claimed\n\n",
+      "context_after": "\n\n"
+    },
+    {
+      "block_id": "blk_table_0001",
+      "node_path": [4],
+      "pm_range": { "from": 334, "to": 558 },
+      "markdown_range": { "start": 334, "end": 552 },
+      "normalized_text": "| Term | 2022 | Post-Embracer | Direction |\n|---|---|---|---|\n| MG ($K) | 200 | 150 | down |\n| Recoupment | 1.0× | 1.4× | up |\n| Conditional floor | 0.6× | 0.4× | down |",
+      "text_hash": "sha256:bt0001hash0000000000000000000000000000000000000000000000000000000",
+      "context_before": "ke this:\n\n",
+      "context_after": "\n\n"
+    },
+    {
+      "block_id": "blk_ul_0001",
+      "node_path": [5],
+      "pm_range": { "from": 560, "to": 712 },
+      "markdown_range": { "start": 554, "end": 706 },
+      "normalized_text": "- The MG drop is direct.\n- The recoupment shift is masked by 'standard practice' language.\n- The conditional-floor change is the one publishers won't volunteer.",
+      "text_hash": "sha256:bu0001hash0000000000000000000000000000000000000000000000000000000",
+      "context_before": " | down |\n\n",
+      "context_after": ""
+    }
+  ]
+}

--- a/tests/fixtures/editorial-room/v0/markdown_source_map.paragraphs.json
+++ b/tests/fixtures/editorial-room/v0/markdown_source_map.paragraphs.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "0",
+  "revision_id": "01HXYZREV001AAAAAAAAAAAAAA",
+  "content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+  "blocks": [
+    {
+      "block_id": "blk_0001",
+      "node_path": [0],
+      "pm_range": { "from": 0, "to": 268 },
+      "markdown_range": { "start": 0, "end": 266 },
+      "normalized_text": "When Embracer wrote down $2.1B last quarter, the surviving indie studios noticed a different number first: the MG. Recoupment terms that would have been 'competitive' in 2022 are now the ceiling, not the floor. The writedown itself isn't structural; the reclassification is.",
+      "text_hash": "sha256:b0001hash00000000000000000000000000000000000000000000000000000000",
+      "context_before": "",
+      "context_after": "\n\n"
+    },
+    {
+      "block_id": "blk_0002",
+      "node_path": [1],
+      "pm_range": { "from": 270, "to": 502 },
+      "markdown_range": { "start": 268, "end": 498 },
+      "normalized_text": "For the studios that signed in 2024-2025, this isn't news. They lived through the conversion. But for anyone entering negotiations now, the deal shape has hardened in ways that weren't visible when Embracer announced.",
+      "text_hash": "sha256:b0002hash00000000000000000000000000000000000000000000000000000000",
+      "context_before": "ation is.\n\n",
+      "context_after": "\n\n"
+    },
+    {
+      "block_id": "blk_0003",
+      "node_path": [2],
+      "pm_range": { "from": 504, "to": 740 },
+      "markdown_range": { "start": 500, "end": 734 },
+      "normalized_text": "The structural change has three components, and they compound. First, MG itself has been reclassified as a conditional liability under post-Embracer accounting. Second, recoupment terms have hardened.",
+      "text_hash": "sha256:b0003hash00000000000000000000000000000000000000000000000000000000",
+      "context_before": "nounced.\n\n",
+      "context_after": "\n\n"
+    },
+    {
+      "block_id": "blk_0004",
+      "node_path": [3],
+      "pm_range": { "from": 742, "to": 880 },
+      "markdown_range": { "start": 736, "end": 872 },
+      "normalized_text": "Third — and this is the piece most studios miss — conditional advances default to lower thresholds when the publisher claims structural risk.",
+      "text_hash": "sha256:b0004hash00000000000000000000000000000000000000000000000000000000",
+      "context_before": "ardened.\n\n",
+      "context_after": "\n\n"
+    },
+    {
+      "block_id": "blk_0005",
+      "node_path": [4],
+      "pm_range": { "from": 882, "to": 1010 },
+      "markdown_range": { "start": 874, "end": 1000 },
+      "normalized_text": "If you're signing in the next 18 months, assume the floor is now the ceiling. Negotiate against that, not against the 2022 numbers.",
+      "text_hash": "sha256:b0005hash00000000000000000000000000000000000000000000000000000000",
+      "context_before": "claims.\n\n",
+      "context_after": ""
+    }
+  ]
+}

--- a/tests/fixtures/editorial-room/v0/suggestions.adv_cut.json
+++ b/tests/fixtures/editorial-room/v0/suggestions.adv_cut.json
@@ -1,0 +1,178 @@
+[
+  {
+    "schema_version": "0",
+    "revision_id": "01HXYZREV001AAAAAAAAAAAAAA",
+    "target_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "source_map_refs": [
+      {
+        "block_id": "blk_0001",
+        "span_id": null,
+        "text_hash": "sha256:b0001hash00000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "markdown_range": { "start": 0, "end": 4 },
+    "anchor_quote": "When",
+    "anchor_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "anchor_context_before": "",
+    "anchor_context_after": " Embracer wrote down",
+    "replacement": null,
+    "rationale": "Trim 'When' filler — the temporal anchor 'last quarter' carries the timing.",
+    "category": "filler",
+    "source_skill": "factory_adv_cut",
+    "source_run_id": "01HXYZRUNADVCUT001AAAAAAAAA"
+  },
+  {
+    "schema_version": "0",
+    "revision_id": "01HXYZREV001AAAAAAAAAAAAAA",
+    "target_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "source_map_refs": [
+      {
+        "block_id": "blk_0002",
+        "span_id": null,
+        "text_hash": "sha256:b0002hash00000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "markdown_range": { "start": 332, "end": 369 },
+    "anchor_quote": "this isn't news. They lived through",
+    "anchor_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "anchor_context_before": "2024-2025, ",
+    "anchor_context_after": " the conversion.",
+    "replacement": "they lived it",
+    "rationale": "Tighten repetition: 'this isn't news. They lived through' compresses to 'they lived it'.",
+    "category": "repetition",
+    "source_skill": "factory_adv_cut",
+    "source_run_id": "01HXYZRUNADVCUT001AAAAAAAAA"
+  },
+  {
+    "schema_version": "0",
+    "revision_id": "01HXYZREV001AAAAAAAAAAAAAA",
+    "target_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "source_map_refs": [
+      {
+        "block_id": "blk_0003",
+        "span_id": null,
+        "text_hash": "sha256:b0003hash00000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "markdown_range": { "start": 580, "end": 624 },
+    "anchor_quote": "may have been reclassified",
+    "anchor_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "anchor_context_before": "MG itself ",
+    "anchor_context_after": " as a conditional liability",
+    "replacement": "is reclassified",
+    "rationale": "Hedge: 'may have been' weakens a claim sourced to filings; the 8-K is unambiguous.",
+    "category": "hedge",
+    "source_skill": "factory_adv_cut",
+    "source_run_id": "01HXYZRUNADVCUT001AAAAAAAAA"
+  },
+  {
+    "schema_version": "0",
+    "revision_id": "01HXYZREV001AAAAAAAAAAAAAA",
+    "target_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "source_map_refs": [
+      {
+        "block_id": "blk_0003",
+        "span_id": null,
+        "text_hash": "sha256:b0003hash00000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "markdown_range": { "start": 668, "end": 696 },
+    "anchor_quote": "have hardened",
+    "anchor_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "anchor_context_before": "recoupment terms ",
+    "anchor_context_after": ".",
+    "replacement": "tightened to 1.4×",
+    "rationale": "Weak verb 'hardened' is vague; replace with the concrete change observed in deals.",
+    "category": "weak_verb",
+    "source_skill": "factory_adv_cut",
+    "source_run_id": "01HXYZRUNADVCUT001AAAAAAAAA"
+  },
+  {
+    "schema_version": "0",
+    "revision_id": "01HXYZREV001AAAAAAAAAAAAAA",
+    "target_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "source_map_refs": [
+      {
+        "block_id": "blk_0004",
+        "span_id": null,
+        "text_hash": "sha256:b0004hash00000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "markdown_range": { "start": 814, "end": 870 },
+    "anchor_quote": "and this is the piece most studios miss",
+    "anchor_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "anchor_context_before": "Third — ",
+    "anchor_context_after": " — conditional advances",
+    "replacement": null,
+    "rationale": "Tangent: meta-commentary about what readers miss; cut without losing the substance.",
+    "category": "tangent",
+    "source_skill": "factory_adv_cut",
+    "source_run_id": "01HXYZRUNADVCUT001AAAAAAAAA"
+  },
+  {
+    "schema_version": "0",
+    "revision_id": "01HXYZREV001AAAAAAAAAAAAAA",
+    "target_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "source_map_refs": [
+      {
+        "block_id": "blk_0005",
+        "span_id": null,
+        "text_hash": "sha256:b0005hash00000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "markdown_range": { "start": 882, "end": 942 },
+    "anchor_quote": "If you're signing in the next 18 months",
+    "anchor_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "anchor_context_before": "",
+    "anchor_context_after": ", assume the floor is now",
+    "replacement": "Signing in the next 18 months",
+    "rationale": "Wording: drop the conditional 'If you're' framing; the imperative is stronger and matches voice.",
+    "category": "wording",
+    "source_skill": "factory_adv_cut",
+    "source_run_id": "01HXYZRUNADVCUT001AAAAAAAAA"
+  },
+  {
+    "schema_version": "0",
+    "revision_id": "01HXYZREV001AAAAAAAAAAAAAA",
+    "target_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "source_map_refs": [
+      {
+        "block_id": "blk_0001",
+        "span_id": null,
+        "text_hash": "sha256:b0001hash00000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "markdown_range": { "start": 0, "end": 268 },
+    "anchor_quote": "When Embracer wrote down $2.1B",
+    "anchor_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "anchor_context_before": "",
+    "anchor_context_after": " last quarter",
+    "replacement": null,
+    "rationale": "Structure: lede frames the writedown first, then pivots to the real claim (reclassification). Reorder so reclassification leads.",
+    "category": "structure",
+    "source_skill": "factory_adv_cut",
+    "source_run_id": "01HXYZRUNADVCUT001AAAAAAAAA"
+  },
+  {
+    "schema_version": "0",
+    "revision_id": "01HXYZREV001AAAAAAAAAAAAAA",
+    "target_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "source_map_refs": [
+      {
+        "block_id": "blk_0005",
+        "span_id": null,
+        "text_hash": "sha256:b0005hash00000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "markdown_range": { "start": 942, "end": 1000 },
+    "anchor_quote": "Negotiate against that, not against the 2022 numbers.",
+    "anchor_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "anchor_context_before": "now the ceiling. ",
+    "anchor_context_after": "",
+    "replacement": "Numbers — not adjectives — close the deal.",
+    "rationale": "Voice drift: trailing imperative is functional but loses the GameMakers cadence. Match signature ('numbers > adjectives').",
+    "category": "voice_drift",
+    "source_skill": "factory_adv_cut",
+    "source_run_id": "01HXYZRUNADVCUT001AAAAAAAAA"
+  }
+]

--- a/tests/fixtures/editorial-room/v0/suggestions.opus_review.json
+++ b/tests/fixtures/editorial-room/v0/suggestions.opus_review.json
@@ -1,0 +1,90 @@
+[
+  {
+    "schema_version": "0",
+    "revision_id": "01HXYZREV001AAAAAAAAAAAAAA",
+    "target_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "source_map_refs": [
+      {
+        "block_id": "blk_0001",
+        "span_id": null,
+        "text_hash": "sha256:b0001hash00000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "markdown_range": { "start": 0, "end": 268 },
+    "anchor_quote": "When Embracer wrote down $2.1B last quarter",
+    "anchor_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "anchor_context_before": "",
+    "anchor_context_after": ", the surviving",
+    "replacement": "Embracer's $2.1B writedown last quarter rewrote one line in their 8-K — and that single change reset every active publisher deal in the indie pipeline.",
+    "rationale": "Lede: open on the structural mechanism (the 8-K rewrite), not the writedown headline. The reclassification is the load-bearing claim; lead with it.",
+    "category": "structure",
+    "source_skill": "factory_opus_review",
+    "source_run_id": "01HXYZRUNOPUSREV001AAAAAAAA"
+  },
+  {
+    "schema_version": "0",
+    "revision_id": "01HXYZREV001AAAAAAAAAAAAAA",
+    "target_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "source_map_refs": [
+      {
+        "block_id": "blk_0002",
+        "span_id": null,
+        "text_hash": "sha256:b0002hash00000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "markdown_range": { "start": 268, "end": 498 },
+    "anchor_quote": "they weren't visible when Embracer announced",
+    "anchor_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "anchor_context_before": "in ways that ",
+    "anchor_context_after": ".",
+    "replacement": "the announcement buried them on page 14 of the 8-K",
+    "rationale": "Wording: 'weren't visible' is passive and vague; cite the page reference (matches voice signature 'numbers > adjectives' + 'cite primary sources').",
+    "category": "wording",
+    "source_skill": "factory_opus_review",
+    "source_run_id": "01HXYZRUNOPUSREV001AAAAAAAA"
+  },
+  {
+    "schema_version": "0",
+    "revision_id": "01HXYZREV001AAAAAAAAAAAAAA",
+    "target_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "source_map_refs": [
+      {
+        "block_id": "blk_0003",
+        "span_id": null,
+        "text_hash": "sha256:b0003hash00000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "markdown_range": { "start": 500, "end": 734 },
+    "anchor_quote": "Second, recoupment terms have hardened.",
+    "anchor_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "anchor_context_before": "accounting. ",
+    "anchor_context_after": "",
+    "replacement": "Second, recoupment hardened from 1.0× to 1.4× across the post-announcement signings I've seen.",
+    "rationale": "Voice drift: 'have hardened' is too clean for GameMakers cadence. Concretize with the observed delta and ground it in first-person observation.",
+    "category": "voice_drift",
+    "source_skill": "factory_opus_review",
+    "source_run_id": "01HXYZRUNOPUSREV001AAAAAAAA"
+  },
+  {
+    "schema_version": "0",
+    "revision_id": "01HXYZREV001AAAAAAAAAAAAAA",
+    "target_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "source_map_refs": [
+      {
+        "block_id": "blk_0004",
+        "span_id": null,
+        "text_hash": "sha256:b0004hash00000000000000000000000000000000000000000000000000000000"
+      }
+    ],
+    "markdown_range": { "start": 736, "end": 872 },
+    "anchor_quote": "when the publisher claims structural risk",
+    "anchor_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+    "anchor_context_before": "lower thresholds ",
+    "anchor_context_after": ".",
+    "replacement": "when the publisher claims structural risk — and post-Embracer, the 'structural risk' claim is now reflexive",
+    "rationale": "Wording: closing the third component without naming the reflex undersells the change. Add the second clause to land the implication.",
+    "category": "wording",
+    "source_skill": "factory_opus_review",
+    "source_run_id": "01HXYZRUNOPUSREV001AAAAAAAA"
+  }
+]


### PR DESCRIPTION
## Summary
- 4 schemas + 4 fixtures covering editor anchor + suggestion + draft-revision primitives (Batch 3 of 5).
- 57/57 tests pass (was 49, +8 from new fixtures × validation+round-trip), typecheck clean, prettier clean.

## What's in this batch
**Schemas** (`docs/contracts/editorial-room/v0/`):
- `markdown_source_map.schema.json` (+ `SourceMapBlock` + `SourceMapSpan` + helper `PmRange`/`MarkdownRange` in `#/definitions`; §5.1)
- `suggestion.schema.json` (+ `SourceMapRef` + `SuggestionCategory` in `#/definitions`; §5.3 per §10 layout)
- `talk_output_revision.schema.json` (§4.6, deferred from Batch 2; `markdown_source_map` field `$ref`s the schema above)
- `talk_output_suggestion.schema.json` (§4.8, deferred from Batch 2; cross-file `$ref`s into `suggestion.schema.json#/definitions/*`)

**Fixtures** (`tests/fixtures/editorial-room/v0/`):
- `markdown_source_map.paragraphs.json` (5 paragraphs)
- `markdown_source_map.lists_tables.json` (heading + paragraph + ordered_list + paragraph + table + bullet_list; covers §5.1 block-level coverage rule)
- `suggestions.adv_cut.json` (8 array elements across `filler`/`repetition`/`hedge`/`weak_verb`/`tangent`/`wording`/`structure`/`voice_drift`)
- `suggestions.opus_review.json` (4 array elements: `structure` + `wording`×2 + `voice_drift`)

## Test runner changes
- `FIXTURE_SCHEMA_OVERRIDES`: `suggestions.{adv_cut,opus_review}.json` (plural) → `suggestion.schema.json` (singular).
- `FIXTURES_AS_ARRAY`: same two fixtures plus the existing `point_note_blocks`.

## Cross-file `$ref` note
`talk_output_suggestion` uses absolute-URI `$ref`s into `suggestion.schema.json#/definitions/{SourceMapRef,MarkdownRange,SuggestionCategory}`. ajv resolves these via `addSchema` registration — the test harness already loads every schema in `v0/` before compiling, so cross-file `$ref`s work without extra plumbing.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test -- src/clawrocket/contracts/editorial-room.test.ts` → 57/57 pass
- [x] `npm run format:check` clean
- [ ] CI green

## Up next (Batch 4 — RPC envelope)
`run_skill.input` + `run_skill.output`, `get_run.input` + `get_run.output` (with `SkillResult` discriminated union), `errors`, `skill_context` (+ `PanelSeed`). 6 schemas, 5 fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)