### PR TITLE
feat: editorial-room v0 Batch 5 — optimization loop (final)

### DIFF
--- a/docs/contracts/editorial-room/v0/cancel_optimization_round.input.schema.json
+++ b/docs/contracts/editorial-room/v0/cancel_optimization_round.input.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/cancel_optimization_round.input.schema.json",
+  "title": "CancelOptimizationRoundInput",
+  "description": "MCP RPC: cancel_optimization_round input. See EDITORIAL_ROOM_CONTRACT.md §6.7.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "round_id", "reason"],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "round_id": { "type": "string", "minLength": 1 },
+    "reason": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }]
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/cancel_optimization_round.output.schema.json
+++ b/docs/contracts/editorial-room/v0/cancel_optimization_round.output.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/cancel_optimization_round.output.schema.json",
+  "title": "CancelOptimizationRoundOutput",
+  "description": "MCP RPC: cancel_optimization_round output. Cancellation completes the current candidate's gates; in-flight LLM calls are NOT aborted (already paid for). acceptable_pool_ids preserved; partial_top_k populated. See EDITORIAL_ROOM_CONTRACT.md §6.7.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "round_id",
+    "status",
+    "acceptable_pool_preserved",
+    "partial_top_k"
+  ],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "round_id": { "type": "string", "minLength": 1 },
+    "status": { "const": "cancelled" },
+    "acceptable_pool_preserved": {
+      "type": "boolean",
+      "description": "Always true; cancellation never throws away accepted candidates."
+    },
+    "partial_top_k": {
+      "type": "array",
+      "items": {
+        "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/optimization_round.schema.json#/definitions/TopKCandidate"
+      },
+      "description": "Best-so-far top-K, ranked from accepted pool."
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/get_optimization_round.input.schema.json
+++ b/docs/contracts/editorial-room/v0/get_optimization_round.input.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/get_optimization_round.input.schema.json",
+  "title": "GetOptimizationRoundInput",
+  "description": "MCP RPC: get_optimization_round input. See EDITORIAL_ROOM_CONTRACT.md §6.7.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "round_id"],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "round_id": { "type": "string", "minLength": 1 }
+  }
+}

--- a/docs/contracts/editorial-room/v0/get_optimization_round.output.schema.json
+++ b/docs/contracts/editorial-room/v0/get_optimization_round.output.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/get_optimization_round.output.schema.json",
+  "title": "GetOptimizationRoundOutput",
+  "description": "MCP RPC: get_optimization_round output. Includes the round + live progress while running. See EDITORIAL_ROOM_CONTRACT.md §6.7.",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "OptimizationProgress": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "current_iteration",
+        "candidates_generated_this_iter",
+        "candidates_accepted_so_far",
+        "cost_so_far_usd",
+        "cost_projected_usd",
+        "current_phase",
+        "partial_provider_failures"
+      ],
+      "properties": {
+        "current_iteration": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-indexed."
+        },
+        "candidates_generated_this_iter": { "type": "integer", "minimum": 0 },
+        "candidates_accepted_so_far": { "type": "integer", "minimum": 0 },
+        "cost_so_far_usd": { "type": "number", "minimum": 0 },
+        "cost_projected_usd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Updated estimate based on rate."
+        },
+        "current_phase": {
+          "type": "string",
+          "enum": [
+            "generating",
+            "rubric_judging",
+            "ssr_scoring",
+            "counter_audience",
+            "ranking",
+            "merging_subloops"
+          ]
+        },
+        "partial_provider_failures": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  },
+  "required": ["schema_version", "round", "progress"],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "round": {
+      "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/optimization_round.schema.json"
+    },
+    "progress": {
+      "anyOf": [
+        { "type": "null" },
+        { "$ref": "#/definitions/OptimizationProgress" }
+      ],
+      "description": "Populated while status=running."
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/optimization_config.schema.json
+++ b/docs/contracts/editorial-room/v0/optimization_config.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/optimization_config.schema.json",
+  "title": "OptimizationConfig",
+  "description": "Configuration for an optimization round. See EDITORIAL_ROOM_CONTRACT.md §6.6.1.",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "OptimizationGates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "rubric_min",
+        "ssr_likelihood_min",
+        "diversity_min",
+        "slop_penalty_max",
+        "ssr_value_min"
+      ],
+      "properties": {
+        "rubric_min": {
+          "type": "object",
+          "additionalProperties": { "type": "number" },
+          "description": "Per-axis hard gate; e.g., { specificity: 3, disputability: 3 }."
+        },
+        "ssr_likelihood_min": {
+          "type": "number",
+          "description": "Per-primary-persona hard gate; default 3.5 for Topics."
+        },
+        "diversity_min": {
+          "type": "number",
+          "description": "Cosine distance from acceptable pool; default 0.4."
+        },
+        "slop_penalty_max": {
+          "type": "number",
+          "description": "Max acceptable slop_penalty for Drafts; default 5.0."
+        },
+        "ssr_value_min": {
+          "anyOf": [{ "type": "null" }, { "type": "number" }],
+          "description": "Per-primary-persona; null for Theme/Topic."
+        }
+      }
+    },
+    "ObjectiveWeights": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ssr_likelihood_mean",
+        "ssr_value_mean",
+        "rubric_composite_mean",
+        "cohort_coverage",
+        "cohort_underservice_penalty",
+        "novelty_bonus"
+      ],
+      "properties": {
+        "ssr_likelihood_mean": { "type": "number", "description": "Typically 0.35." },
+        "ssr_value_mean": { "type": "number", "description": "Typically 0.20." },
+        "rubric_composite_mean": { "type": "number", "description": "Typically 0.30." },
+        "cohort_coverage": { "type": "number", "description": "Typically 0.05." },
+        "cohort_underservice_penalty": {
+          "type": "number",
+          "description": "Typically -0.05 (negative)."
+        },
+        "novelty_bonus": { "type": "number", "description": "Typically 0.15." }
+      }
+    }
+  },
+  "required": [
+    "schema_version",
+    "persona_slugs",
+    "n_candidates_per_iter",
+    "n_iterations",
+    "n_winners_carried",
+    "n_ssr_samples",
+    "top_k_returned",
+    "diversity_strategy",
+    "diversity_min_distance",
+    "cohort_targeted_subloops",
+    "contrast_mutation_fraction",
+    "gates",
+    "objective_weights",
+    "budget_usd",
+    "wallclock_cap_ms",
+    "convergence_min_iters_for_signal",
+    "convergence_delta_threshold",
+    "context",
+    "voice_slug",
+    "scoring_pipeline_slug"
+  ],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "persona_slugs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Primary personas. Defaults to SetupState.audience_persona_slugs for the parent Piece; explicit override here is recorded in OptimizationRound.config but does NOT mutate SetupState."
+    },
+    "n_candidates_per_iter": { "type": "integer", "minimum": 1 },
+    "n_iterations": { "type": "integer", "minimum": 1 },
+    "n_winners_carried": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Top-K winners that survive into iter 2+ (typically 5)."
+    },
+    "n_ssr_samples": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "SSR samples per (persona, candidate); default 8."
+    },
+    "top_k_returned": { "type": "integer", "minimum": 1 },
+    "diversity_strategy": {
+      "type": "string",
+      "enum": ["minimal", "default", "aggressive"]
+    },
+    "diversity_min_distance": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Cosine distance threshold; default 0.4."
+    },
+    "cohort_targeted_subloops": {
+      "type": "boolean",
+      "description": "Run separate sub-loop per persona cohort."
+    },
+    "contrast_mutation_fraction": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Fraction of mutations using explicit-contrast prompts (default 0.4)."
+    },
+    "gates": { "$ref": "#/definitions/OptimizationGates" },
+    "objective_weights": { "$ref": "#/definitions/ObjectiveWeights" },
+    "budget_usd": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Hard cap; round aborts if projected > budget."
+    },
+    "wallclock_cap_ms": {
+      "anyOf": [{ "type": "null" }, { "type": "number", "minimum": 0 }],
+      "description": "Optional; null = no wallclock cap."
+    },
+    "convergence_min_iters_for_signal": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Default 2."
+    },
+    "convergence_delta_threshold": {
+      "type": "number",
+      "description": "Default 0.05; min improvement to keep iterating."
+    },
+    "context": {
+      "anyOf": [
+        { "type": "null" },
+        { "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/skill_context.schema.json" }
+      ],
+      "description": "For Theme/Topic; null otherwise."
+    },
+    "voice_slug": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Resolved from setup_state when piece_id is set; explicit when piece_id is null (e.g., for Theme search)."
+    },
+    "scoring_pipeline_slug": { "type": "string", "minLength": 1 }
+  }
+}

