### PR TITLE
feat: Editorial Room Setup page (0p-a vertical slice)

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -31,6 +31,7 @@ import {
 } from './lib/api';
 import { AiAgentsPage } from './pages/AiAgentsPage';
 import { DataConnectorsPage } from './pages/DataConnectorsPage';
+import { EditorialSetupPage } from './pages/EditorialSetupPage';
 import { MainChannelPage } from './pages/MainChannelPage';
 import { TalkDetailPage } from './pages/TalkDetailPage';
 import { TalkListPage } from './pages/TalkListPage';
@@ -672,6 +673,27 @@ export function App() {
 
   if (auth.status === 'unauthenticated') {
     return <SignInView onSignedIn={refreshSession} />;
+  }
+
+  // Editorial Room runs in its own shell (no ClawTalk sidebar/header) —
+  // the 6-pill phase strip is the navigation per docs/design/01_setup.md.
+  if (location.pathname.startsWith('/editorial')) {
+    return (
+      <Routes>
+        <Route
+          path="/editorial"
+          element={<Navigate to="/editorial/setup" replace />}
+        />
+        <Route
+          path="/editorial/setup"
+          element={<EditorialSetupPage onUnauthorized={handleUnauthorized} />}
+        />
+        <Route
+          path="/editorial/*"
+          element={<Navigate to="/editorial/setup" replace />}
+        />
+      </Routes>
+    );
   }
 
   return (

--- a/webapp/src/pages/EditorialSetupPage.tsx
+++ b/webapp/src/pages/EditorialSetupPage.tsx
@@ -1,0 +1,448 @@
+import { useMemo, useState } from 'react';
+
+// SetupState mirrors docs/contracts/editorial-room/v0/setup_state.schema.json
+// (also in EDITORIAL_ROOM_CONTRACT.md §2.1). Held in component state for the
+// 0p-a vertical slice; no persistence yet.
+type DeliverableType =
+  | 'longform_post'
+  | 'podcast_script'
+  | 'book_chapter'
+  | 'social_post'
+  | 'memo';
+
+type Destination =
+  | 'substack_md'
+  | 'google_doc'
+  | 'plain_md'
+  | 'youtube_script'
+  | 'other';
+
+type SetupState = {
+  schema_version: '0';
+  setup_version: number;
+  deliverable_type: DeliverableType;
+  voice_page_slug: string;
+  length_target: { min_words: number; max_words: number } | null;
+  destination: Destination;
+  audience_persona_slugs: string[];
+  llm_room_agent_profile_ids: string[];
+  scoring_pipeline_slug: string;
+  updated_at: string;
+  updated_by_user_id: string;
+};
+
+const PHASES = [
+  { id: 'setup', label: '01 SETUP' },
+  { id: 'theme-topics', label: '02 THEME + TOPICS' },
+  { id: 'points-outline', label: '03 POINTS + OUTLINE' },
+  { id: 'draft', label: '04 DRAFT' },
+  { id: 'polish', label: '05 POLISH' },
+  { id: 'ship', label: '06 SHIP' },
+] as const;
+
+type SectionId = 'deliverable' | 'audience' | 'llm-room' | 'scoring';
+
+const SECTIONS: ReadonlyArray<{ id: SectionId; num: string; name: string }> = [
+  { id: 'deliverable', num: '01', name: 'Deliverable' },
+  { id: 'audience', num: '02', name: 'Audience' },
+  { id: 'llm-room', num: '03', name: 'LLM Room' },
+  { id: 'scoring', num: '04', name: 'Scoring System' },
+];
+
+const DELIVERABLE_LABELS: Record<DeliverableType, string> = {
+  longform_post: 'Longform Post',
+  podcast_script: 'Podcast Script',
+  book_chapter: 'Book Chapter',
+  social_post: 'Social Post',
+  memo: 'Memo',
+};
+
+const DESTINATION_LABELS: Record<Destination, string> = {
+  substack_md: 'Substack · Markdown export',
+  google_doc: 'Google Doc',
+  plain_md: 'Plain Markdown',
+  youtube_script: 'YouTube Script',
+  other: 'Other',
+};
+
+function defaultSetupState(): SetupState {
+  return {
+    schema_version: '0',
+    setup_version: 1,
+    deliverable_type: 'longform_post',
+    voice_page_slug: 'voice/gamemakers-2026',
+    length_target: { min_words: 2000, max_words: 2500 },
+    destination: 'substack_md',
+    audience_persona_slugs: [],
+    llm_room_agent_profile_ids: [],
+    scoring_pipeline_slug: 'scoring_pipeline/gamemakers_default',
+    updated_at: new Date().toISOString(),
+    updated_by_user_id: 'user_local_joseph',
+  };
+}
+
+function sectionStatus(
+  id: SectionId,
+  s: SetupState,
+): 'done' | 'in_progress' | 'not_started' {
+  switch (id) {
+    case 'deliverable':
+      return s.voice_page_slug && s.deliverable_type ? 'done' : 'not_started';
+    case 'audience':
+      if (s.audience_persona_slugs.length >= 1) return 'done';
+      return 'not_started';
+    case 'llm-room':
+      if (s.llm_room_agent_profile_ids.length >= 2) return 'done';
+      return 'not_started';
+    case 'scoring':
+      return s.scoring_pipeline_slug ? 'done' : 'not_started';
+  }
+}
+
+type Props = {
+  onUnauthorized?: () => void;
+};
+
+export function EditorialSetupPage(_props: Props) {
+  const [setup, setSetup] = useState<SetupState>(defaultSetupState);
+  const [activeSection, setActiveSection] = useState<SectionId>('deliverable');
+  const [pieceTitle, setPieceTitle] = useState('Untitled Piece — new');
+
+  const update = (patch: Partial<SetupState>) =>
+    setSetup((s) => ({
+      ...s,
+      ...patch,
+      setup_version: s.setup_version + 1,
+      updated_at: new Date().toISOString(),
+    }));
+
+  const sectionsDone = useMemo(
+    () => SECTIONS.filter((s) => sectionStatus(s.id, setup) === 'done').length,
+    [setup],
+  );
+
+  return (
+    <div className="editorial-room">
+      <header className="editorial-phase-strip">
+        <div className="editorial-phase-strip-brand">
+          <span className="editorial-phase-strip-mark">ER</span>
+          <span className="editorial-phase-strip-title">
+            Editorial Room <span className="editorial-version">v0P</span>
+          </span>
+        </div>
+        <nav className="editorial-phase-strip-pills">
+          {PHASES.map((p) => (
+            <span
+              key={p.id}
+              className={`editorial-phase-pill${p.id === 'setup' ? ' editorial-phase-pill-active' : ''}`}
+            >
+              {p.label}
+            </span>
+          ))}
+        </nav>
+        <div className="editorial-phase-strip-actions">
+          <button type="button" className="editorial-chip-button" disabled>
+            ⌘K
+          </button>
+          <button type="button" className="editorial-chip-button" disabled>
+            HISTORY
+          </button>
+          <button type="button" className="editorial-chip-button" disabled>
+            SAVE
+          </button>
+        </div>
+      </header>
+
+      <div className="editorial-meta-bar">
+        <span className="editorial-meta-prefix">SETUP</span>
+        <input
+          className="editorial-meta-title"
+          value={pieceTitle}
+          onChange={(e) => setPieceTitle(e.target.value)}
+          aria-label="Piece title"
+        />
+        <span className="editorial-meta-pip">
+          {sectionsDone} OF {SECTIONS.length} SECTIONS DONE
+        </span>
+        <span className="editorial-meta-pip editorial-meta-pip-muted">
+          {SECTIONS.find((s) => s.id === activeSection)?.name.toUpperCase()}{' '}
+          OPEN
+        </span>
+        <div className="editorial-meta-actions">
+          <button type="button" className="editorial-chip-button" disabled>
+            ↻ CLONE FROM PRIOR PIECE
+          </button>
+          <button type="button" className="editorial-chip-button" disabled>
+            LOAD PRESET
+          </button>
+        </div>
+      </div>
+
+      <div className="editorial-setup-grid">
+        <aside className="editorial-setup-rail">
+          <h2 className="editorial-rail-heading">SETUP SECTIONS</h2>
+          <ul className="editorial-section-list">
+            {SECTIONS.map((s) => {
+              const status = sectionStatus(s.id, setup);
+              return (
+                <li key={s.id}>
+                  <button
+                    type="button"
+                    className={`editorial-section-row${activeSection === s.id ? ' editorial-section-row-active' : ''}`}
+                    onClick={() => setActiveSection(s.id)}
+                  >
+                    <span
+                      className={`editorial-status-dot editorial-status-${status}`}
+                      aria-hidden="true"
+                    />
+                    <span className="editorial-section-name">{s.name}</span>
+                    <span className="editorial-section-status">
+                      {status === 'done'
+                        ? 'configured'
+                        : status === 'in_progress'
+                          ? 'in progress'
+                          : 'not yet'}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+
+          <h2 className="editorial-rail-heading editorial-rail-heading-spaced">
+            OR LOAD PRESET
+          </h2>
+          <ul className="editorial-preset-list">
+            <li className="editorial-preset-row">
+              <span className="editorial-preset-name">GameMakers default</span>
+              <span className="editorial-preset-sub">
+                3 personas · A R M · default scoring
+              </span>
+            </li>
+            <li className="editorial-preset-row">
+              <span className="editorial-preset-name">Memo · short form</span>
+              <span className="editorial-preset-sub">
+                1 persona · 1 agent · rubric only
+              </span>
+            </li>
+          </ul>
+        </aside>
+
+        <main className="editorial-setup-content">
+          {activeSection === 'deliverable' && (
+            <DeliverableSection setup={setup} update={update} />
+          )}
+          {activeSection === 'audience' && (
+            <StubSection
+              num="02"
+              title="Who is this for?"
+              copy="Add personas from your library. Each one becomes a scoring perspective at every layer."
+              note="Persona library picker, suggestions, weight editing — coming next slice."
+            />
+          )}
+          {activeSection === 'llm-room' && (
+            <StubSection
+              num="03"
+              title="Who is in the LLM Room?"
+              copy="Pick agent profiles that critique, propose, and score during the run."
+              note="Agent library + per-agent stance/cost — coming next slice."
+            />
+          )}
+          {activeSection === 'scoring' && (
+            <StubSection
+              num="04"
+              title="What scoring system governs gates?"
+              copy="Pick a scoring pipeline. Tune scorer weights and budget caps inline."
+              note="Pipeline picker · weighted-scorer editor · budget caps — coming next slice."
+            />
+          )}
+        </main>
+
+        <aside className="editorial-setup-preview">
+          <h2 className="editorial-rail-heading">LIVE PREVIEW</h2>
+          <p className="editorial-preview-blurb">
+            How this Setup surfaces downstream.
+          </p>
+
+          <section className="editorial-preview-card">
+            <h3 className="editorial-preview-card-title">
+              CONTEXT BAR · THEME PHASE
+            </h3>
+            <p className="editorial-preview-mock">
+              {DELIVERABLE_LABELS[setup.deliverable_type].toUpperCase()}
+              {setup.length_target
+                ? ` · ${setup.length_target.min_words.toLocaleString()}–${setup.length_target.max_words.toLocaleString()} words`
+                : ' · no length target'}
+            </p>
+            <p className="editorial-preview-mock">
+              {setup.audience_persona_slugs.length > 0
+                ? setup.audience_persona_slugs.join(' · ')
+                : '⚠ no personas yet'}
+            </p>
+            <p className="editorial-preview-mock">
+              {setup.scoring_pipeline_slug
+                ? setup.scoring_pipeline_slug
+                : '⚠ scoring not set'}
+            </p>
+          </section>
+
+          <section className="editorial-preview-card">
+            <h3 className="editorial-preview-card-title">SETUP IMPACT</h3>
+            <ul className="editorial-preview-bullets">
+              <li>every Theme/Topic gets a per-persona score column</li>
+              <li>cohort-targeted sub-loops in optimization</li>
+              <li>counter-audience pass at Polish (drafts only)</li>
+              <li>cost ≈ $2.10 per Topic round (3 personas)</li>
+            </ul>
+          </section>
+
+          <section className="editorial-preview-card editorial-preview-debug">
+            <h3 className="editorial-preview-card-title">
+              SETUP STATE · v{setup.setup_version}
+            </h3>
+            <pre className="editorial-preview-json">
+              {JSON.stringify(setup, null, 2)}
+            </pre>
+          </section>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function DeliverableSection({
+  setup,
+  update,
+}: {
+  setup: SetupState;
+  update: (patch: Partial<SetupState>) => void;
+}) {
+  const target = setup.length_target;
+  return (
+    <section className="editorial-section-workspace">
+      <p className="editorial-section-eyebrow">SECTION 01 · OF 04</p>
+      <h1 className="editorial-section-heading">What are you producing?</h1>
+      <p className="editorial-section-subhead">
+        Define the deliverable, voice, length, and destination. These four
+        fields flow into every downstream phase.
+      </p>
+
+      <div className="editorial-field-grid">
+        <label className="editorial-field">
+          <span className="editorial-field-label">TYPE</span>
+          <select
+            value={setup.deliverable_type}
+            onChange={(e) =>
+              update({ deliverable_type: e.target.value as DeliverableType })
+            }
+          >
+            {(Object.keys(DELIVERABLE_LABELS) as DeliverableType[]).map((k) => (
+              <option key={k} value={k}>
+                {DELIVERABLE_LABELS[k]}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="editorial-field">
+          <span className="editorial-field-label">VOICE</span>
+          <input
+            type="text"
+            value={setup.voice_page_slug}
+            placeholder="voice/gamemakers-2026"
+            onChange={(e) => update({ voice_page_slug: e.target.value })}
+          />
+        </label>
+
+        <label className="editorial-field">
+          <span className="editorial-field-label">DESTINATION</span>
+          <select
+            value={setup.destination}
+            onChange={(e) =>
+              update({ destination: e.target.value as Destination })
+            }
+          >
+            {(Object.keys(DESTINATION_LABELS) as Destination[]).map((k) => (
+              <option key={k} value={k}>
+                {DESTINATION_LABELS[k]}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <fieldset className="editorial-field editorial-field-range">
+          <legend className="editorial-field-label">LENGTH TARGET</legend>
+          <label className="editorial-field-inline">
+            <span>min</span>
+            <input
+              type="number"
+              min={0}
+              value={target?.min_words ?? ''}
+              onChange={(e) =>
+                update({
+                  length_target: {
+                    min_words: Number(e.target.value),
+                    max_words: target?.max_words ?? Number(e.target.value),
+                  },
+                })
+              }
+            />
+          </label>
+          <label className="editorial-field-inline">
+            <span>max</span>
+            <input
+              type="number"
+              min={0}
+              value={target?.max_words ?? ''}
+              onChange={(e) =>
+                update({
+                  length_target: {
+                    min_words: target?.min_words ?? Number(e.target.value),
+                    max_words: Number(e.target.value),
+                  },
+                })
+              }
+            />
+          </label>
+          <button
+            type="button"
+            className="editorial-field-clear"
+            onClick={() => update({ length_target: null })}
+            disabled={target === null}
+          >
+            clear
+          </button>
+        </fieldset>
+      </div>
+
+      <div className="editorial-section-footer">
+        <span className="editorial-section-footer-meta">
+          setup_version {setup.setup_version} · changes stale dependent scores
+        </span>
+      </div>
+    </section>
+  );
+}
+
+function StubSection({
+  num,
+  title,
+  copy,
+  note,
+}: {
+  num: string;
+  title: string;
+  copy: string;
+  note: string;
+}) {
+  return (
+    <section className="editorial-section-workspace">
+      <p className="editorial-section-eyebrow">SECTION {num} · OF 04</p>
+      <h1 className="editorial-section-heading">{title}</h1>
+      <p className="editorial-section-subhead">{copy}</p>
+      <div className="editorial-stub-callout">
+        <strong>NEXT SLICE.</strong> {note}
+      </div>
+    </section>
+  );
+}

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -4409,3 +4409,531 @@ a {
   text-transform: uppercase;
   opacity: 0.6;
 }
+
+/* ============================================================
+ * Editorial Room — 01 SETUP
+ * Spec: docs/design/01_setup.md
+ * Visual style: warm-white canvas, monospace caps for chips/pips,
+ * 8px radius on cards, single editorial accent (red).
+ * ============================================================ */
+
+.editorial-room {
+  height: 100vh;
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  background: linear-gradient(180deg, #fbf8f2 0%, #f5f3ee 100%);
+  color: #1d2433;
+  overflow: hidden;
+}
+
+.editorial-phase-strip {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.6rem 1.25rem;
+  border-bottom: 1px solid #ddd6c8;
+  background: #fff;
+}
+
+.editorial-phase-strip-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-shrink: 0;
+}
+
+.editorial-phase-strip-mark {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #1d2433;
+  border-radius: 6px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.editorial-phase-strip-title {
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-style: italic;
+  font-size: 1.05rem;
+}
+
+.editorial-version {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-left: 0.25rem;
+  opacity: 0.55;
+}
+
+.editorial-phase-strip-pills {
+  display: flex;
+  gap: 0.25rem;
+  flex: 1;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.editorial-phase-pill {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  padding: 0.4rem 0.7rem;
+  border: 1px solid #ddd6c8;
+  border-radius: 8px;
+  color: #6c6655;
+  background: #fbf8f2;
+  cursor: default;
+  white-space: nowrap;
+}
+
+.editorial-phase-pill-active {
+  background: #1d2433;
+  color: #fff;
+  border-color: #1d2433;
+}
+
+.editorial-phase-strip-actions {
+  display: inline-flex;
+  gap: 0.35rem;
+  flex-shrink: 0;
+}
+
+.editorial-chip-button {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.35rem 0.6rem;
+  border: 1px solid #ddd6c8;
+  border-radius: 6px;
+  background: #fff;
+  color: #1d2433;
+  cursor: pointer;
+}
+
+.editorial-chip-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.editorial-meta-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.5rem 1.25rem;
+  border-bottom: 1px solid #ddd6c8;
+  background: #fbf8f2;
+  flex-wrap: wrap;
+}
+
+.editorial-meta-prefix {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+}
+
+.editorial-meta-title {
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-style: italic;
+  font-size: 1.1rem;
+  border: none;
+  background: transparent;
+  color: inherit;
+  padding: 0.25rem 0.4rem;
+  border-radius: 4px;
+  flex: 1;
+  min-width: 12rem;
+}
+
+.editorial-meta-title:focus {
+  outline: none;
+  background: #fff;
+  box-shadow: inset 0 0 0 1px #ddd6c8;
+}
+
+.editorial-meta-pip {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #ddd6c8;
+  border-radius: 4px;
+  color: #1d2433;
+  background: #fff;
+}
+
+.editorial-meta-pip-muted {
+  color: #6c6655;
+}
+
+.editorial-meta-actions {
+  display: inline-flex;
+  gap: 0.35rem;
+  margin-left: auto;
+}
+
+.editorial-setup-grid {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr) 340px;
+  gap: 0;
+  overflow: hidden;
+}
+
+.editorial-setup-rail {
+  border-right: 1px solid #ddd6c8;
+  padding: 1.1rem 1rem;
+  overflow-y: auto;
+  background: #fbf8f2;
+}
+
+.editorial-rail-heading {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.64rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #6c6655;
+  margin: 0 0 0.7rem;
+  font-weight: 600;
+}
+
+.editorial-rail-heading-spaced {
+  margin-top: 1.5rem;
+}
+
+.editorial-section-list,
+.editorial-preset-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.editorial-section-row {
+  display: grid;
+  grid-template-columns: 18px 1fr;
+  grid-template-rows: auto auto;
+  align-items: center;
+  gap: 0 0.55rem;
+  width: 100%;
+  text-align: left;
+  padding: 0.55rem 0.5rem;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  color: inherit;
+}
+
+.editorial-section-row:hover {
+  background: #f4efe3;
+}
+
+.editorial-section-row-active {
+  background: #1d2433;
+  color: #fff;
+}
+
+.editorial-section-row-active:hover {
+  background: #1d2433;
+}
+
+.editorial-status-dot {
+  grid-row: 1 / span 2;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1px solid #1d2433;
+  background: transparent;
+}
+
+.editorial-section-row-active .editorial-status-dot {
+  border-color: #fff;
+}
+
+.editorial-status-done {
+  background: #1d2433;
+}
+
+.editorial-section-row-active .editorial-status-done {
+  background: #fff;
+}
+
+.editorial-status-in_progress {
+  background: #b7372a;
+  border-color: #b7372a;
+}
+
+.editorial-status-not_started {
+  background: transparent;
+}
+
+.editorial-section-name {
+  font-size: 0.92rem;
+  font-weight: 500;
+}
+
+.editorial-section-status {
+  grid-column: 2;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  opacity: 0.65;
+}
+
+.editorial-preset-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.45rem 0.5rem;
+  border-radius: 6px;
+}
+
+.editorial-preset-row:hover {
+  background: #f4efe3;
+}
+
+.editorial-preset-name {
+  font-size: 0.88rem;
+}
+
+.editorial-preset-sub {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6c6655;
+}
+
+.editorial-setup-content {
+  padding: 1.6rem 2rem;
+  overflow-y: auto;
+  background: #fbf8f2;
+}
+
+.editorial-section-workspace {
+  max-width: 720px;
+}
+
+.editorial-section-eyebrow {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+  margin: 0 0 0.5rem;
+}
+
+.editorial-section-heading {
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-size: 2rem;
+  line-height: 1.15;
+  margin: 0 0 0.55rem;
+}
+
+.editorial-section-subhead {
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-style: italic;
+  color: #4a4738;
+  margin: 0 0 1.6rem;
+  max-width: 56ch;
+}
+
+.editorial-field-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem 1.25rem;
+}
+
+.editorial-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.editorial-field-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+}
+
+.editorial-field input,
+.editorial-field select {
+  font-family: inherit;
+  font-size: 0.95rem;
+  padding: 0.5rem 0.65rem;
+  border: 1px solid #ddd6c8;
+  border-radius: 6px;
+  background: #fff;
+  color: #1d2433;
+}
+
+.editorial-field input:focus,
+.editorial-field select:focus {
+  outline: none;
+  border-color: #1d2433;
+}
+
+.editorial-field-range {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  align-items: end;
+  gap: 0.35rem 0.6rem;
+}
+
+.editorial-field-range > legend {
+  grid-column: 1 / -1;
+  padding: 0;
+  margin-bottom: 0.35rem;
+}
+
+.editorial-field-inline {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.editorial-field-inline > span {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  color: #6c6655;
+}
+
+.editorial-field-inline > input {
+  font-family: inherit;
+  font-size: 0.95rem;
+  padding: 0.5rem 0.65rem;
+  border: 1px solid #ddd6c8;
+  border-radius: 6px;
+  background: #fff;
+}
+
+.editorial-field-clear {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.45rem 0.55rem;
+  border: 1px solid #ddd6c8;
+  background: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+  align-self: end;
+}
+
+.editorial-field-clear:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.editorial-section-footer {
+  margin-top: 1.5rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.04em;
+  color: #6c6655;
+}
+
+.editorial-stub-callout {
+  border: 1px dashed #b7372a;
+  background: #fff5f1;
+  border-radius: 8px;
+  padding: 1rem 1.1rem;
+  font-size: 0.92rem;
+  color: #7a2419;
+}
+
+.editorial-setup-preview {
+  border-left: 1px solid #ddd6c8;
+  padding: 1.1rem 1rem;
+  overflow-y: auto;
+  background: #fbf8f2;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.editorial-preview-blurb {
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-style: italic;
+  font-size: 0.85rem;
+  color: #4a4738;
+  margin: -0.4rem 0 0.4rem;
+}
+
+.editorial-preview-card {
+  background: #fff;
+  border: 1px solid #ddd6c8;
+  border-radius: 8px;
+  padding: 0.7rem 0.85rem;
+}
+
+.editorial-preview-card-title {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+  margin: 0 0 0.45rem;
+  font-weight: 600;
+}
+
+.editorial-preview-mock {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+  margin: 0.15rem 0;
+  color: #1d2433;
+}
+
+.editorial-preview-bullets {
+  margin: 0;
+  padding-left: 1.05rem;
+  font-size: 0.78rem;
+  color: #4a4738;
+}
+
+.editorial-preview-bullets li {
+  margin-bottom: 0.2rem;
+}
+
+.editorial-preview-debug {
+  background: #f4efe3;
+}
+
+.editorial-preview-json {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.66rem;
+  line-height: 1.35;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: #1d2433;
+}
+
+@media (max-width: 1100px) {
+  .editorial-setup-grid {
+    grid-template-columns: 200px minmax(0, 1fr);
+  }
+  .editorial-setup-preview {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
First UI surface for Phase 0p. Renders the canonical Setup screen layout from \`docs/design/01_setup.md\` with the Deliverable section functional and the other 3 sections stubbed for the next slice.

## Visible in the page
- **6-pill phase strip** per `01_setup.md` §2 (navigation only; pills non-interactive in this slice)
- **Meta bar** with editable piece title, section-progress pip, active-section indicator
- **3-column grid**: Setup Sections rail (210px) + Active Section workspace + Live Preview rail (340px); preview rail collapses on narrow viewports
- **Setup Sections list** with status dots (filled = done, hollow = not started) and per-section completion summaries
- **Deliverable section** as a working form: type / voice / destination / length min-max / clear-target. Edits update an in-memory `SetupState` matching `docs/contracts/editorial-room/v0/setup_state.schema.json` — `setup_version` increments on every change per §1
- **Live Preview rail** with three cards: context-bar mock, setup-impact bullets, debug card showing the live `SetupState` JSON

## Routing
- `/editorial/setup` is the canonical path
- `App.tsx` early-returns the editorial routes **outside the ClawTalk shell** per `design/01_setup.md` (the phase strip IS the editorial nav; no ClawTalk sidebar visible)
- `/editorial` and `/editorial/*` fall back to `/editorial/setup`

## Out of scope (next slices)
- Audience / LLM Room / Scoring sections render stub callouts
- No persistence (in-memory only); lands alongside `EditorialPiece` persistence
- Phase pills don't route yet (no other phase pages exist)
- Preset library, clone-from-prior-piece, persona library picker — deferred

## How to view
\`\`\`bash
# terminal 1
npm run dev

# terminal 2
npm run dev:web
\`\`\`
Sign in via existing auth flow → navigate to **http://localhost:5173/editorial/setup**

## Test plan
- [x] `npm --prefix webapp run typecheck` clean
- [x] `npm --prefix webapp run build` clean (66 modules, 70 KB CSS, 630 KB JS)
- [x] `npm --prefix webapp run test` → 172 passing, 1 pre-existing skip
- [x] `npx prettier --check` clean
- [ ] Joseph eyeballs the page locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)