### PR TITLE
feat: section nav buttons + voice dropdown (Editorial Setup)

### DIFF
--- a/webapp/src/pages/EditorialSetupPage.tsx
+++ b/webapp/src/pages/EditorialSetupPage.tsx
@@ -65,6 +65,22 @@ const DESTINATION_LABELS: Record<Destination, string> = {
   other: 'Other',
 };
 
+// Voice library shown in the Deliverable section's voice picker. In production
+// this list comes from rocketorchestra's voice page library; for 0p we
+// hardcode the seeded voice plus a few plausible siblings so the dropdown
+// has options to choose from. The first slug matches `seeds/voice/
+// gamemakers_2026.md`; the rest are placeholders that will resolve once
+// rocketorchestra is wired up.
+const AVAILABLE_VOICES: ReadonlyArray<{ slug: string; label: string }> = [
+  { slug: 'voice/gamemakers-2026', label: 'GameMakers (2026)' },
+  { slug: 'voice/longform-essay-2026', label: 'Longform Essay (2026)' },
+  {
+    slug: 'voice/podcast-conversational-2026',
+    label: 'Podcast · Conversational (2026)',
+  },
+  { slug: 'voice/memo-tight-2026', label: 'Memo · Tight (2026)' },
+];
+
 function defaultSetupState(): SetupState {
   return {
     schema_version: '0',
@@ -120,6 +136,27 @@ export function EditorialSetupPage(_props: Props) {
     () => SECTIONS.filter((s) => sectionStatus(s.id, setup) === 'done').length,
     [setup],
   );
+
+  const sectionIdx = SECTIONS.findIndex((s) => s.id === activeSection);
+  const prevSection = sectionIdx > 0 ? SECTIONS[sectionIdx - 1] : null;
+  const nextSection =
+    sectionIdx >= 0 && sectionIdx < SECTIONS.length - 1
+      ? SECTIONS[sectionIdx + 1]
+      : null;
+  const navProps = {
+    prev: prevSection
+      ? {
+          name: prevSection.name,
+          onClick: () => setActiveSection(prevSection.id),
+        }
+      : null,
+    next: nextSection
+      ? {
+          name: nextSection.name,
+          onClick: () => setActiveSection(nextSection.id),
+        }
+      : null,
+  };
 
   return (
     <div className="editorial-room">
@@ -230,7 +267,7 @@ export function EditorialSetupPage(_props: Props) {
 
         <main className="editorial-setup-content">
           {activeSection === 'deliverable' && (
-            <DeliverableSection setup={setup} update={update} />
+            <DeliverableSection setup={setup} update={update} nav={navProps} />
           )}
           {activeSection === 'audience' && (
             <StubSection
@@ -238,6 +275,7 @@ export function EditorialSetupPage(_props: Props) {
               title="Who is this for?"
               copy="Add personas from your library. Each one becomes a scoring perspective at every layer."
               note="Persona library picker, suggestions, weight editing — coming next slice."
+              nav={navProps}
             />
           )}
           {activeSection === 'llm-room' && (
@@ -246,6 +284,7 @@ export function EditorialSetupPage(_props: Props) {
               title="Who is in the LLM Room?"
               copy="Pick agent profiles that critique, propose, and score during the run."
               note="Agent library + per-agent stance/cost — coming next slice."
+              nav={navProps}
             />
           )}
           {activeSection === 'scoring' && (
@@ -254,6 +293,7 @@ export function EditorialSetupPage(_props: Props) {
               title="What scoring system governs gates?"
               copy="Pick a scoring pipeline. Tune scorer weights and budget caps inline."
               note="Pipeline picker · weighted-scorer editor · budget caps — coming next slice."
+              nav={navProps}
             />
           )}
         </main>
@@ -310,22 +350,78 @@ export function EditorialSetupPage(_props: Props) {
   );
 }
 
+type SectionNavProps = {
+  prev: { name: string; onClick: () => void } | null;
+  next: { name: string; onClick: () => void } | null;
+};
+
+function SectionNav({ prev, next }: SectionNavProps) {
+  if (!prev && !next) return null;
+  return (
+    <div className="editorial-section-nav">
+      {prev ? (
+        <button
+          type="button"
+          className="editorial-chip-button"
+          onClick={prev.onClick}
+        >
+          ← {prev.name.toUpperCase()}
+        </button>
+      ) : null}
+      {next ? (
+        <button
+          type="button"
+          className="editorial-chip-button editorial-chip-button-primary"
+          onClick={next.onClick}
+        >
+          {next.name.toUpperCase()} →
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function SectionHeader({
+  num,
+  title,
+  copy,
+  nav,
+}: {
+  num: string;
+  title: string;
+  copy: string;
+  nav: SectionNavProps;
+}) {
+  return (
+    <header className="editorial-section-header">
+      <div className="editorial-section-header-text">
+        <p className="editorial-section-eyebrow">SECTION {num} · OF 04</p>
+        <h1 className="editorial-section-heading">{title}</h1>
+        <p className="editorial-section-subhead">{copy}</p>
+      </div>
+      <SectionNav prev={nav.prev} next={nav.next} />
+    </header>
+  );
+}
+
 function DeliverableSection({
   setup,
   update,
+  nav,
 }: {
   setup: SetupState;
   update: (patch: Partial<SetupState>) => void;
+  nav: SectionNavProps;
 }) {
   const target = setup.length_target;
   return (
     <section className="editorial-section-workspace">
-      <p className="editorial-section-eyebrow">SECTION 01 · OF 04</p>
-      <h1 className="editorial-section-heading">What are you producing?</h1>
-      <p className="editorial-section-subhead">
-        Define the deliverable, voice, length, and destination. These four
-        fields flow into every downstream phase.
-      </p>
+      <SectionHeader
+        num="01"
+        title="What are you producing?"
+        copy="Define the deliverable, voice, length, and destination. These four fields flow into every downstream phase."
+        nav={nav}
+      />
 
       <div className="editorial-field-grid">
         <label className="editorial-field">
@@ -346,12 +442,21 @@ function DeliverableSection({
 
         <label className="editorial-field">
           <span className="editorial-field-label">VOICE</span>
-          <input
-            type="text"
+          <select
             value={setup.voice_page_slug}
-            placeholder="voice/gamemakers-2026"
             onChange={(e) => update({ voice_page_slug: e.target.value })}
-          />
+          >
+            {AVAILABLE_VOICES.map((v) => (
+              <option key={v.slug} value={v.slug}>
+                {v.label}
+              </option>
+            ))}
+            {AVAILABLE_VOICES.every((v) => v.slug !== setup.voice_page_slug) ? (
+              <option value={setup.voice_page_slug}>
+                {setup.voice_page_slug} (custom)
+              </option>
+            ) : null}
+          </select>
         </label>
 
         <label className="editorial-field">
@@ -429,17 +534,17 @@ function StubSection({
   title,
   copy,
   note,
+  nav,
 }: {
   num: string;
   title: string;
   copy: string;
   note: string;
+  nav: SectionNavProps;
 }) {
   return (
     <section className="editorial-section-workspace">
-      <p className="editorial-section-eyebrow">SECTION {num} · OF 04</p>
-      <h1 className="editorial-section-heading">{title}</h1>
-      <p className="editorial-section-subhead">{copy}</p>
+      <SectionHeader num={num} title={title} copy={copy} nav={nav} />
       <div className="editorial-stub-callout">
         <strong>NEXT SLICE.</strong> {note}
       </div>

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -4523,6 +4523,48 @@ a {
   cursor: not-allowed;
 }
 
+.editorial-chip-button-primary {
+  background: #1d2433;
+  color: #fff;
+  border-color: #1d2433;
+}
+
+.editorial-chip-button-primary:hover:not(:disabled) {
+  background: #0f1626;
+  border-color: #0f1626;
+}
+
+.editorial-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.25rem;
+  margin-bottom: 1.6rem;
+}
+
+.editorial-section-header-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.editorial-section-header-text > .editorial-section-eyebrow,
+.editorial-section-header-text > .editorial-section-heading,
+.editorial-section-header-text > .editorial-section-subhead {
+  margin-bottom: 0.5rem;
+}
+
+.editorial-section-header-text > .editorial-section-subhead {
+  margin-bottom: 0;
+}
+
+.editorial-section-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  flex-shrink: 0;
+  align-items: flex-end;
+}
+
 .editorial-meta-bar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
Two changes per feedback on the 0p-a slice.

## 1. Section nav (← prev / next →) in each section header
Per `docs/design/01_setup.md` §5.1. Click advances `activeSection`. Layout:
- **Deliverable** — only `AUDIENCE →` (primary, dark fill)
- **Audience** — `← DELIVERABLE` and `LLM ROOM →`
- **LLM Room** — `← AUDIENCE` and `SCORING SYSTEM →`
- **Scoring System** — only `← LLM ROOM`

The left-rail section list still works for arbitrary jumps; the header nav is the sequential "next" path.

## 2. Voice field is now a dropdown
Was free text. Options (hardcoded for 0p; production fetches from rocketorchestra voice library):
- `voice/gamemakers-2026` (matches `seeds/voice/gamemakers_2026.md`)
- `voice/longform-essay-2026`
- `voice/podcast-conversational-2026`
- `voice/memo-tight-2026`

If the current slug doesn't match any option (e.g., loaded from a future preset), it appears as a `(custom)` entry so the select stays controlled.

## Refactors
- Extracted `SectionHeader` component to share eyebrow/heading/subhead/nav layout.
- New `SectionNav` renders the chip buttons; null branches hidden at boundaries.
- Added `editorial-chip-button-primary` variant for the next button.
- Added `editorial-section-header` flex layout so nav floats top-right per the design spec ASCII.

## Test plan
- [x] `npm --prefix webapp run typecheck` clean
- [x] `npm --prefix webapp run build` clean
- [x] `npm --prefix webapp run test` → 172 passing, 1 pre-existing skip
- [x] `npx prettier --check` clean
- [ ] Joseph eyeballs the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)