--- a/docs/contracts/editorial-room/v0/optimization_round.schema.json
+++ b/docs/contracts/editorial-room/v0/optimization_round.schema.json
@@ -1,0 +1,316 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/optimization_round.schema.json",
+  "title": "OptimizationRound",
+  "description": "Cached record of one optimization round. See EDITORIAL_ROOM_CONTRACT.md §4.7. NOTE: §4.7 also defines OptimizationTrial (per-candidate audit log) but §10 doesn't list a separate trial schema; deferred to a future batch when fixture/usage emerges.",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "RubricScore": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "axis",
+        "score",
+        "scale",
+        "gap",
+        "fix",
+        "weakest_quote",
+        "note"
+      ],
+      "properties": {
+        "axis": { "type": "string", "minLength": 1 },
+        "score": { "type": "number", "description": "Typically 1-5." },
+        "scale": {
+          "type": "array",
+          "items": [{ "type": "number" }, { "type": "number" }],
+          "minItems": 2,
+          "maxItems": 2,
+          "additionalItems": false
+        },
+        "gap": {
+          "anyOf": [{ "type": "null" }, { "type": "string" }],
+          "description": "What's missing."
+        },
+        "fix": {
+          "anyOf": [{ "type": "null" }, { "type": "string" }],
+          "description": "How to improve."
+        },
+        "weakest_quote": {
+          "anyOf": [{ "type": "null" }, { "type": "string" }],
+          "description": "For Draft-level scoring."
+        },
+        "note": {
+          "anyOf": [{ "type": "null" }, { "type": "string" }]
+        }
+      }
+    },
+    "SsrPersonaResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "persona_slug",
+        "family",
+        "pmf",
+        "scale",
+        "mean",
+        "confidence",
+        "reasoning_quote"
+      ],
+      "properties": {
+        "persona_slug": { "type": "string", "minLength": 1 },
+        "family": {
+          "type": "string",
+          "minLength": 1,
+          "description": "'likelihood' | 'value' | 'appeal' | 'satisfaction' | …"
+        },
+        "pmf": {
+          "type": "array",
+          "items": { "type": "number", "minimum": 0, "maximum": 1 },
+          "description": "Probability mass function over the Likert scale."
+        },
+        "scale": {
+          "type": "array",
+          "items": [{ "type": "number" }, { "type": "number" }],
+          "minItems": 2,
+          "maxItems": 2,
+          "additionalItems": false,
+          "description": "e.g., [1, 5]."
+        },
+        "mean": { "type": "number" },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Normalized Shannon entropy [0,1]."
+        },
+        "reasoning_quote": {
+          "anyOf": [{ "type": "null" }, { "type": "string" }],
+          "description": "Synthetic free-text response."
+        }
+      }
+    },
+    "CounterAudienceObjection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["quoted_line", "objection", "severity"],
+      "properties": {
+        "quoted_line": {
+          "anyOf": [{ "type": "null" }, { "type": "string" }],
+          "description": "Line in the draft being objected to."
+        },
+        "objection": { "type": "string", "minLength": 1 },
+        "severity": {
+          "type": "string",
+          "enum": ["minor", "moderate", "major"]
+        }
+      }
+    },
+    "CounterAudienceResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["persona_slug", "objections"],
+      "properties": {
+        "persona_slug": { "type": "string", "minLength": 1 },
+        "objections": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/CounterAudienceObjection" }
+        }
+      }
+    },
+    "TopKCandidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "rank",
+        "rank_basis",
+        "candidate_id",
+        "candidate_kind",
+        "rubric_scores",
+        "ssr_distributions",
+        "counter_audience",
+        "comparable_history",
+        "diversity_position",
+        "composite_score",
+        "novelty_bonus",
+        "cohort_coverage_score"
+      ],
+      "properties": {
+        "rank": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-indexed."
+        },
+        "rank_basis": {
+          "type": "string",
+          "enum": ["composite", "cohort_reservation", "novelty_reservation"]
+        },
+        "candidate_id": { "type": "string", "minLength": 1 },
+        "candidate_kind": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Matches OptimizationRound.target_kind."
+        },
+        "rubric_scores": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/definitions/RubricScore" },
+          "description": "Keyed by axis."
+        },
+        "ssr_distributions": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/SsrPersonaResult" }
+        },
+        "counter_audience": {
+          "anyOf": [
+            { "type": "null" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/definitions/CounterAudienceResult" }
+            }
+          ],
+          "description": "For Drafts only; null otherwise."
+        },
+        "comparable_history": {
+          "anyOf": [{ "type": "null" }, { "type": "string" }],
+          "description": "Human-readable comparison ('scores higher than 73% of...')."
+        },
+        "diversity_position": {
+          "anyOf": [{ "type": "null" }, { "type": "string" }],
+          "description": "'most novel of top-K' / 'primary cohort' / etc."
+        },
+        "composite_score": { "type": "number" },
+        "novelty_bonus": { "type": "number" },
+        "cohort_coverage_score": { "type": "number" }
+      }
+    }
+  },
+  "required": [
+    "id",
+    "schema_version",
+    "piece_id",
+    "setup_version",
+    "target_kind",
+    "parent_object",
+    "config",
+    "status",
+    "convergence_reason",
+    "started_at",
+    "completed_at",
+    "candidates_generated",
+    "candidates_accepted",
+    "acceptable_pool_ids",
+    "top_k",
+    "reject_reason_histogram",
+    "cost_estimate_usd",
+    "cost_actual_usd",
+    "wallclock_actual_ms",
+    "triggered_by_user_id",
+    "source_run_ids"
+  ],
+  "properties": {
+    "id": { "type": "string", "minLength": 1, "description": "ULID." },
+    "schema_version": { "const": "0" },
+    "piece_id": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+      "description": "Null for Theme-search rounds (no parent Piece)."
+    },
+    "setup_version": {
+      "anyOf": [{ "type": "null" }, { "type": "integer", "minimum": 1 }]
+    },
+    "target_kind": {
+      "type": "string",
+      "enum": [
+        "theme",
+        "topic",
+        "point",
+        "outline",
+        "draft_polish",
+        "draft_fullsearch"
+      ]
+    },
+    "parent_object": {
+      "anyOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "ref"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "ref": {
+              "anyOf": [
+                { "type": "null" },
+                { "type": "string", "minLength": 1 }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "config": {
+      "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/optimization_config.schema.json"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "queued",
+        "running",
+        "completed",
+        "failed",
+        "cancelled",
+        "partial"
+      ]
+    },
+    "convergence_reason": {
+      "anyOf": [
+        { "type": "null" },
+        {
+          "type": "string",
+          "enum": [
+            "budget_hit",
+            "iteration_max",
+            "wallclock_cap",
+            "convergence_signal",
+            "user_stopped",
+            "empty_acceptable_pool",
+            "errored"
+          ]
+        }
+      ]
+    },
+    "started_at": { "type": "string", "format": "date-time" },
+    "completed_at": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "format": "date-time" }]
+    },
+    "candidates_generated": { "type": "integer", "minimum": 0 },
+    "candidates_accepted": { "type": "integer", "minimum": 0 },
+    "acceptable_pool_ids": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "ULIDs of all accepted candidates (full pool)."
+    },
+    "top_k": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/TopKCandidate" },
+      "description": "Ranked top-K returned to user."
+    },
+    "reject_reason_histogram": {
+      "type": "object",
+      "additionalProperties": { "type": "integer", "minimum": 0 },
+      "description": "e.g., { 'specificity_lt_3': 18, 'diversity_lt_0_4': 12 }."
+    },
+    "cost_estimate_usd": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Pre-launch estimate."
+    },
+    "cost_actual_usd": { "type": "number", "minimum": 0 },
+    "wallclock_actual_ms": { "type": "number", "minimum": 0 },
+    "triggered_by_user_id": { "type": "string", "minLength": 1 },
+    "source_run_ids": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Run_ids of every internal Skill call."
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/run_optimization.input.schema.json
+++ b/docs/contracts/editorial-room/v0/run_optimization.input.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/run_optimization.input.schema.json",
+  "title": "RunOptimizationInput",
+  "description": "MCP RPC: run_optimization input. Wraps an OptimizationConfig with target identity. See EDITORIAL_ROOM_CONTRACT.md §6.6.1.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "idempotency_key",
+    "piece_id",
+    "setup_version",
+    "target_kind",
+    "parent_object",
+    "config"
+  ],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "idempotency_key": {
+      "type": "string",
+      "minLength": 1,
+      "description": "sha256(user_id|target_kind|parent_object_ref|setup_version|config_canonical_json) per §6.6.3."
+    },
+    "piece_id": {
+      "anyOf": [{ "type": "null" }, { "type": "string", "minLength": 1 }],
+      "description": "Null for Theme-search rounds."
+    },
+    "setup_version": {
+      "anyOf": [{ "type": "null" }, { "type": "integer", "minimum": 1 }]
+    },
+    "target_kind": {
+      "type": "string",
+      "enum": [
+        "theme",
+        "topic",
+        "point",
+        "outline",
+        "draft_polish",
+        "draft_fullsearch"
+      ]
+    },
+    "parent_object": {
+      "anyOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "ref"],
+          "properties": {
+            "kind": { "type": "string", "minLength": 1 },
+            "ref": {
+              "anyOf": [
+                { "type": "null" },
+                { "type": "string", "minLength": 1 }
+              ]
+            }
+          }
+        }
+      ],
+      "description": "e.g., { kind: 'theme', ref: 'theme/...' } for Topic optimization. Null for top-level Theme search."
+    },
+    "config": {
+      "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/optimization_config.schema.json"
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/run_optimization.output.schema.json
+++ b/docs/contracts/editorial-room/v0/run_optimization.output.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/run_optimization.output.schema.json",
+  "title": "RunOptimizationOutput",
+  "description": "MCP RPC: run_optimization output. Returns immediately with round_id; clawrocket polls via get_optimization_round. See EDITORIAL_ROOM_CONTRACT.md §6.6.2.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "round_id",
+    "status",
+    "is_replay",
+    "cost_estimate_usd",
+    "cost_estimate_p10",
+    "cost_estimate_p90",
+    "wallclock_estimate_ms",
+    "requires_double_confirm"
+  ],
+  "properties": {
+    "schema_version": { "const": "0" },
+    "round_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "ULID of the OptimizationRound row in clawrocket."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["queued", "running"]
+    },
+    "is_replay": {
+      "type": "boolean",
+      "description": "True if same idempotency key already in flight per §6.6.3."
+    },
+    "cost_estimate_usd": { "type": "number", "minimum": 0 },
+    "cost_estimate_p10": {
+      "type": "number",
+      "minimum": 0,
+      "description": "10th percentile of past similar runs."
+    },
+    "cost_estimate_p90": {
+      "type": "number",
+      "minimum": 0,
+      "description": "90th percentile."
+    },
+    "wallclock_estimate_ms": { "type": "number", "minimum": 0 },
+    "requires_double_confirm": {
+      "type": "boolean",
+      "description": "True ONLY for target_kind = 'draft_fullsearch' per §6.6.2."
+    }
+  }
+}

