### PR TITLE
feat: editorial-room v0 Batch 4 — RPC envelope

### DIFF
--- a/docs/contracts/editorial-room/v0/errors.schema.json
+++ b/docs/contracts/editorial-room/v0/errors.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/errors.schema.json",
+  "title": "Error",
+  "description": "Common error envelope for cross-repo RPCs. See EDITORIAL_ROOM_CONTRACT.md §10. Documented codes: revision_not_found (§6.5), payload_too_large (§7), schema_version_mismatch (§8), two_vendor_violation (§6.6.4). Code set is intentionally open — it evolves as new error conditions are surfaced.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["code", "message", "details"],
+  "properties": {
+    "code": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Canonical error code, e.g., 'revision_not_found'."
+    },
+    "message": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable explanation."
+    },
+    "details": {
+      "anyOf": [{ "type": "null" }, { "type": "object" }],
+      "description": "Optional structured detail map; may carry path / field / received-value / expected-value etc."
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/get_run.input.schema.json
+++ b/docs/contracts/editorial-room/v0/get_run.input.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/get_run.input.schema.json",
+  "title": "GetRunInput",
+  "description": "MCP RPC: get_run input. See EDITORIAL_ROOM_CONTRACT.md §6.3.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "run_id"],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "run_id": { "type": "string", "minLength": 1 }
+  }
+}

