### PR TITLE
feat: 0p-2 score-state + proposal-outcome fixtures

### DIFF
--- a/tests/fixtures/editorial-room/v0/proposal_card.accepted.json
+++ b/tests/fixtures/editorial-room/v0/proposal_card.accepted.json
@@ -1,0 +1,25 @@
+{
+  "id": "01HXYZPROP300ACCEPTEDAAAAAA",
+  "schema_version": "0",
+  "source_run_id": "01HXYZRUN300ACCEPTEDAAAAAAA",
+  "source_skill": "factory_topic_propose_optimize",
+  "proposal_kind": "create_topic",
+  "target_object": {
+    "kind": "topic",
+    "ref": null
+  },
+  "proposed_diff": {
+    "parent_theme_slug": "theme/ai-impact-on-game-dev",
+    "working_title": "How Embracer's writedown changed indie publishing terms",
+    "thesis": "Surviving studios are signing 2022-rate deals to keep going — Embracer's writedown shifted bargaining power away from devs in a way locked in for 18+ months.",
+    "why_now": "Embracer's Q3 8-K reclassified MGs as conditional liabilities; Devolver's prelim Q4 echoed the change.",
+    "status": "active"
+  },
+  "rationale": "Topic-optimize round 01HXYZABC456PQR789STUVWXYZ ranked this top-K rank 1 by composite (rubric 7.6 + SSR mean 8.0 + novelty bonus 0.15).",
+  "agent_attribution": ["agent/argus", "agent/scribe", "agent/mei-cohort"],
+  "status": "accepted",
+  "user_edit": null,
+  "resolved_at": "2026-04-30T11:48:32.140Z",
+  "resolved_by_user_id": "user_local_joseph",
+  "resolution_note": null
+}

--- a/tests/fixtures/editorial-room/v0/proposal_card.edited.json
+++ b/tests/fixtures/editorial-room/v0/proposal_card.edited.json
@@ -1,0 +1,25 @@
+{
+  "id": "01HXYZPROP302EDITEDAAAAAAAA",
+  "schema_version": "0",
+  "source_run_id": "01HXYZRUN302EDITEDAAAAAAAAA",
+  "source_skill": "factory_point_improve_toward_score",
+  "proposal_kind": "improve_toward_score",
+  "target_object": {
+    "kind": "point",
+    "ref": "point/embracer-mg-reclassification-load-bearing"
+  },
+  "proposed_diff": {
+    "claim": "MG-as-conditional-liability is the load-bearing accounting change — without it the deal-shape lockdown collapses inside one quarter.",
+    "rationale": "Tightens the causal chain between the accounting change and the deal-shape persistence. Adds a falsifiable temporal claim ('inside one quarter')."
+  },
+  "rationale": "Point currently scores SSR likelihood mean 0.62 (just under 0.65 gate). Tightening the causal chain projects to ~0.74 based on rubric judge sensitivity analysis.",
+  "agent_attribution": ["agent/argus"],
+  "status": "edited",
+  "user_edit": {
+    "claim": "MG-as-conditional-liability is the load-bearing accounting change — without it the deal-shape lockdown unwinds within two quarters.",
+    "rationale": "Tightens the causal chain. The 'two quarters' window matches what Annapurna's source said in the verification call; one quarter overstated."
+  },
+  "resolved_at": "2026-04-30T11:54:41.770Z",
+  "resolved_by_user_id": "user_local_joseph",
+  "resolution_note": "Accepted the substance; softened 'one quarter' to 'two quarters' to match the Annapurna verification."
+}