--- a/docs/contracts/editorial-room/v0/top_k_candidate.schema.json
+++ b/docs/contracts/editorial-room/v0/top_k_candidate.schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://clawrocket.dev/contracts/editorial-room/v0/top_k_candidate.schema.json",
+  "title": "TopKCandidate (wrapper)",
+  "description": "Standalone wrapper for fixture validation only. Canonical definition lives in optimization_round.schema.json#/definitions/TopKCandidate. NOTE: §10 of EDITORIAL_ROOM_CONTRACT.md doesn't list this schema explicitly, but §9.1 lists `top_k_candidate.full.json` as a fixture and per-fixture validation requires a self-addressable schema. Shipped as a sibling wrapper to keep the contract self-consistent.",
+  "$ref": "https://clawrocket.dev/contracts/editorial-room/v0/optimization_round.schema.json#/definitions/TopKCandidate"
+}

--- a/tests/fixtures/editorial-room/v0/get_optimization_round.output.running.json
+++ b/tests/fixtures/editorial-room/v0/get_optimization_round.output.running.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "0",
+  "round": {
+    "id": "01HXYZROUND003CCCCCCCCCCCC",
+    "schema_version": "0",
+    "piece_id": "piece_01HXYZ789ABC",
+    "setup_version": 7,
+    "target_kind": "topic",
+    "parent_object": {
+      "kind": "theme",
+      "ref": "theme/ai-impact-on-game-dev"
+    },
+    "config": {
+      "schema_version": "0",
+      "persona_slugs": [
+        "persona/ankit-indie-dev",
+        "persona/ravi-studio-lead",
+        "persona/mei-publisher"
+      ],
+      "n_candidates_per_iter": 8,
+      "n_iterations": 3,
+      "n_winners_carried": 5,
+      "n_ssr_samples": 8,
+      "top_k_returned": 5,
+      "diversity_strategy": "default",
+      "diversity_min_distance": 0.4,
+      "cohort_targeted_subloops": false,
+      "contrast_mutation_fraction": 0.4,
+      "gates": {
+        "rubric_min": { "specificity": 3, "disputability": 3 },
+        "ssr_likelihood_min": 3.5,
+        "diversity_min": 0.4,
+        "slop_penalty_max": 5.0,
+        "ssr_value_min": null
+      },
+      "objective_weights": {
+        "ssr_likelihood_mean": 0.35,
+        "ssr_value_mean": 0.2,
+        "rubric_composite_mean": 0.3,
+        "cohort_coverage": 0.05,
+        "cohort_underservice_penalty": -0.05,
+        "novelty_bonus": 0.15
+      },
+      "budget_usd": 5.0,
+      "wallclock_cap_ms": null,
+      "convergence_min_iters_for_signal": 2,
+      "convergence_delta_threshold": 0.05,
+      "context": null,
+      "voice_slug": "voice/gamemakers-2026",
+      "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default"
+    },
+    "status": "running",
+    "convergence_reason": null,
+    "started_at": "2026-04-30T13:00:00.000Z",
+    "completed_at": null,
+    "candidates_generated": 12,
+    "candidates_accepted": 7,
+    "acceptable_pool_ids": [
+      "01HXYZCAND030AAAAAAAAAAAAA",
+      "01HXYZCAND031BBBBBBBBBBBBB",
+      "01HXYZCAND032CCCCCCCCCCCCC",
+      "01HXYZCAND033DDDDDDDDDDDDD",
+      "01HXYZCAND034EEEEEEEEEEEEE",
+      "01HXYZCAND035FFFFFFFFFFFFF",
+      "01HXYZCAND036GGGGGGGGGGGGG"
+    ],
+    "top_k": [],
+    "reject_reason_histogram": {
+      "specificity_lt_3": 3,
+      "diversity_lt_0_4": 2
+    },
+    "cost_estimate_usd": 4.2,
+    "cost_actual_usd": 1.92,
+    "wallclock_actual_ms": 88420,
+    "triggered_by_user_id": "user_local_joseph",
+    "source_run_ids": [
+      "01HXYZRUNGEN030AAAAAAAAAAA",
+      "01HXYZRUNGEN031BBBBBBBBBBB"
+    ]
+  },
+  "progress": {
+    "current_iteration": 2,
+    "candidates_generated_this_iter": 4,
+    "candidates_accepted_so_far": 7,
+    "cost_so_far_usd": 1.92,
+    "cost_projected_usd": 3.95,
+    "current_phase": "ssr_scoring",
+    "partial_provider_failures": []
+  }
+}