--- a/docs/contracts/editorial-room/v0/get_run.output.schema.json
+++ b/docs/contracts/editorial-room/v0/get_run.output.schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/get_run.output.schema.json",
+  "title": "GetRunOutput",
+  "description": "MCP RPC: get_run output. Includes the SkillResult discriminated union by `kind`. See EDITORIAL_ROOM_CONTRACT.md §6.3.",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "InlineError": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": { "type": "string", "minLength": 1 },
+        "message": { "type": "string", "minLength": 1 }
+      },
+      "description": "Inline error subset used by GetRunOutput.error. The standalone errors.schema.json envelope additionally carries `details`; this inline shape is intentionally narrower per §6.3."
+    },
+    "Progress": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["current_step", "pct"],
+      "properties": {
+        "current_step": { "type": "string", "minLength": 1 },
+        "pct": { "type": "number", "minimum": 0, "maximum": 100 }
+      }
+    },
+    "SkillResult": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "data"],
+          "properties": {
+            "kind": { "const": "score" },
+            "data": {
+              "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/score_result.schema.json"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "data"],
+          "properties": {
+            "kind": { "const": "suggestions" },
+            "data": {
+              "type": "array",
+              "items": {
+                "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/suggestion.schema.json"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "data"],
+          "properties": {
+            "kind": { "const": "proposals" },
+            "data": {
+              "type": "array",
+              "items": {
+                "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/proposal_card.schema.json"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "data"],
+          "properties": {
+            "kind": { "const": "discussion_turn" },
+            "data": {
+              "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/discussion_session.schema.json#/definitions/DiscussionTurn"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "data"],
+          "properties": {
+            "kind": { "const": "outline" },
+            "data": {
+              "type": "object",
+              "description": "Outline shape — full schema deferred per §11 ('Outline page schema'). 0p uses fixtures."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "data"],
+          "properties": {
+            "kind": { "const": "raw_text" },
+            "data": { "type": "string" }
+          }
+        }
+      ]
+    }
+  },
+  "required": [
+    "schema_version",
+    "run_id",
+    "status",
+    "progress",
+    "result",
+    "error",
+    "cost_so_far_usd",
+    "elapsed_ms",
+    "partial_provider_failures"
+  ],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "run_id": { "type": "string", "minLength": 1 },
+    "status": {
+      "type": "string",
+      "enum": ["queued", "running", "completed", "failed", "partial"]
+    },
+    "progress": {
+      "anyOf": [{ "type": "null" }, { "$ref": "#/definitions/Progress" }]
+    },
+    "result": {
+      "anyOf": [{ "type": "null" }, { "$ref": "#/definitions/SkillResult" }],
+      "description": "Present when status in {completed, partial}."
+    },
+    "error": {
+      "anyOf": [{ "type": "null" }, { "$ref": "#/definitions/InlineError" }]
+    },
+    "cost_so_far_usd": { "type": "number", "minimum": 0 },
+    "elapsed_ms": { "type": "number", "minimum": 0 },
+    "partial_provider_failures": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Names of providers that errored but didn't kill the run."
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/run_skill.input.schema.json
+++ b/docs/contracts/editorial-room/v0/run_skill.input.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/run_skill.input.schema.json",
+  "title": "RunSkillInput",
+  "description": "MCP RPC: run_skill input. See EDITORIAL_ROOM_CONTRACT.md §6.1.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "skill_slug",
+    "idempotency_key",
+    "piece_id",
+    "setup_version",
+    "target_object",
+    "target_revision_id",
+    "target_content_hash",
+    "params",
+    "agent_profile_ids",
+    "context"
+  ],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "skill_slug": {
+      "type": "string",
+      "minLength": 1,
+      "description": "e.g., 'factory_opus_review', 'factory_point_debate'."
+    },
+    "idempotency_key": {
+      "type": "string",
+      "minLength": 1,
+      "description": "sha256(user_id|agent_id|skill_slug|target_revision_id|target_content_hash|setup_version|params_canonical_json) per §6.4."
+    },
+    "piece_id": { "type": "string", "minLength": 1 },
+    "setup_version": { "type": "integer", "minimum": 1 },
+    "target_object": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "ref"],
+      "properties": {
+        "kind": { "type": "string", "minLength": 1 },
+        "ref": {
+          "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }]
+        }
+      }
+    },
+    "target_revision_id": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+      "description": "For draft skills."
+    },
+    "target_content_hash": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+      "description": "For draft skills."
+    },
+    "params": {
+      "type": "object",
+      "description": "Skill-specific params (subset of allowed fields per skill)."
+    },
+    "agent_profile_ids": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "For multi-LLM skills."
+    },
+    "context": {
+      "anyOf": [
+        { "type": "null" },
+        { "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/skill_context.schema.json" }
+      ],
+      "description": "Used by Theme/Topic propose Skills; null for everything else."
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/run_skill.output.schema.json
+++ b/docs/contracts/editorial-room/v0/run_skill.output.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/run_skill.output.schema.json",
+  "title": "RunSkillOutput",
+  "description": "MCP RPC: run_skill output. See EDITORIAL_ROOM_CONTRACT.md §6.2. Returns immediately with run_id; clawrocket polls via get_run.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "run_id", "status", "is_replay", "result_url"],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "run_id": { "type": "string", "minLength": 1, "description": "ULID." },
+    "status": {
+      "type": "string",
+      "enum": ["queued", "running", "completed", "failed"]
+    },
+    "is_replay": {
+      "type": "boolean",
+      "description": "True if this is the same run as a previous identical request (idempotency replay per §6.4)."
+    },
+    "result_url": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+      "description": "Present when status=completed; URL to fetch ScoreResult / Suggestion[] / ProposalCard[]."
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/skill_context.schema.json
+++ b/docs/contracts/editorial-room/v0/skill_context.schema.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/skill_context.schema.json",
+  "title": "SkillContext",
+  "description": "Optional context bag passed into Theme/Topic propose Skills. Carries PCP windowing and Panel Talk seeds. See EDITORIAL_ROOM_CONTRACT.md §6.1.",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "PanelSeed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "panel_id",
+        "turn_ids",
+        "talking_point_ids",
+        "dialectic_result_ids",
+        "treat_as"
+      ],
+      "properties": {
+        "panel_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Source Panel Talk panel."
+        },
+        "turn_ids": {
+          "anyOf": [
+            { "type": "null" },
+            {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            }
+          ],
+          "description": "Specific turns to consider; null = all."
+        },
+        "talking_point_ids": {
+          "anyOf": [
+            { "type": "null" },
+            {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            }
+          ],
+          "description": "Saved talking points to seed from."
+        },
+        "dialectic_result_ids": {
+          "anyOf": [
+            { "type": "null" },
+            {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            }
+          ],
+          "description": "Saved dialectic outputs to seed from."
+        },
+        "treat_as": {
+          "type": "string",
+          "enum": ["synthesis", "thesis", "antithesis", "open_question"],
+          "description": "How the Skill should weight the seed: synthesis = prefer Themes that resolve the disagreement; thesis/antithesis = take that side; open_question = open the question further."
+        }
+      }
+    }
+  },
+  "required": [
+    "pcp_window",
+    "pcp_types",
+    "panel_seed",
+    "seed_emphasis",
+    "exclude_existing_themes",
+    "exclude_existing_topics",
+    "competition_check"
+  ],
+  "properties": {
+    "pcp_window": {
+      "anyOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["from", "to"],
+          "properties": {
+            "from": { "type": "string", "format": "date-time" },
+            "to": { "type": "string", "format": "date-time" }
+          }
+        }
+      ],
+      "description": "ISO interval; null = no PCP."
+    },
+    "pcp_types": {
+      "anyOf": [
+        { "type": "null" },
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "calendar",
+              "linear",
+              "slack_dm",
+              "slack_channel",
+              "work_this_week",
+              "github_activity",
+              "asana",
+              "notion",
+              "browser_history_curated",
+              "voice_memo_transcripts",
+              "manual_notes"
+            ]
+          }
+        }
+      ],
+      "description": "Subset of the 11 PCP types; null = all available."
+    },
+    "panel_seed": {
+      "anyOf": [{ "type": "null" }, { "$ref": "#/definitions/PanelSeed" }],
+      "description": "Panel Talk seeding per 02_HERO_APPLICATIONS.md §2.7.5; null = no panel-derived seeds."
+    },
+    "seed_emphasis": {
+      "anyOf": [
+        { "type": "null" },
+        {
+          "type": "string",
+          "enum": ["pcp", "panel", "media_diet", "unmet_needs", "mixed"]
+        }
+      ],
+      "description": "null = mixed (default for Theme propose). 'panel' weights panel seeds heaviest."
+    },
+    "exclude_existing_themes": {
+      "type": "boolean",
+      "description": "Default true for theme propose."
+    },
+    "exclude_existing_topics": {
+      "anyOf": [
+        { "type": "null" },
+        {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      ],
+      "description": "Explicit topic refs to exclude."
+    },
+    "competition_check": {
+      "type": "boolean",
+      "description": "Default true; checks personas' media_diet for Topic-overlap."
+    }
+  }
+}