--- a/tests/fixtures/editorial-room/v0/proposal_card.parked.json
+++ b/tests/fixtures/editorial-room/v0/proposal_card.parked.json
@@ -1,0 +1,25 @@
+{
+  "id": "01HXYZPROP303PARKEDAAAAAAAA",
+  "schema_version": "0",
+  "source_run_id": "01HXYZRUN303PARKEDAAAAAAAAA",
+  "source_skill": "factory_topic_propose_optimize",
+  "proposal_kind": "create_topic",
+  "target_object": {
+    "kind": "topic",
+    "ref": null
+  },
+  "proposed_diff": {
+    "parent_theme_slug": "theme/ai-impact-on-game-dev",
+    "working_title": "The audio-tools bottleneck in indie pipelines",
+    "thesis": "Audio is the last manual stage in a generative-AI-fluent indie pipeline; the gap is structural, not skill-based.",
+    "why_now": "ElevenLabs/Suno gains in 2025 are real but the integration story is bad; this is where the next 12 months of wins land.",
+    "status": "active"
+  },
+  "rationale": "Rank 3 of 5 in the optimize round; aggregate 7.0. Solid topic but adjacent to the current Theme rather than core.",
+  "agent_attribution": ["agent/argus", "agent/mei-cohort"],
+  "status": "parked",
+  "user_edit": null,
+  "resolved_at": "2026-04-30T11:55:08.330Z",
+  "resolved_by_user_id": "user_local_joseph",
+  "resolution_note": "Worth writing in the next quarter when ElevenLabs DAW integration matures. Parking — revisit Q3."
+}

--- a/tests/fixtures/editorial-room/v0/proposal_card.rejected.json
+++ b/tests/fixtures/editorial-room/v0/proposal_card.rejected.json
@@ -1,0 +1,25 @@
+{
+  "id": "01HXYZPROP301REJECTEDAAAAAA",
+  "schema_version": "0",
+  "source_run_id": "01HXYZRUN301REJECTEDAAAAAAA",
+  "source_skill": "factory_topic_propose_optimize",
+  "proposal_kind": "create_topic",
+  "target_object": {
+    "kind": "topic",
+    "ref": null
+  },
+  "proposed_diff": {
+    "parent_theme_slug": "theme/ai-impact-on-game-dev",
+    "working_title": "AI tooling makes solo devs 10× faster",
+    "thesis": "Cursor + Claude let one developer ship what took five last year.",
+    "why_now": "Late-2025 productivity reports show 5-10× output gains.",
+    "status": "active"
+  },
+  "rationale": "Topic-optimize round produced this as rank 4 of 5; aggregate 6.4. Surface for user pick.",
+  "agent_attribution": ["agent/argus", "agent/scribe"],
+  "status": "rejected",
+  "user_edit": null,
+  "resolved_at": "2026-04-30T11:49:18.020Z",
+  "resolved_by_user_id": "user_local_joseph",
+  "resolution_note": "Topic angle is too close to back_catalog/2025-09-cursor-changed-everything; reader will read it as a rerun. Reject for novelty."
+}

--- a/tests/fixtures/editorial-room/v0/score_snapshot.partial.json
+++ b/tests/fixtures/editorial-room/v0/score_snapshot.partial.json
@@ -1,0 +1,74 @@
+{
+  "id": "01HXYZSCRSNAP013PARTIALAAAA",
+  "piece_id": "piece_01HXYZ789ABC",
+  "setup_version": 7,
+  "object_kind": "topic",
+  "object_ref": "topic/ai-impact-on-game-dev-why-ai-art-pl-wins-on-paper-loses-at-funding",
+  "object_content_hash": "sha256:topic012hash000000000000000000000000000000000000000000000000000",
+  "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default",
+  "selected_persona_slugs": [
+    "persona/ankit-indie-dev",
+    "persona/ravi-studio-lead",
+    "persona/mei-publisher"
+  ],
+  "result": {
+    "schema_version": "0",
+    "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default",
+    "aggregate_score": 6.4,
+    "score_scale": [0, 10],
+    "score_direction": "higher_better",
+    "per_dimension": {
+      "specificity": 7.0,
+      "disputability": 6.5,
+      "novelty": 6.5,
+      "voice_match": 6.0
+    },
+    "per_persona": {
+      "persona/ankit-indie-dev": 7.0,
+      "persona/ravi-studio-lead": 6.0
+    },
+    "confidence": "relative-only",
+    "notes": [
+      "partial — mei-cohort SSR provider (Google) timed out after 10000ms.",
+      "Aggregate computed over 2 of 3 primary personas; UI should mark mei column as failed.",
+      "Retry mei sub-loop or refresh to recompute fully."
+    ],
+    "per_scorer_breakdown": [
+      {
+        "scorer_id": "rubric_judge_opus",
+        "role": "score",
+        "passed_gate": null,
+        "raw_score": 6.5,
+        "scale": [0, 10],
+        "notes": []
+      },
+      {
+        "scorer_id": "ssr_core_local",
+        "role": "score",
+        "passed_gate": null,
+        "raw_score": 6.5,
+        "scale": [0, 10],
+        "notes": [
+          "ankit + ravi sampled successfully (8 samples each).",
+          "mei provider timed out; persona excluded from aggregate."
+        ]
+      },
+      {
+        "scorer_id": "voice_drift",
+        "role": "score",
+        "passed_gate": null,
+        "raw_score": 6.0,
+        "scale": [0, 10],
+        "notes": []
+      }
+    ],
+    "metadata": {
+      "cost_usd": 0.048,
+      "latency_ms": 12200,
+      "models_used": ["claude-opus-4-7", "claude-sonnet-4-6"]
+    }
+  },
+  "computed_at": "2026-04-30T11:51:12.420Z",
+  "cost_usd": 0.048,
+  "is_stale": false
+}