--- a/tests/fixtures/editorial-room/v0/optimization_config.draft_fullsearch.json
+++ b/tests/fixtures/editorial-room/v0/optimization_config.draft_fullsearch.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "0",
+  "persona_slugs": [
+    "persona/ankit-indie-dev",
+    "persona/ravi-studio-lead",
+    "persona/mei-publisher"
+  ],
+  "n_candidates_per_iter": 12,
+  "n_iterations": 5,
+  "n_winners_carried": 5,
+  "n_ssr_samples": 12,
+  "top_k_returned": 3,
+  "diversity_strategy": "aggressive",
+  "diversity_min_distance": 0.5,
+  "cohort_targeted_subloops": true,
+  "contrast_mutation_fraction": 0.5,
+  "gates": {
+    "rubric_min": {
+      "specificity": 3,
+      "disputability": 3,
+      "voice": 3
+    },
+    "ssr_likelihood_min": 3.5,
+    "diversity_min": 0.5,
+    "slop_penalty_max": 4.0,
+    "ssr_value_min": 3.0
+  },
+  "objective_weights": {
+    "ssr_likelihood_mean": 0.3,
+    "ssr_value_mean": 0.25,
+    "rubric_composite_mean": 0.25,
+    "cohort_coverage": 0.05,
+    "cohort_underservice_penalty": -0.05,
+    "novelty_bonus": 0.2
+  },
+  "budget_usd": 50.0,
+  "wallclock_cap_ms": 600000,
+  "convergence_min_iters_for_signal": 3,
+  "convergence_delta_threshold": 0.05,
+  "context": null,
+  "voice_slug": "voice/gamemakers-2026",
+  "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default"
+}