--- a/src/clawrocket/contracts/editorial-room.test.ts
+++ b/src/clawrocket/contracts/editorial-room.test.ts
@@ -32,6 +32,7 @@ function loadJson(path: string): unknown {
 const schemaFilenames = readdirSync(schemaDir).filter((f) =>
   f.endsWith('.schema.json'),
 );
+const SCHEMA_SET: ReadonlySet<string> = new Set(schemaFilenames);
 for (const file of schemaFilenames) {
   ajv.addSchema(loadJson(resolve(schemaDir, file)) as AnySchemaObject);
 }
@@ -49,13 +50,16 @@ function validatorFor(schemaFile: string): ValidateFunction {
   return validate;
 }
 
-// Convention: a fixture named `<base>.<variant>.json` validates against
-// `<base>.schema.json`. e.g., `theme.derived_from_pcp.json` →
-// `theme.schema.json`; `setup_state.minimal.json` → `setup_state.schema.json`.
-// A few fixtures in EDITORIAL_ROOM_CONTRACT.md §9.1 use a different shape
-// (e.g., `point_with_evidence.example.json` for the `point` schema, or
-// `point_note_blocks.example.json` plural-named for the singular schema);
-// those are listed in `FIXTURE_SCHEMA_OVERRIDES`.
+// Resolution rule for fixture → schema:
+// 1. Explicit override map (for fixtures whose name doesn't decompose to the
+//    target schema, e.g., `point_with_evidence` for `point`, or plural-named
+//    `point_note_blocks` for singular `point_note_block`).
+// 2. Longest-prefix match on the dotted stem against the actual schema set.
+//    e.g., `run_skill.input.score.json` tries `run_skill.input.schema.json`
+//    before falling back to shorter prefixes. This handles multi-dot bases
+//    like `run_skill.input` and `get_run.output` automatically.
+// 3. Fallback to first-token convention if no prefix matches; the resulting
+//    schema lookup will throw with a clear "not registered" message.
 const FIXTURE_SCHEMA_OVERRIDES: Record<string, string> = {
   'point_with_evidence.example.json': 'point.schema.json',
   'point_note_blocks.example.json': 'point_note_block.schema.json',
@@ -75,8 +79,15 @@ function schemaFileForFixture(fixtureFile: string): string {
   if (fixtureFile in FIXTURE_SCHEMA_OVERRIDES) {
     return FIXTURE_SCHEMA_OVERRIDES[fixtureFile];
   }
-  const base = fixtureFile.split('.')[0];
-  return `${base}.schema.json`;
+  const stem = fixtureFile.replace(/\.json$/, '');
+  const parts = stem.split('.');
+  for (let n = parts.length; n >= 1; n--) {
+    const candidate = `${parts.slice(0, n).join('.')}.schema.json`;
+    if (SCHEMA_SET.has(candidate)) {
+      return candidate;
+    }
+  }
+  return `${parts[0]}.schema.json`;
 }
 
 function sortKeys(value: unknown): unknown {

--- a/tests/fixtures/editorial-room/v0/get_run.output.completed.score.json
+++ b/tests/fixtures/editorial-room/v0/get_run.output.completed.score.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "0",
+  "run_id": "01HXYZRUNSCR001AAAAAAAAAAAA",
+  "status": "completed",
+  "progress": null,
+  "result": {
+    "kind": "score",
+    "data": {
+      "schema_version": "0",
+      "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default",
+      "aggregate_score": 7.8,
+      "score_scale": [0, 10],
+      "score_direction": "higher_better",
+      "per_dimension": {
+        "specificity": 8.2,
+        "disputability": 7.5,
+        "novelty": 8.0,
+        "voice_match": 7.6
+      },
+      "per_persona": {
+        "persona/ankit-indie-dev": 9.0,
+        "persona/ravi-studio-lead": 9.0,
+        "persona/mei-publisher": 7.0
+      },
+      "confidence": "absolute",
+      "notes": [
+        "All hard gates pass.",
+        "SSR likelihood mean across primary personas: 0.78."
+      ],
+      "per_scorer_breakdown": [
+        {
+          "scorer_id": "rubric_judge_opus",
+          "role": "score",
+          "passed_gate": null,
+          "raw_score": 7.6,
+          "scale": [0, 10],
+          "notes": []
+        },
+        {
+          "scorer_id": "ssr_core_local",
+          "role": "score",
+          "passed_gate": null,
+          "raw_score": 8.0,
+          "scale": [0, 10],
+          "notes": []
+        },
+        {
+          "scorer_id": "specificity_gate",
+          "role": "gate",
+          "passed_gate": true,
+          "raw_score": null,
+          "scale": [0, 10],
+          "notes": []
+        }
+      ],
+      "metadata": {
+        "cost_usd": 0.064,
+        "latency_ms": 11420,
+        "models_used": ["claude-opus-4-7", "claude-sonnet-4-6"]
+      }
+    }
+  },
+  "error": null,
+  "cost_so_far_usd": 0.064,
+  "elapsed_ms": 11420,
+  "partial_provider_failures": []
+}

--- a/tests/fixtures/editorial-room/v0/get_run.output.completed.suggestions.json
+++ b/tests/fixtures/editorial-room/v0/get_run.output.completed.suggestions.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "0",
+  "run_id": "01HXYZRUNADVCUT001AAAAAAAAA",
+  "status": "completed",
+  "progress": null,
+  "result": {
+    "kind": "suggestions",
+    "data": [
+      {
+        "schema_version": "0",
+        "revision_id": "01HXYZREV001AAAAAAAAAAAAAA",
+        "target_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+        "source_map_refs": [
+          {
+            "block_id": "blk_0001",
+            "span_id": null,
+            "text_hash": "sha256:b0001hash00000000000000000000000000000000000000000000000000000000"
+          }
+        ],
+        "markdown_range": { "start": 0, "end": 4 },
+        "anchor_quote": "When",
+        "anchor_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+        "anchor_context_before": "",
+        "anchor_context_after": " Embracer wrote down",
+        "replacement": null,
+        "rationale": "Trim 'When' filler — the temporal anchor 'last quarter' carries the timing.",
+        "category": "filler",
+        "source_skill": "factory_adv_cut",
+        "source_run_id": "01HXYZRUNADVCUT001AAAAAAAAA"
+      },
+      {
+        "schema_version": "0",
+        "revision_id": "01HXYZREV001AAAAAAAAAAAAAA",
+        "target_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+        "source_map_refs": [
+          {
+            "block_id": "blk_0003",
+            "span_id": null,
+            "text_hash": "sha256:b0003hash00000000000000000000000000000000000000000000000000000000"
+          }
+        ],
+        "markdown_range": { "start": 580, "end": 624 },
+        "anchor_quote": "may have been reclassified",
+        "anchor_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+        "anchor_context_before": "MG itself ",
+        "anchor_context_after": " as a conditional liability",
+        "replacement": "is reclassified",
+        "rationale": "Hedge: 'may have been' weakens a claim sourced to filings; the 8-K is unambiguous.",
+        "category": "hedge",
+        "source_skill": "factory_adv_cut",
+        "source_run_id": "01HXYZRUNADVCUT001AAAAAAAAA"
+      }
+    ]
+  },
+  "error": null,
+  "cost_so_far_usd": 0.04,
+  "elapsed_ms": 7890,
+  "partial_provider_failures": []
+}