--- a/tests/fixtures/editorial-room/v0/score_snapshot.pending.json
+++ b/tests/fixtures/editorial-room/v0/score_snapshot.pending.json
@@ -1,0 +1,37 @@
+{
+  "id": "01HXYZSCRSNAP010PENDINGAAAA",
+  "piece_id": "piece_01HXYZ789ABC",
+  "setup_version": 7,
+  "object_kind": "topic",
+  "object_ref": "topic/ai-impact-on-game-dev-how-embracers-writedown-changed-indie-publishing-terms",
+  "object_content_hash": "sha256:topic001hash000000000000000000000000000000000000000000000000000",
+  "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default",
+  "selected_persona_slugs": [
+    "persona/ankit-indie-dev",
+    "persona/ravi-studio-lead",
+    "persona/mei-publisher"
+  ],
+  "result": {
+    "schema_version": "0",
+    "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default",
+    "aggregate_score": null,
+    "score_scale": [0, 10],
+    "score_direction": "higher_better",
+    "per_dimension": {},
+    "per_persona": null,
+    "confidence": "experimental",
+    "notes": [
+      "pending — scoring run in flight (run_id 01HXYZRUNSCR010PENDINGAA)",
+      "no aggregate yet; UI should render skeleton/ellipsis."
+    ],
+    "per_scorer_breakdown": [],
+    "metadata": {
+      "cost_usd": 0,
+      "latency_ms": 0,
+      "models_used": []
+    }
+  },
+  "computed_at": "2026-04-30T11:46:55.000Z",
+  "cost_usd": null,
+  "is_stale": false
+}

--- a/tests/fixtures/editorial-room/v0/score_snapshot.stale.json
+++ b/tests/fixtures/editorial-room/v0/score_snapshot.stale.json
@@ -1,0 +1,63 @@
+{
+  "id": "01HXYZSCRSNAP012STALEAAAAAA",
+  "piece_id": "piece_01HXYZ789ABC",
+  "setup_version": 6,
+  "object_kind": "topic",
+  "object_ref": "topic/ai-impact-on-game-dev-how-embracers-writedown-changed-indie-publishing-terms",
+  "object_content_hash": "sha256:topic001hash000000000000000000000000000000000000000000000000000",
+  "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default",
+  "selected_persona_slugs": [
+    "persona/ankit-indie-dev",
+    "persona/ravi-studio-lead",
+    "persona/mei-publisher"
+  ],
+  "result": {
+    "schema_version": "0",
+    "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default",
+    "aggregate_score": 7.8,
+    "score_scale": [0, 10],
+    "score_direction": "higher_better",
+    "per_dimension": {
+      "specificity": 8.2,
+      "disputability": 7.5,
+      "novelty": 8.0,
+      "voice_match": 7.6
+    },
+    "per_persona": {
+      "persona/ankit-indie-dev": 9.0,
+      "persona/ravi-studio-lead": 9.0,
+      "persona/mei-publisher": 7.0
+    },
+    "confidence": "absolute",
+    "notes": [
+      "Computed before Setup change; setup_version 6 → 7 invalidated this snapshot.",
+      "Recompute on next read or explicit refresh."
+    ],
+    "per_scorer_breakdown": [
+      {
+        "scorer_id": "rubric_judge_opus",
+        "role": "score",
+        "passed_gate": null,
+        "raw_score": 7.6,
+        "scale": [0, 10],
+        "notes": []
+      },
+      {
+        "scorer_id": "ssr_core_local",
+        "role": "score",
+        "passed_gate": null,
+        "raw_score": 8.0,
+        "scale": [0, 10],
+        "notes": []
+      }
+    ],
+    "metadata": {
+      "cost_usd": 0.064,
+      "latency_ms": 11420,
+      "models_used": ["claude-opus-4-7", "claude-sonnet-4-6"]
+    }
+  },
+  "computed_at": "2026-04-29T18:22:14.180Z",
+  "cost_usd": 0.064,
+  "is_stale": true
+}