--- a/tests/fixtures/editorial-room/v0/optimization_config.topic_default.json
+++ b/tests/fixtures/editorial-room/v0/optimization_config.topic_default.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "0",
+  "persona_slugs": [
+    "persona/ankit-indie-dev",
+    "persona/ravi-studio-lead",
+    "persona/mei-publisher"
+  ],
+  "n_candidates_per_iter": 8,
+  "n_iterations": 3,
+  "n_winners_carried": 5,
+  "n_ssr_samples": 8,
+  "top_k_returned": 5,
+  "diversity_strategy": "default",
+  "diversity_min_distance": 0.4,
+  "cohort_targeted_subloops": false,
+  "contrast_mutation_fraction": 0.4,
+  "gates": {
+    "rubric_min": {
+      "specificity": 3,
+      "disputability": 3
+    },
+    "ssr_likelihood_min": 3.5,
+    "diversity_min": 0.4,
+    "slop_penalty_max": 5.0,
+    "ssr_value_min": null
+  },
+  "objective_weights": {
+    "ssr_likelihood_mean": 0.35,
+    "ssr_value_mean": 0.2,
+    "rubric_composite_mean": 0.3,
+    "cohort_coverage": 0.05,
+    "cohort_underservice_penalty": -0.05,
+    "novelty_bonus": 0.15
+  },
+  "budget_usd": 5.0,
+  "wallclock_cap_ms": null,
+  "convergence_min_iters_for_signal": 2,
+  "convergence_delta_threshold": 0.05,
+  "context": null,
+  "voice_slug": "voice/gamemakers-2026",
+  "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default"
+}

--- a/tests/fixtures/editorial-room/v0/optimization_round.cancelled.json
+++ b/tests/fixtures/editorial-room/v0/optimization_round.cancelled.json
@@ -1,0 +1,113 @@
+{
+  "id": "01HXYZROUND002BBBBBBBBBBBB",
+  "schema_version": "0",
+  "piece_id": "piece_01HXYZ789ABC",
+  "setup_version": 7,
+  "target_kind": "topic",
+  "parent_object": {
+    "kind": "theme",
+    "ref": "theme/ai-impact-on-game-dev"
+  },
+  "config": {
+    "schema_version": "0",
+    "persona_slugs": [
+      "persona/ankit-indie-dev",
+      "persona/ravi-studio-lead",
+      "persona/mei-publisher"
+    ],
+    "n_candidates_per_iter": 8,
+    "n_iterations": 3,
+    "n_winners_carried": 5,
+    "n_ssr_samples": 8,
+    "top_k_returned": 5,
+    "diversity_strategy": "default",
+    "diversity_min_distance": 0.4,
+    "cohort_targeted_subloops": false,
+    "contrast_mutation_fraction": 0.4,
+    "gates": {
+      "rubric_min": { "specificity": 3, "disputability": 3 },
+      "ssr_likelihood_min": 3.5,
+      "diversity_min": 0.4,
+      "slop_penalty_max": 5.0,
+      "ssr_value_min": null
+    },
+    "objective_weights": {
+      "ssr_likelihood_mean": 0.35,
+      "ssr_value_mean": 0.2,
+      "rubric_composite_mean": 0.3,
+      "cohort_coverage": 0.05,
+      "cohort_underservice_penalty": -0.05,
+      "novelty_bonus": 0.15
+    },
+    "budget_usd": 5.0,
+    "wallclock_cap_ms": null,
+    "convergence_min_iters_for_signal": 2,
+    "convergence_delta_threshold": 0.05,
+    "context": null,
+    "voice_slug": "voice/gamemakers-2026",
+    "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default"
+  },
+  "status": "cancelled",
+  "convergence_reason": "user_stopped",
+  "started_at": "2026-04-30T12:00:00.000Z",
+  "completed_at": "2026-04-30T12:01:32.450Z",
+  "candidates_generated": 14,
+  "candidates_accepted": 6,
+  "acceptable_pool_ids": [
+    "01HXYZCAND020AAAAAAAAAAAAA",
+    "01HXYZCAND021BBBBBBBBBBBBB",
+    "01HXYZCAND022CCCCCCCCCCCCC",
+    "01HXYZCAND023DDDDDDDDDDDDD",
+    "01HXYZCAND024EEEEEEEEEEEEE",
+    "01HXYZCAND025FFFFFFFFFFFFF"
+  ],
+  "top_k": [
+    {
+      "rank": 1,
+      "rank_basis": "composite",
+      "candidate_id": "01HXYZCAND020AAAAAAAAAAAAA",
+      "candidate_kind": "topic",
+      "rubric_scores": {
+        "specificity": {
+          "axis": "specificity",
+          "score": 4,
+          "scale": [1, 5],
+          "gap": null,
+          "fix": null,
+          "weakest_quote": null,
+          "note": null
+        }
+      },
+      "ssr_distributions": [
+        {
+          "persona_slug": "persona/ankit-indie-dev",
+          "family": "likelihood",
+          "pmf": [0.05, 0.1, 0.2, 0.4, 0.25],
+          "scale": [1, 5],
+          "mean": 3.7,
+          "confidence": 0.65,
+          "reasoning_quote": "Worth opening."
+        }
+      ],
+      "counter_audience": null,
+      "comparable_history": null,
+      "diversity_position": null,
+      "composite_score": 7.1,
+      "novelty_bonus": 0.1,
+      "cohort_coverage_score": 0.5
+    }
+  ],
+  "reject_reason_histogram": {
+    "specificity_lt_3": 5,
+    "diversity_lt_0_4": 2,
+    "ssr_likelihood_lt_3_5": 1
+  },
+  "cost_estimate_usd": 4.2,
+  "cost_actual_usd": 1.84,
+  "wallclock_actual_ms": 92450,
+  "triggered_by_user_id": "user_local_joseph",
+  "source_run_ids": [
+    "01HXYZRUNGEN020AAAAAAAAAAA",
+    "01HXYZRUNRUB020BBBBBBBBBBB"
+  ]
+}