--- a/tests/fixtures/editorial-room/v0/get_run.output.partial.json
+++ b/tests/fixtures/editorial-room/v0/get_run.output.partial.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "0",
+  "run_id": "01HXYZRUNPARTIAL001AAAAAAAA",
+  "status": "partial",
+  "progress": null,
+  "result": {
+    "kind": "discussion_turn",
+    "data": {
+      "id": "01HXYZTURN001AAAAAAAAAAAAAA",
+      "user_message": "Where should the angle land — deal-shape or accounting?",
+      "initiator": "user",
+      "initiated_action": null,
+      "agent_responses": [
+        {
+          "agent_profile_id": "agent/argus",
+          "provider_id": "anthropic",
+          "model_id": "claude-opus-4-7",
+          "text": "The accounting reclassification is the load-bearing piece — without it the deal shape doesn't lock. Lead with the reclassification.",
+          "citations": [],
+          "cost_usd": 0.018,
+          "latency_ms": 4210,
+          "status": "completed",
+          "error_message": null
+        },
+        {
+          "agent_profile_id": "agent/scribe",
+          "provider_id": "anthropic",
+          "model_id": "claude-sonnet-4-6",
+          "text": "Pushing back: a person needs to land in §2. The reclassification is correct but bloodless. Use the Annapurna note.",
+          "citations": [],
+          "cost_usd": 0.006,
+          "latency_ms": 3120,
+          "status": "completed",
+          "error_message": null
+        },
+        {
+          "agent_profile_id": "agent/mei-cohort",
+          "provider_id": "google",
+          "model_id": "gemini-2.5-pro",
+          "text": "",
+          "citations": [],
+          "cost_usd": 0,
+          "latency_ms": 9999,
+          "status": "timed_out",
+          "error_message": "provider timeout after 10000ms"
+        }
+      ],
+      "proposals": [],
+      "retained_for_session": false,
+      "cost_usd": 0.024,
+      "latency_ms": 10100,
+      "partial_provider_failures": ["google"],
+      "created_at": "2026-04-30T11:42:00.000Z"
+    }
+  },
+  "error": null,
+  "cost_so_far_usd": 0.024,
+  "elapsed_ms": 10100,
+  "partial_provider_failures": ["google"]
+}