--- a/tests/fixtures/editorial-room/v0/score_snapshot.unknown.json
+++ b/tests/fixtures/editorial-room/v0/score_snapshot.unknown.json
@@ -1,0 +1,37 @@
+{
+  "id": "01HXYZSCRSNAP011UNKNOWNAAAA",
+  "piece_id": "piece_01HXYZ789ABC",
+  "setup_version": 7,
+  "object_kind": "topic",
+  "object_ref": "topic/ai-impact-on-game-dev-the-6-person-studio-is-the-new-20-person-studio",
+  "object_content_hash": "sha256:topic011hash000000000000000000000000000000000000000000000000000",
+  "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default",
+  "selected_persona_slugs": [
+    "persona/ankit-indie-dev",
+    "persona/ravi-studio-lead",
+    "persona/mei-publisher"
+  ],
+  "result": {
+    "schema_version": "0",
+    "scoring_pipeline_slug": "scoring_pipeline/gamemakers_default",
+    "aggregate_score": null,
+    "score_scale": [0, 10],
+    "score_direction": "higher_better",
+    "per_dimension": {},
+    "per_persona": null,
+    "confidence": "experimental",
+    "notes": [
+      "unknown — never computed for this object_ref + setup_version + content_hash combination.",
+      "User has not yet triggered scoring; render as 'no signal' rather than 'pending'."
+    ],
+    "per_scorer_breakdown": [],
+    "metadata": {
+      "cost_usd": 0,
+      "latency_ms": 0,
+      "models_used": []
+    }
+  },
+  "computed_at": "1970-01-01T00:00:00.000Z",
+  "cost_usd": null,
+  "is_stale": false
+}


### PR DESCRIPTION
## Summary
Closes the second batch of 0p-2 fixture gaps from `06_PHASE_1A_KICKOFF.md`. 8 new fixtures, no schema or test-runner changes (longest-prefix matching auto-discovers them).

## What's added
**ScoreSnapshot state variants** (4 fixtures):
- `score_snapshot.pending` — scoring run in flight; `aggregate_score: null`; empty `per_dimension`; notes flag the active run_id
- `score_snapshot.unknown` — never computed; epoch `computed_at` as a UI hint to render 'no signal' rather than 'pending'
- `score_snapshot.stale` — full result populated under `setup_version: 6` while current is 7; `is_stale: true`
- `score_snapshot.partial` — Mei provider timed out mid-round; aggregate computed over 2 of 3 personas; `per_persona` missing mei; `confidence: 'relative-only'`

**ProposalCard outcome variants** (4 fixtures):
- `proposal_card.accepted` — `create_topic` accepted as-is
- `proposal_card.rejected` — `create_topic` rejected with novelty rationale in `resolution_note`
- `proposal_card.edited` — `improve_toward_score` accepted with `user_edit` populated (softened 'one quarter' to 'two quarters' per source)
- `proposal_card.parked` — `create_topic` parked for next quarter with rationale

## Note on schema flexibility
`ScoreSnapshot` doesn't have an explicit status enum; pending / unknown / partial / scored states are encoded via the existing fields (`aggregate_score` nullable, `per_persona` nullable, `notes` array, `is_stale` flag). If the UI surfaces a need for an explicit status enum, that's a future contract change. Documented inline in the fixture `notes` arrays so consumers see the conventional encoding.

## What's still deferred
- **GameMakers draft (TalkOutputRevision)** — held until 0p-b editor-loop work begins so the fixture content reflects the actual editor's output shape (Tiptap JSON + content_md_snapshot + markdown_source_map all need to be coherent with each other; cheaper to author when we know what the editor produces).

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test -- src/clawrocket/contracts/editorial-room.test.ts` → 99/99 pass (was 83, +16)
- [x] `npm run format:check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)