--- a/tests/fixtures/editorial-room/v0/optimization_round.completed.topic.json
+++ b/tests/fixtures/editorial-room/v0/optimization_round.completed.topic.json
@@ -1,0 +1,202 @@
+{
+  "id": "01HXYZROUND001AAAAAAAAAAAA",
+  "schema_version": "0",
+  "piece_id": "piece_01HXYZ789ABC",
+  "setup_version": 7,
+  "target_kind": "topic",
+  "parent_object": {
+    "kind": "theme",
+    "ref": "theme/ai-impact-on-game-dev"
+  },
+  "config": {
+    "schema_version": "0",
+    "persona_slugs": [
+      "persona/ankit-indie-dev",
+      "persona/ravi-studio-lead",
+      "persona/mei-publisher"
+    ],
+    "n_candidates_per_iter": 8,
+    "n_iterations": 3,
+    "n_winners_carried": 5,
+    "n_ssr_samples": 8,
+    "top_k_returned": 5,
+    "diversity_strategy": "default",
+    "diversity_min_distance": 0.4,
+    "cohort_targeted_subloops": false,
+    "contrast_mutation_fraction": 0.4,
+    "gates": {
+      "rubric_min": { "specificity": 3, "disputability": 3 },
+      "ssr_likelihood_min": 3.5,
+      "diversity_min": 0.4,
+      "slop_penalty_max": 5.0,
+      "ssr_value_min": null
+    },
+    "objective_weights": {
+      "ssr_likelihood_mean": 0.35,
+      "ssr_value_mean": 0.2,
+      "rubric_composite_mean": 0.3,
+      "cohort_coverage": 0.05,
+      "cohort_underservice_penalty": -0.05,
+      "novelty_bonus": 0.15
+    },
+    "budget_usd": 5.0,
+    "wallclock_cap_ms": null,
+    "convergence_min_iters_for_signal": 2,
+    "convergence_delta_threshold": 0.05,
+    "context": null,
+    "voice_slug": "voice/gamemakers-2026",
+    "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default"
+  },
+  "status": "completed",
+  "convergence_reason": "convergence_signal",
+  "started_at": "2026-04-30T11:30:00.000Z",
+  "completed_at": "2026-04-30T11:33:42.180Z",
+  "candidates_generated": 24,
+  "candidates_accepted": 14,
+  "acceptable_pool_ids": [
+    "01HXYZCAND001AAAAAAAAAAAAA",
+    "01HXYZCAND002BBBBBBBBBBBBB",
+    "01HXYZCAND003CCCCCCCCCCCCC",
+    "01HXYZCAND004DDDDDDDDDDDDD",
+    "01HXYZCAND005EEEEEEEEEEEEE",
+    "01HXYZCAND006FFFFFFFFFFFFF",
+    "01HXYZCAND007GGGGGGGGGGGGG",
+    "01HXYZCAND008HHHHHHHHHHHHH",
+    "01HXYZCAND009IIIIIIIIIIIII",
+    "01HXYZCAND010JJJJJJJJJJJJJ",
+    "01HXYZCAND011KKKKKKKKKKKKK",
+    "01HXYZCAND012LLLLLLLLLLLLL",
+    "01HXYZCAND013MMMMMMMMMMMMM",
+    "01HXYZCAND014NNNNNNNNNNNNN"
+  ],
+  "top_k": [
+    {
+      "rank": 1,
+      "rank_basis": "composite",
+      "candidate_id": "01HXYZCAND001AAAAAAAAAAAAA",
+      "candidate_kind": "topic",
+      "rubric_scores": {
+        "specificity": {
+          "axis": "specificity",
+          "score": 4.5,
+          "scale": [1, 5],
+          "gap": null,
+          "fix": null,
+          "weakest_quote": null,
+          "note": null
+        },
+        "disputability": {
+          "axis": "disputability",
+          "score": 4,
+          "scale": [1, 5],
+          "gap": null,
+          "fix": null,
+          "weakest_quote": null,
+          "note": null
+        }
+      },
+      "ssr_distributions": [
+        {
+          "persona_slug": "persona/ankit-indie-dev",
+          "family": "likelihood",
+          "pmf": [0.02, 0.05, 0.12, 0.36, 0.45],
+          "scale": [1, 5],
+          "mean": 4.17,
+          "confidence": 0.78,
+          "reasoning_quote": "Exactly the angle I haven't seen elsewhere."
+        }
+      ],
+      "counter_audience": null,
+      "comparable_history": "Scores higher than 78% of completed Topic-optimize rounds.",
+      "diversity_position": "primary cohort",
+      "composite_score": 7.82,
+      "novelty_bonus": 0.15,
+      "cohort_coverage_score": 0.65
+    },
+    {
+      "rank": 2,
+      "rank_basis": "composite",
+      "candidate_id": "01HXYZCAND002BBBBBBBBBBBBB",
+      "candidate_kind": "topic",
+      "rubric_scores": {
+        "specificity": {
+          "axis": "specificity",
+          "score": 4,
+          "scale": [1, 5],
+          "gap": null,
+          "fix": null,
+          "weakest_quote": null,
+          "note": null
+        }
+      },
+      "ssr_distributions": [
+        {
+          "persona_slug": "persona/ravi-studio-lead",
+          "family": "likelihood",
+          "pmf": [0.05, 0.1, 0.2, 0.4, 0.25],
+          "scale": [1, 5],
+          "mean": 3.7,
+          "confidence": 0.7,
+          "reasoning_quote": "Solid framing."
+        }
+      ],
+      "counter_audience": null,
+      "comparable_history": null,
+      "diversity_position": null,
+      "composite_score": 7.4,
+      "novelty_bonus": 0.1,
+      "cohort_coverage_score": 0.55
+    },
+    {
+      "rank": 3,
+      "rank_basis": "novelty_reservation",
+      "candidate_id": "01HXYZCAND008HHHHHHHHHHHHH",
+      "candidate_kind": "topic",
+      "rubric_scores": {
+        "specificity": {
+          "axis": "specificity",
+          "score": 3.5,
+          "scale": [1, 5],
+          "gap": null,
+          "fix": null,
+          "weakest_quote": null,
+          "note": null
+        }
+      },
+      "ssr_distributions": [
+        {
+          "persona_slug": "persona/mei-publisher",
+          "family": "likelihood",
+          "pmf": [0.1, 0.2, 0.3, 0.3, 0.1],
+          "scale": [1, 5],
+          "mean": 3.1,
+          "confidence": 0.55,
+          "reasoning_quote": "Different angle, worth showing."
+        }
+      ],
+      "counter_audience": null,
+      "comparable_history": null,
+      "diversity_position": "novelty-reserved slot; furthest from primary cluster.",
+      "composite_score": 6.8,
+      "novelty_bonus": 0.25,
+      "cohort_coverage_score": 0.4
+    }
+  ],
+  "reject_reason_histogram": {
+    "specificity_lt_3": 4,
+    "diversity_lt_0_4": 3,
+    "ssr_likelihood_lt_3_5": 2,
+    "disputability_lt_3": 1
+  },
+  "cost_estimate_usd": 4.2,
+  "cost_actual_usd": 3.87,
+  "wallclock_actual_ms": 222180,
+  "triggered_by_user_id": "user_local_joseph",
+  "source_run_ids": [
+    "01HXYZRUNGEN001AAAAAAAAAAA",
+    "01HXYZRUNGEN002BBBBBBBBBBB",
+    "01HXYZRUNGEN003CCCCCCCCCCC",
+    "01HXYZRUNRUB001DDDDDDDDDDD",
+    "01HXYZRUNSSR001EEEEEEEEEEE"
+  ]
+}