--- a/tests/fixtures/editorial-room/v0/run_skill.input.adv_cut.json
+++ b/tests/fixtures/editorial-room/v0/run_skill.input.adv_cut.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "0",
+  "skill_slug": "factory_adv_cut",
+  "idempotency_key": "sha256:idemkey002run_skill_adv_cut00000000000000000000000000000000000",
+  "piece_id": "piece_01HXYZ789ABC",
+  "setup_version": 7,
+  "target_object": {
+    "kind": "draft",
+    "ref": "draft/01HXYZ789ABC"
+  },
+  "target_revision_id": "01HXYZREV001AAAAAAAAAAAAAA",
+  "target_content_hash": "sha256:rev001aaa00000000000000000000000000000000000000000000000000000000",
+  "params": {
+    "max_suggestions": 30,
+    "categories": [
+      "filler",
+      "repetition",
+      "hedge",
+      "weak_verb",
+      "tangent",
+      "wording",
+      "structure",
+      "voice_drift"
+    ]
+  },
+  "agent_profile_ids": ["agent/argus"],
+  "context": null
+}

--- a/tests/fixtures/editorial-room/v0/run_skill.input.score.json
+++ b/tests/fixtures/editorial-room/v0/run_skill.input.score.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "0",
+  "skill_slug": "factory_score",
+  "idempotency_key": "sha256:idemkey001run_skill_score00000000000000000000000000000000000000",
+  "piece_id": "piece_01HXYZ789ABC",
+  "setup_version": 7,
+  "target_object": {
+    "kind": "topic",
+    "ref": "topic/ai-impact-on-game-dev-how-embracers-writedown-changed-indie-publishing-terms"
+  },
+  "target_revision_id": null,
+  "target_content_hash": "sha256:topic001hash000000000000000000000000000000000000000000000000000",
+  "params": {
+    "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default",
+    "selected_persona_slugs": [
+      "persona/ankit-indie-dev",
+      "persona/ravi-studio-lead",
+      "persona/mei-publisher"
+    ]
+  },
+  "agent_profile_ids": [],
+  "context": null
+}


### PR DESCRIPTION
## Summary
- 6 schemas + 5 fixtures covering the cross-repo MCP RPC contract (Batch 4 of 5).
- 67/67 tests pass (was 57, +10 from new fixtures × validation+round-trip), typecheck clean, prettier clean.

## What's in this batch
**Schemas** (`docs/contracts/editorial-room/v0/`):
- `errors.schema.json` — common error envelope `{ code, message, details }` (§10)
- `skill_context.schema.json` — `SkillContext` + `PanelSeed` in `#/definitions` (§6.1)
- `run_skill.input.schema.json` (§6.1; `context` field `$ref`s skill_context)
- `run_skill.output.schema.json` (§6.2)
- `get_run.input.schema.json` (§6.3)
- `get_run.output.schema.json` (§6.3) with the **`SkillResult` discriminated union** (`oneOf` by `kind` ∈ `{score, suggestions, proposals, discussion_turn, outline, raw_text}`; cross-file `$ref`s to `score_result`, `suggestion[]`, `proposal_card[]`, `discussion_session#/definitions/DiscussionTurn`). Inline error subset `{ code, message }` per §6.3 (narrower than the standalone errors envelope).

**Fixtures** (`tests/fixtures/editorial-room/v0/`):
- `run_skill.input.score.json`
- `run_skill.input.adv_cut.json`
- `get_run.output.completed.score.json` (`kind: score`)
- `get_run.output.completed.suggestions.json` (`kind: suggestions`, 2 elements)
- `get_run.output.partial.json` (`kind: discussion_turn`, `status: partial`, with `partial_provider_failures: ["google"]`)

## Test runner change
\`schemaFileForFixture()\` now does **longest-prefix matching** against the actual schema set: `run_skill.input.score.json` walks from `run_skill.input.score.schema.json` (no match) to `run_skill.input.schema.json` (match). Removes the need for explicit overrides on multi-dot bases. Manual overrides retained only for fixtures whose name doesn't decompose to a registered schema (`point_with_evidence`, `point_note_blocks`, `suggestions.{adv_cut,opus_review}`).

## Notable design choices
- **Outline's `data` field** in `SkillResult` is `type: object` placeholder per §11 ('Outline page schema' deferred until authoring patterns settle).
- The standalone `errors.schema.json` carries `details` per §10; the inline `error` in `get_run.output.error` is the narrower `{ code, message }` shape per §6.3 — kept distinct to match the contract literally.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test -- src/clawrocket/contracts/editorial-room.test.ts` → 67/67 pass
- [x] `npm run format:check` clean
- [ ] CI green

## Up next (Batch 5 — final, optimization loop)
\`optimization_round\` (+ \`TopKCandidate\` + \`RubricScore\` + \`SsrPersonaResult\` + \`CounterAudienceResult\`), \`optimization_config\` (+ \`OptimizationGates\` + \`ObjectiveWeights\`), \`run_optimization.{input,output}\`, \`get_optimization_round.{input,output}\` (+ \`OptimizationProgress\`), \`cancel_optimization_round.{input,output}\`. 8 schemas, 8 fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)