--- a/tests/fixtures/editorial-room/v0/run_optimization.input.topic.json
+++ b/tests/fixtures/editorial-room/v0/run_optimization.input.topic.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": "0",
+  "idempotency_key": "sha256:idemkeyrunopttopic000000000000000000000000000000000000000000000",
+  "piece_id": "piece_01HXYZ789ABC",
+  "setup_version": 7,
+  "target_kind": "topic",
+  "parent_object": {
+    "kind": "theme",
+    "ref": "theme/ai-impact-on-game-dev"
+  },
+  "config": {
+    "schema_version": "0",
+    "persona_slugs": [
+      "persona/ankit-indie-dev",
+      "persona/ravi-studio-lead",
+      "persona/mei-publisher"
+    ],
+    "n_candidates_per_iter": 8,
+    "n_iterations": 3,
+    "n_winners_carried": 5,
+    "n_ssr_samples": 8,
+    "top_k_returned": 5,
+    "diversity_strategy": "default",
+    "diversity_min_distance": 0.4,
+    "cohort_targeted_subloops": false,
+    "contrast_mutation_fraction": 0.4,
+    "gates": {
+      "rubric_min": { "specificity": 3, "disputability": 3 },
+      "ssr_likelihood_min": 3.5,
+      "diversity_min": 0.4,
+      "slop_penalty_max": 5.0,
+      "ssr_value_min": null
+    },
+    "objective_weights": {
+      "ssr_likelihood_mean": 0.35,
+      "ssr_value_mean": 0.2,
+      "rubric_composite_mean": 0.3,
+      "cohort_coverage": 0.05,
+      "cohort_underservice_penalty": -0.05,
+      "novelty_bonus": 0.15
+    },
+    "budget_usd": 5.0,
+    "wallclock_cap_ms": null,
+    "convergence_min_iters_for_signal": 2,
+    "convergence_delta_threshold": 0.05,
+    "context": null,
+    "voice_slug": "voice/gamemakers-2026",
+    "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default"
+  }
+}

--- a/tests/fixtures/editorial-room/v0/run_optimization.output.json
+++ b/tests/fixtures/editorial-room/v0/run_optimization.output.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "0",
+  "round_id": "01HXYZROUND001AAAAAAAAAAAA",
+  "status": "queued",
+  "is_replay": false,
+  "cost_estimate_usd": 4.2,
+  "cost_estimate_p10": 3.5,
+  "cost_estimate_p90": 5.1,
+  "wallclock_estimate_ms": 180000,
+  "requires_double_confirm": false
+}

--- a/tests/fixtures/editorial-room/v0/top_k_candidate.full.json
+++ b/tests/fixtures/editorial-room/v0/top_k_candidate.full.json
@@ -1,0 +1,79 @@
+{
+  "rank": 1,
+  "rank_basis": "composite",
+  "candidate_id": "01HXYZCAND001AAAAAAAAAAAAA",
+  "candidate_kind": "topic",
+  "rubric_scores": {
+    "specificity": {
+      "axis": "specificity",
+      "score": 4.5,
+      "scale": [1, 5],
+      "gap": "Could name the specific deal terms (MG, recoupment %) earlier.",
+      "fix": "Move the deal-shape numbers into the lede.",
+      "weakest_quote": null,
+      "note": "Strong overall; weakest in opening paragraph."
+    },
+    "disputability": {
+      "axis": "disputability",
+      "score": 4,
+      "scale": [1, 5],
+      "gap": "Counter-take is acknowledged but not engaged.",
+      "fix": "Cite the Annapurna counter explicitly.",
+      "weakest_quote": null,
+      "note": null
+    },
+    "novelty": {
+      "axis": "novelty",
+      "score": 4.5,
+      "scale": [1, 5],
+      "gap": null,
+      "fix": null,
+      "weakest_quote": null,
+      "note": "Highest novelty in the candidate pool."
+    },
+    "voice": {
+      "axis": "voice",
+      "score": 4,
+      "scale": [1, 5],
+      "gap": "One hedge ('may have been') breaks the declarative cadence.",
+      "fix": "Replace with 'is reclassified'.",
+      "weakest_quote": "may have been reclassified",
+      "note": null
+    }
+  },
+  "ssr_distributions": [
+    {
+      "persona_slug": "persona/ankit-indie-dev",
+      "family": "likelihood",
+      "pmf": [0.02, 0.05, 0.12, 0.36, 0.45],
+      "scale": [1, 5],
+      "mean": 4.17,
+      "confidence": 0.78,
+      "reasoning_quote": "I'd open this. The reclassification framing is exactly the angle I haven't seen elsewhere."
+    },
+    {
+      "persona_slug": "persona/ravi-studio-lead",
+      "family": "likelihood",
+      "pmf": [0.03, 0.07, 0.15, 0.38, 0.37],
+      "scale": [1, 5],
+      "mean": 3.99,
+      "confidence": 0.72,
+      "reasoning_quote": "Worth my time — but I want a person in §2."
+    },
+    {
+      "persona_slug": "persona/mei-publisher",
+      "family": "likelihood",
+      "pmf": [0.05, 0.15, 0.3, 0.35, 0.15],
+      "scale": [1, 5],
+      "mean": 3.4,
+      "confidence": 0.68,
+      "reasoning_quote": "Useful, but cite the 8-K page numbers up front."
+    }
+  ],
+  "counter_audience": null,
+  "comparable_history": "Scores higher than 78% of completed Topic-optimize rounds in the AI-Impact theme.",
+  "diversity_position": "primary cohort (indie-dev focus); paired with a cohort_reservation slot at rank 4.",
+  "composite_score": 7.82,
+  "novelty_bonus": 0.15,
+  "cohort_coverage_score": 0.65
+}


### PR DESCRIPTION
## Summary
- 9 schemas + 8 fixtures covering the optimization round lifecycle (Batch 5 of 5 — final).
- 83/83 tests pass (was 67, +16 from new fixtures × validation+round-trip), typecheck clean, prettier clean.
- **0p-1 (executable cross-repo contract) is now complete.** Both repos can validate the same fixtures against the same machine contract.

## What's in this batch
**Schemas** (`docs/contracts/editorial-room/v0/`):
- `optimization_config.schema.json` (+ `OptimizationGates` + `ObjectiveWeights`; §6.6.1)
- `optimization_round.schema.json` (+ `TopKCandidate` + `RubricScore` + `SsrPersonaResult` + `CounterAudienceResult` + `CounterAudienceObjection`; §4.7)
- `top_k_candidate.schema.json` (wrapper `$ref`'ing `optimization_round#/definitions/TopKCandidate`; needed because §9.1 lists `top_k_candidate.full.json` as a fixture)
- `run_optimization.input.schema.json` (§6.6.1)
- `run_optimization.output.schema.json` (§6.6.2)
- `get_optimization_round.input.schema.json` (§6.7)
- `get_optimization_round.output.schema.json` (+ `OptimizationProgress`; §6.7)
- `cancel_optimization_round.input.schema.json` (§6.7)
- `cancel_optimization_round.output.schema.json` (§6.7)

**Fixtures** (`tests/fixtures/editorial-room/v0/`):
- `optimization_config.topic_default.json`, `optimization_config.draft_fullsearch.json`
- `optimization_round.completed.topic.json` (3 top-K candidates, mixed `rank_basis`)
- `optimization_round.cancelled.json` (`status: cancelled`, partial pool preserved)
- `run_optimization.input.topic.json`, `run_optimization.output.json` (queued, with cost estimates + p10/p90)
- `get_optimization_round.output.running.json` (mid-run, `current_phase: ssr_scoring`, progress populated)
- `top_k_candidate.full.json` (full rubric_scores + ssr_distributions + composite/novelty/cohort breakdowns)

## Contract gaps surfaced
- **§10 doesn't list `top_k_candidate.schema.json`** even though §9.1 lists `top_k_candidate.full.json` as a fixture. Shipped a wrapper `$ref`'ing the canonical definition.
- **§4.7 defines `OptimizationTrial`** (per-candidate audit log for learning/audit) but §10 doesn't list a separate schema for it. Deferred — fixtures and live usage haven't required it yet.

## Final status (after this batch)

| Metric | Count |
|---|---|
| Schemas registered | **35** (33 from §10 + 2 added: `panel_provenance`, `top_k_candidate`) |
| Fixtures registered | **35** (all of §9.1 covered) |
| Tests | **83/83 passing** |

## Cumulative contract gaps for a doc-only reconciliation PR
1. §10 missing `panel_provenance.schema.json` entry (§3.9.2 defines it)
2. §10 missing `top_k_candidate.schema.json` entry (§9.1 fixture requires it)
3. §10 missing `optimization_trial.schema.json` entry (§4.7 defines it)
4. §4.1 `PointNoteBlock.type` enum vs `design/03_points_outline.md` note types
5. §4.4 `ProposalActionKind` vs §4.5 `ProposalKind` naming
6. §10 vs §4.5 `ProposedDiff` strictness — strict per-kind oneOf deferred

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test -- src/clawrocket/contracts/editorial-room.test.ts` → 83/83 pass
- [x] `npm run format:check` clean
- [ ] CI green

## Up next (post-0p-1)
0p-1 is complete. Remaining 0p deliverables:
- **0p-2**: additional fixtures for partial-provider / stale / failed states (some shipped inline; can be expanded as edge cases emerge)
- **0p-a**: portfolio loop UI (`Setup` → `Theme/Topic` → `Points/Notes` → fixture LLM Discussion)
- **0p-b**: editor loop UI (Tiptap + source-map anchoring + Substack export)
- **0p-3/4**: acceptance gates (Joseph runs the local proof end-to-end)
- **0p-5**: write `PHASE_0P_STOP_GO.md` outcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)