### PR TITLE
feat: Theme + Topics workspace + phase-strip navigation (0p-a)

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -32,6 +32,7 @@ import {
 import { AiAgentsPage } from './pages/AiAgentsPage';
 import { DataConnectorsPage } from './pages/DataConnectorsPage';
 import { EditorialSetupPage } from './pages/EditorialSetupPage';
+import { ThemeTopicsWorkspacePage } from './pages/ThemeTopicsWorkspacePage';
 import { MainChannelPage } from './pages/MainChannelPage';
 import { TalkDetailPage } from './pages/TalkDetailPage';
 import { TalkListPage } from './pages/TalkListPage';
@@ -687,6 +688,12 @@ export function App() {
         <Route
           path="/editorial/setup"
           element={<EditorialSetupPage onUnauthorized={handleUnauthorized} />}
+        />
+        <Route
+          path="/editorial/theme-topics"
+          element={
+            <ThemeTopicsWorkspacePage onUnauthorized={handleUnauthorized} />
+          }
         />
         <Route
           path="/editorial/*"

--- a/webapp/src/components/EditorialPhaseStrip.tsx
+++ b/webapp/src/components/EditorialPhaseStrip.tsx
@@ -1,0 +1,82 @@
+import { Link } from 'react-router-dom';
+
+export type EditorialPhaseId =
+  | 'setup'
+  | 'theme-topics'
+  | 'points-outline'
+  | 'draft'
+  | 'polish'
+  | 'ship';
+
+type Phase = {
+  id: EditorialPhaseId;
+  label: string;
+  path: string | null;
+};
+
+const PHASES: ReadonlyArray<Phase> = [
+  { id: 'setup', label: '01 SETUP', path: '/editorial/setup' },
+  {
+    id: 'theme-topics',
+    label: '02 THEME + TOPICS',
+    path: '/editorial/theme-topics',
+  },
+  { id: 'points-outline', label: '03 POINTS + OUTLINE', path: null },
+  { id: 'draft', label: '04 DRAFT', path: null },
+  { id: 'polish', label: '05 POLISH', path: null },
+  { id: 'ship', label: '06 SHIP', path: null },
+];
+
+export function EditorialPhaseStrip({
+  activePhase,
+}: {
+  activePhase: EditorialPhaseId;
+}) {
+  return (
+    <header className="editorial-phase-strip">
+      <div className="editorial-phase-strip-brand">
+        <span className="editorial-phase-strip-mark">ER</span>
+        <span className="editorial-phase-strip-title">
+          Editorial Room <span className="editorial-version">v0P</span>
+        </span>
+      </div>
+      <nav className="editorial-phase-strip-pills">
+        {PHASES.map((p) => {
+          const isActive = p.id === activePhase;
+          const isDisabled = !p.path;
+          const className =
+            'editorial-phase-pill' +
+            (isActive ? ' editorial-phase-pill-active' : '') +
+            (isDisabled ? ' editorial-phase-pill-disabled' : '');
+          if (p.path && !isActive) {
+            return (
+              <Link key={p.id} to={p.path} className={className}>
+                {p.label}
+              </Link>
+            );
+          }
+          return (
+            <span
+              key={p.id}
+              className={className}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              {p.label}
+            </span>
+          );
+        })}
+      </nav>
+      <div className="editorial-phase-strip-actions">
+        <button type="button" className="editorial-chip-button" disabled>
+          ⌘K
+        </button>
+        <button type="button" className="editorial-chip-button" disabled>
+          HISTORY
+        </button>
+        <button type="button" className="editorial-chip-button" disabled>
+          SAVE
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/webapp/src/pages/EditorialSetupPage.tsx
+++ b/webapp/src/pages/EditorialSetupPage.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useState } from 'react';
 
+import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
+
 // SetupState mirrors docs/contracts/editorial-room/v0/setup_state.schema.json
 // (also in EDITORIAL_ROOM_CONTRACT.md §2.1). Held in component state for the
 // 0p-a vertical slice; no persistence yet.
@@ -30,15 +32,6 @@ type SetupState = {
   updated_at: string;
   updated_by_user_id: string;
 };
-
-const PHASES = [
-  { id: 'setup', label: '01 SETUP' },
-  { id: 'theme-topics', label: '02 THEME + TOPICS' },
-  { id: 'points-outline', label: '03 POINTS + OUTLINE' },
-  { id: 'draft', label: '04 DRAFT' },
-  { id: 'polish', label: '05 POLISH' },
-  { id: 'ship', label: '06 SHIP' },
-] as const;
 
 type SectionId = 'deliverable' | 'audience' | 'llm-room' | 'scoring';
 
@@ -160,35 +153,7 @@ export function EditorialSetupPage(_props: Props) {
 
   return (
     <div className="editorial-room">
-      <header className="editorial-phase-strip">
-        <div className="editorial-phase-strip-brand">
-          <span className="editorial-phase-strip-mark">ER</span>
-          <span className="editorial-phase-strip-title">
-            Editorial Room <span className="editorial-version">v0P</span>
-          </span>
-        </div>
-        <nav className="editorial-phase-strip-pills">
-          {PHASES.map((p) => (
-            <span
-              key={p.id}
-              className={`editorial-phase-pill${p.id === 'setup' ? ' editorial-phase-pill-active' : ''}`}
-            >
-              {p.label}
-            </span>
-          ))}
-        </nav>
-        <div className="editorial-phase-strip-actions">
-          <button type="button" className="editorial-chip-button" disabled>
-            ⌘K
-          </button>
-          <button type="button" className="editorial-chip-button" disabled>
-            HISTORY
-          </button>
-          <button type="button" className="editorial-chip-button" disabled>
-            SAVE
-          </button>
-        </div>
-      </header>
+      <EditorialPhaseStrip activePhase="setup" />
 
       <div className="editorial-meta-bar">
         <span className="editorial-meta-prefix">SETUP</span>

--- a/webapp/src/pages/ThemeTopicsWorkspacePage.tsx
+++ b/webapp/src/pages/ThemeTopicsWorkspacePage.tsx
@@ -1,0 +1,824 @@
+import { useMemo, useState } from 'react';
+
+import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
+
+// ───────────────────────────────────────────────────────────────────────────
+// Fixture-shaped data, hardcoded inline for the 0p-a vertical slice. Real
+// loads come from rocketorchestra page reads + clawrocket score_snapshots /
+// discussion_sessions / point_note_blocks once those are wired up.
+// ───────────────────────────────────────────────────────────────────────────
+
+type Theme = {
+  slug: string;
+  name: string;
+  version: number;
+  topicCount: number;
+  score: number;
+};
+
+type Persona = { slug: string; letter: string; name: string };
+
+type ScoreRow = {
+  persona: Persona;
+  score: number;
+  note: string;
+};
+
+type Topic = {
+  slug: string;
+  workingTitle: string;
+  thesis: string;
+  score: number;
+  scoreRow: ScoreRow[];
+  aggregate: { score: number; ssr: number; gatesPass: boolean };
+  notes: NoteBlock[];
+  discussion: DiscussionTurn[];
+  sources: SourceCard[];
+  isCounter?: boolean;
+};
+
+// Topic-scoped note types per design/02_theme_topics.md §6.4
+// ('angle | stake | thought | concern | other'). Differs from the schema's
+// PointNoteBlock.type enum — flagged in earlier PR descriptions; resolved
+// in a future contract reconciliation.
+type NoteType = 'angle' | 'stake' | 'thought' | 'concern' | 'other';
+type NoteBlock = {
+  id: string;
+  type: NoteType;
+  body: string;
+  debated?: boolean;
+};
+
+type DiscussionTurn = {
+  id: string;
+  agent: Persona;
+  timestamp: string;
+  noteRefs: NoteType[];
+  body: string;
+  proposes: string | null;
+};
+
+type SourceCard = {
+  id: string;
+  index: number;
+  type: 'PRIMARY' | 'ANEC' | 'SEC';
+  title: string;
+  detail: string;
+  cited: boolean;
+  disputed?: boolean;
+};
+
+const PRIMARY_PERSONAS: ReadonlyArray<Persona> = [
+  { slug: 'persona/ankit-indie-dev', letter: 'A', name: 'ANKIT' },
+  { slug: 'persona/ravi-studio-lead', letter: 'R', name: 'RAVI' },
+  { slug: 'persona/mei-publisher', letter: 'M', name: 'MEI' },
+];
+
+const SETUP_CHIPS = {
+  length: '1k–1.4k words',
+  audience: 'indie devs · mid-career',
+  ssrThreshold: 'SSR ≥ 0.6',
+  pmfThreshold: 'PMF ≥ 7',
+};
+
+const THEMES: ReadonlyArray<Theme> = [
+  {
+    slug: 'ai-impact',
+    name: 'AI Impact on Game Dev',
+    version: 4,
+    topicCount: 3,
+    score: 7.4,
+  },
+  {
+    slug: 'creative-burnout',
+    name: 'Creative Burnout',
+    version: 2,
+    topicCount: 1,
+    score: 7.1,
+  },
+  {
+    slug: 'indie-economics-2025',
+    name: 'Indie Economics 2025',
+    version: 3,
+    topicCount: 2,
+    score: 6.8,
+  },
+  {
+    slug: 'genre-consolidation',
+    name: 'Genre Consolidation',
+    version: 1,
+    topicCount: 1,
+    score: 6.6,
+  },
+  {
+    slug: 'steam-discoverability',
+    name: 'Steam Discoverability',
+    version: 2,
+    topicCount: 1,
+    score: 6.2,
+  },
+  {
+    slug: 'publisher-relations',
+    name: 'Publisher Relations',
+    version: 1,
+    topicCount: 0,
+    score: 5.4,
+  },
+];
+
+const EMBRACER_TOPIC: Topic = {
+  slug: 'embracer-writedown',
+  workingTitle: "How Embracer's $2.1B writedown changed indie publishing terms",
+  thesis:
+    "Surviving studios are signing 2022-rate deals to keep going — Embracer's writedown shifted bargaining power away from devs in a way that's locked in for 18+ months.",
+  score: 7.8,
+  scoreRow: [
+    { persona: PRIMARY_PERSONAS[0], score: 9, note: '"lead with this"' },
+    {
+      persona: PRIMARY_PERSONAS[1],
+      score: 9,
+      note: 'needs a person · ⚑',
+    },
+    {
+      persona: PRIMARY_PERSONAS[2],
+      score: 7,
+      note: '"verify Devolver $5"',
+    },
+  ],
+  aggregate: { score: 7.8, ssr: 0.78, gatesPass: true },
+  notes: [
+    {
+      id: 'n1',
+      type: 'angle',
+      body: 'What changed in MG accounting — your next deal will be different.',
+      debated: true,
+    },
+    {
+      id: 'n2',
+      type: 'stake',
+      body: 'Mid-tier studios pay; tiny indies get a relative tailwind.',
+    },
+    {
+      id: 'n3',
+      type: 'thought',
+      body: "The 'reverts in 18 months' counter is publisher-bias — flag above.",
+    },
+    {
+      id: 'n4',
+      type: 'concern',
+      body: 'Annapurna staffer (background) contradicts filings — VERIFY before draft.',
+      debated: true,
+    },
+    {
+      id: 'n5',
+      type: 'thought',
+      body: 'Devolver Q4 prelim ambiguous on conditional MGs.',
+    },
+  ],
+  discussion: [
+    {
+      id: 't1',
+      agent: PRIMARY_PERSONAS[0],
+      timestamp: '11:42',
+      noteRefs: ['angle'],
+      body: 'The angle note is the load-bearing one. Lead with the MG-as-conditional-liability framing.',
+      proposes: null,
+    },
+    {
+      id: 't2',
+      agent: PRIMARY_PERSONAS[1],
+      timestamp: '11:43',
+      noteRefs: ['stake'],
+      body: "The stake is right but abstract. Add a thought-note: which specific solo dev got their deal repapered? That's the piece.",
+      proposes: 'ADD: SOLO-DEV CASE STUDY',
+    },
+    {
+      id: 't3',
+      agent: PRIMARY_PERSONAS[2],
+      timestamp: '11:43',
+      noteRefs: ['concern'],
+      body: 'Annapurna concern is a real falsifier — needs verification before this clears Polish. Flagged.',
+      proposes: null,
+    },
+    {
+      id: 't4',
+      agent: PRIMARY_PERSONAS[0],
+      timestamp: '11:47',
+      noteRefs: ['stake', 'concern'],
+      body: "Agreed. If Annapurna's claim holds, the 'tiny indies tailwind' stake is wrong, not just incomplete.",
+      proposes: null,
+    },
+  ],
+  sources: [
+    {
+      id: 's1',
+      index: 1,
+      type: 'PRIMARY',
+      title: 'Embracer Q3 8-K',
+      detail: 'pp.14-16, MG reclassification',
+      cited: true,
+    },
+    {
+      id: 's2',
+      index: 2,
+      type: 'PRIMARY',
+      title: 'Devolver Q4 prelim',
+      detail: '$5 conditional advances',
+      cited: true,
+      disputed: true,
+    },
+    {
+      id: 's3',
+      index: 3,
+      type: 'ANEC',
+      title: 'Annapurna staffer',
+      detail: 'background, contradicts $2',
+      cited: true,
+    },
+    {
+      id: 's4',
+      index: 4,
+      type: 'SEC',
+      title: 'Game Industry News',
+      detail: 'Apr 2025 explainer',
+      cited: false,
+    },
+  ],
+};
+
+const SIX_PERSON_TOPIC: Topic = {
+  slug: '6-person-studio',
+  workingTitle: 'The 6-person studio is the new 20-person studio',
+  thesis:
+    'AI-assisted pipelines compress the staffing curve so a 6-person team ships what a 20-person team did in 2022 — but only if you redesign the org.',
+  score: 6.6,
+  scoreRow: [
+    { persona: PRIMARY_PERSONAS[0], score: 7, note: '"angle is real"' },
+    {
+      persona: PRIMARY_PERSONAS[1],
+      score: 6,
+      note: 'org-redesign hand-wave',
+    },
+    { persona: PRIMARY_PERSONAS[2], score: 7, note: 'reasonable framing' },
+  ],
+  aggregate: { score: 6.6, ssr: 0.62, gatesPass: true },
+  notes: [
+    {
+      id: 'n1',
+      type: 'angle',
+      body: 'Compressed staffing curve, not just "AI makes faster" — the org has to redesign roles.',
+    },
+    {
+      id: 'n2',
+      type: 'stake',
+      body: 'Founders who keep the 20-person mental model burn 2× the runway.',
+    },
+    {
+      id: 'n3',
+      type: 'concern',
+      body: 'Sample of 1 (Manor Lords). Need second case before this is a Topic.',
+    },
+  ],
+  discussion: [
+    {
+      id: 't1',
+      agent: PRIMARY_PERSONAS[1],
+      timestamp: '10:14',
+      noteRefs: ['concern'],
+      body: 'Sample of 1 means we either find a second case study or downgrade to a Stake note inside the Embracer Topic.',
+      proposes: null,
+    },
+  ],
+  sources: [
+    {
+      id: 's1',
+      index: 1,
+      type: 'PRIMARY',
+      title: 'Manor Lords postmortem',
+      detail: 'Slavic Magic blog, Mar 2025',
+      cited: true,
+    },
+  ],
+};
+
+const AI_ART_TOPIC: Topic = {
+  slug: 'ai-art-pl',
+  workingTitle: 'Why AI-art P&L wins on paper, loses at funding time',
+  thesis:
+    'Investors discount AI-asset pipelines because the IP-defensibility story is unsettled — the savings are real but the cap-table impact is negative.',
+  score: 6.1,
+  scoreRow: [
+    { persona: PRIMARY_PERSONAS[0], score: 7, note: 'punchy framing' },
+    { persona: PRIMARY_PERSONAS[1], score: 6, note: 'thin on data' },
+    {
+      persona: PRIMARY_PERSONAS[2],
+      score: 5,
+      note: '"name 3 funds that say this"',
+    },
+  ],
+  aggregate: { score: 6.1, ssr: 0.59, gatesPass: false },
+  notes: [
+    {
+      id: 'n1',
+      type: 'angle',
+      body: 'Cap-table discount is real — investors are pricing legal risk into AI-asset studios.',
+    },
+    {
+      id: 'n2',
+      type: 'thought',
+      body: 'Need at least 3 named funds for this to clear the gate.',
+    },
+  ],
+  discussion: [],
+  sources: [],
+};
+
+const COUNTER_TOPIC: Topic = {
+  slug: 'ai-tooling-overhyped',
+  workingTitle: 'Why AI tooling is overhyped for solo devs',
+  thesis:
+    'For solo devs the productivity gains are real but the pipeline overhead eats most of them — the marginal hire is still cheaper than the marginal AI subscription.',
+  score: 5.8,
+  scoreRow: [
+    { persona: PRIMARY_PERSONAS[0], score: 6, note: 'contrarian — keep' },
+    { persona: PRIMARY_PERSONAS[1], score: 5, note: 'overstated' },
+    { persona: PRIMARY_PERSONAS[2], score: 6, note: 'useful counter' },
+  ],
+  aggregate: { score: 5.8, ssr: 0.52, gatesPass: false },
+  notes: [],
+  discussion: [],
+  sources: [],
+  isCounter: true,
+};
+
+const TOPICS_BY_THEME: Record<string, ReadonlyArray<Topic>> = {
+  'ai-impact': [EMBRACER_TOPIC, SIX_PERSON_TOPIC, AI_ART_TOPIC, COUNTER_TOPIC],
+  'creative-burnout': [],
+  'indie-economics-2025': [],
+  'genre-consolidation': [],
+  'steam-discoverability': [],
+  'publisher-relations': [],
+};
+
+// ───────────────────────────────────────────────────────────────────────────
+// Page
+// ───────────────────────────────────────────────────────────────────────────
+
+const NOTE_TYPE_LABEL: Record<NoteType, string> = {
+  angle: 'ANGLE',
+  stake: 'STAKE',
+  thought: 'THOUGHT',
+  concern: 'CONCERN',
+  other: 'OTHER',
+};
+
+const NOTE_TYPES: ReadonlyArray<NoteType> = [
+  'angle',
+  'stake',
+  'thought',
+  'concern',
+  'other',
+];
+
+type Props = {
+  onUnauthorized?: () => void;
+};
+
+export function ThemeTopicsWorkspacePage(_props: Props) {
+  const [activeThemeSlug, setActiveThemeSlug] = useState<string>('ai-impact');
+  const [activeTopicSlug, setActiveTopicSlug] =
+    useState<string>('embracer-writedown');
+
+  const topics = useMemo(
+    () => TOPICS_BY_THEME[activeThemeSlug] ?? [],
+    [activeThemeSlug],
+  );
+  const mainTopics = useMemo(
+    () => topics.filter((t) => !t.isCounter),
+    [topics],
+  );
+  const counterTopics = useMemo(
+    () => topics.filter((t) => t.isCounter),
+    [topics],
+  );
+
+  const activeTopic =
+    topics.find((t) => t.slug === activeTopicSlug) ?? topics[0] ?? null;
+
+  const activeTheme = THEMES.find((t) => t.slug === activeThemeSlug);
+
+  return (
+    <div className="editorial-room">
+      <EditorialPhaseStrip activePhase="theme-topics" />
+
+      <div className="editorial-tt-chipbar">
+        <div className="editorial-tt-chipbar-personas">
+          {PRIMARY_PERSONAS.map((p) => (
+            <span
+              key={p.slug}
+              className="editorial-persona-avatar"
+              data-persona={p.letter}
+            >
+              {p.letter}
+            </span>
+          ))}
+          <span className="editorial-tt-chipbar-text">
+            {PRIMARY_PERSONAS.length} personas
+          </span>
+        </div>
+        <span className="editorial-tt-chipbar-sep">·</span>
+        <span className="editorial-tt-chipbar-text">{SETUP_CHIPS.length}</span>
+        <span className="editorial-tt-chipbar-sep">·</span>
+        <span className="editorial-tt-chipbar-text">
+          {SETUP_CHIPS.audience}
+        </span>
+        <span className="editorial-tt-chipbar-sep">·</span>
+        <span className="editorial-tt-chipbar-pip">
+          {SETUP_CHIPS.ssrThreshold}
+        </span>
+        <span className="editorial-tt-chipbar-pip">
+          {SETUP_CHIPS.pmfThreshold}
+        </span>
+        <button
+          type="button"
+          className="editorial-chip-button editorial-tt-chipbar-edit"
+          disabled
+        >
+          edit setup
+        </button>
+      </div>
+
+      <div className="editorial-tt-grid">
+        {/* THEMES COLUMN */}
+        <aside className="editorial-tt-themes">
+          <h2 className="editorial-rail-heading">THEMES · {THEMES.length}</h2>
+          <ul className="editorial-tt-theme-list">
+            {THEMES.map((t) => (
+              <li key={t.slug}>
+                <button
+                  type="button"
+                  className={
+                    'editorial-tt-theme-card' +
+                    (t.slug === activeThemeSlug
+                      ? ' editorial-tt-theme-card-active'
+                      : '')
+                  }
+                  onClick={() => {
+                    setActiveThemeSlug(t.slug);
+                    const next = TOPICS_BY_THEME[t.slug] ?? [];
+                    if (next.length > 0) {
+                      setActiveTopicSlug(next[0].slug);
+                    }
+                  }}
+                >
+                  <span className="editorial-tt-theme-name">{t.name}</span>
+                  <span className="editorial-tt-theme-meta">
+                    V{t.version} · {t.topicCount} TOPICS
+                  </span>
+                  <span className="editorial-tt-theme-score">
+                    {t.score.toFixed(1)}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            className="editorial-tt-propose-button"
+            disabled
+          >
+            + PROPOSE THEMES
+          </button>
+        </aside>
+
+        {/* TOPICS COLUMN */}
+        <aside className="editorial-tt-topics">
+          <h2 className="editorial-rail-heading">
+            TOPICS · UNDER{' '}
+            <span className="editorial-tt-topics-theme">
+              {activeTheme?.name.toUpperCase().replace(/ /g, ' ')}
+            </span>
+            <span className="editorial-rail-heading-count">
+              · {mainTopics.length}
+            </span>
+          </h2>
+          {mainTopics.length === 0 ? (
+            <p className="editorial-tt-empty">
+              No Topics under this Theme yet.
+            </p>
+          ) : (
+            <ul className="editorial-tt-topic-list">
+              {mainTopics.map((t) => (
+                <li key={t.slug}>
+                  <button
+                    type="button"
+                    className={
+                      'editorial-tt-topic-card' +
+                      (t.slug === activeTopicSlug
+                        ? ' editorial-tt-topic-card-active'
+                        : '')
+                    }
+                    onClick={() => setActiveTopicSlug(t.slug)}
+                  >
+                    <span className="editorial-tt-topic-title">
+                      {t.workingTitle}
+                    </span>
+                    <span className="editorial-tt-topic-score">
+                      {t.score.toFixed(1)}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+          <button
+            type="button"
+            className="editorial-tt-propose-button"
+            disabled
+          >
+            + PROPOSE TOPICS
+          </button>
+
+          {counterTopics.length > 0 ? (
+            <>
+              <h2 className="editorial-rail-heading editorial-rail-heading-spaced editorial-rail-heading-counter">
+                COUNTER-TOPIC · {counterTopics.length}
+              </h2>
+              <ul className="editorial-tt-topic-list">
+                {counterTopics.map((t) => (
+                  <li key={t.slug}>
+                    <button
+                      type="button"
+                      className={
+                        'editorial-tt-topic-card editorial-tt-topic-card-counter' +
+                        (t.slug === activeTopicSlug
+                          ? ' editorial-tt-topic-card-active'
+                          : '')
+                      }
+                      onClick={() => setActiveTopicSlug(t.slug)}
+                    >
+                      <span className="editorial-tt-topic-title">
+                        {t.workingTitle}
+                      </span>
+                      <span className="editorial-tt-topic-score">
+                        {t.score.toFixed(1)}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : null}
+        </aside>
+
+        {/* CENTER: TOPIC DETAIL */}
+        <main className="editorial-tt-center">
+          {activeTopic ? (
+            <TopicDetail topic={activeTopic} />
+          ) : (
+            <div className="editorial-tt-center-empty">
+              Pick a Theme with Topics to start.
+            </div>
+          )}
+        </main>
+
+        {/* SOURCES RAIL */}
+        <aside className="editorial-tt-sources">
+          <div className="editorial-tt-sources-header">
+            <h2 className="editorial-rail-heading">
+              SOURCES · {activeTopic?.sources.length ?? 0}
+            </h2>
+            <button type="button" className="editorial-chip-button" disabled>
+              + ADD
+            </button>
+          </div>
+          {activeTopic && activeTopic.sources.length > 0 ? (
+            <ul className="editorial-tt-source-list">
+              {activeTopic.sources.map((s) => (
+                <li key={s.id} className="editorial-tt-source-card">
+                  <div className="editorial-tt-source-row">
+                    <span className="editorial-tt-source-index">
+                      SRC #{s.index}
+                    </span>
+                    <span className="editorial-tt-source-type">{s.type}</span>
+                  </div>
+                  <div className="editorial-tt-source-title">{s.title}</div>
+                  <div className="editorial-tt-source-detail">{s.detail}</div>
+                  <div className="editorial-tt-source-badges">
+                    {s.cited ? (
+                      <span className="editorial-tt-source-badge editorial-tt-source-badge-cited">
+                        ✓ CITED
+                      </span>
+                    ) : null}
+                    {s.disputed ? (
+                      <span className="editorial-tt-source-badge editorial-tt-source-badge-disputed">
+                        ! DISPUTED
+                      </span>
+                    ) : null}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="editorial-tt-empty">No sources yet.</p>
+          )}
+
+          <div className="editorial-tt-source-dropzone">
+            DROP FILE OR PASTE URL
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function TopicDetail({ topic }: { topic: Topic }) {
+  return (
+    <article className="editorial-tt-topic-detail">
+      <header className="editorial-tt-topic-header">
+        <span className="editorial-tt-topic-eyebrow">TOPIC</span>
+        <h1 className="editorial-tt-topic-heading">{topic.workingTitle}</h1>
+        <div className="editorial-tt-topic-actions">
+          <button type="button" className="editorial-chip-button" disabled>
+            + POINT
+          </button>
+          <button
+            type="button"
+            className="editorial-chip-button editorial-chip-button-primary"
+            disabled
+          >
+            OPTIMIZE TOPIC →
+          </button>
+        </div>
+      </header>
+
+      <div className="editorial-tt-score-row">
+        {topic.scoreRow.map((cell) => (
+          <div key={cell.persona.slug} className="editorial-tt-score-cell">
+            <div className="editorial-tt-score-cell-head">
+              <span
+                className="editorial-persona-avatar editorial-persona-avatar-sm"
+                data-persona={cell.persona.letter}
+              >
+                {cell.persona.letter}
+              </span>
+              <span className="editorial-tt-score-cell-name">
+                {cell.persona.name}
+              </span>
+            </div>
+            <div
+              className={
+                'editorial-tt-score-cell-number' +
+                (cell.score < 5
+                  ? ' editorial-tt-score-cell-number-low'
+                  : cell.score >= 7
+                    ? ' editorial-tt-score-cell-number-high'
+                    : '')
+              }
+            >
+              {cell.score}
+            </div>
+            <div className="editorial-tt-score-cell-note">{cell.note}</div>
+          </div>
+        ))}
+        <div className="editorial-tt-score-cell editorial-tt-score-cell-aggregate">
+          <div className="editorial-tt-score-cell-head">
+            <span className="editorial-tt-score-cell-name">AGGREGATE</span>
+          </div>
+          <div className="editorial-tt-score-cell-number">
+            {topic.aggregate.score.toFixed(1)}
+          </div>
+          <div className="editorial-tt-score-cell-note">
+            SSR {topic.aggregate.ssr.toFixed(2)} ·{' '}
+            {topic.aggregate.gatesPass ? '✓ GATES' : '✗ GATES'}
+          </div>
+        </div>
+      </div>
+
+      <section className="editorial-tt-oneliner">
+        <h3 className="editorial-tt-section-label">ONE-LINER</h3>
+        <p className="editorial-tt-oneliner-body">{topic.thesis}</p>
+      </section>
+
+      <section className="editorial-tt-notes">
+        <header className="editorial-tt-notes-header">
+          <h3 className="editorial-tt-section-label">
+            NOTES · {topic.notes.length}
+          </h3>
+          <div className="editorial-tt-notes-add">
+            {NOTE_TYPES.map((nt) => (
+              <button
+                key={nt}
+                type="button"
+                className={`editorial-chip-button editorial-tt-note-chip editorial-tt-note-chip-${nt}`}
+                disabled
+              >
+                + {NOTE_TYPE_LABEL[nt]}
+              </button>
+            ))}
+          </div>
+        </header>
+        {topic.notes.length === 0 ? (
+          <p className="editorial-tt-empty">
+            No notes yet — pick a type to start.
+          </p>
+        ) : (
+          <ul className="editorial-tt-note-grid">
+            {topic.notes.map((n) => (
+              <li
+                key={n.id}
+                className={`editorial-tt-note-card editorial-tt-note-card-${n.type}`}
+              >
+                <div className="editorial-tt-note-head">
+                  <span
+                    className={`editorial-tt-note-dot editorial-tt-note-dot-${n.type}`}
+                  />
+                  <span className="editorial-tt-note-type">
+                    {NOTE_TYPE_LABEL[n.type]}
+                  </span>
+                  {n.debated ? (
+                    <span className="editorial-tt-note-debated">DEBATED</span>
+                  ) : null}
+                </div>
+                <p className="editorial-tt-note-body">{n.body}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="editorial-tt-discussion">
+        <header className="editorial-tt-discussion-header">
+          <h3 className="editorial-tt-section-label">
+            PANEL DISCUSSION · {topic.discussion.length} TURNS
+            {topic.discussion.length > 0 ? ' DEBATING NOTES ABOVE' : ''}
+          </h3>
+          <span className="editorial-tt-discussion-last">
+            {topic.discussion.length > 0
+              ? `LAST ${topic.discussion[topic.discussion.length - 1].timestamp}`
+              : '—'}
+          </span>
+        </header>
+        {topic.discussion.length === 0 ? (
+          <p className="editorial-tt-empty">
+            No discussion yet — ask the panel.
+          </p>
+        ) : (
+          <ol className="editorial-tt-turn-list">
+            {topic.discussion.map((t) => (
+              <li key={t.id} className="editorial-tt-turn">
+                <div className="editorial-tt-turn-head">
+                  <span
+                    className="editorial-persona-avatar editorial-persona-avatar-sm"
+                    data-persona={t.agent.letter}
+                  >
+                    {t.agent.letter}
+                  </span>
+                  <span className="editorial-tt-turn-name">{t.agent.name}</span>
+                  <span className="editorial-tt-turn-timestamp">
+                    {t.timestamp}
+                  </span>
+                  {t.noteRefs.map((nr) => (
+                    <span
+                      key={nr}
+                      className={`editorial-tt-turn-noteref editorial-tt-turn-noteref-${nr}`}
+                    >
+                      ↑ note: {nr}
+                    </span>
+                  ))}
+                </div>
+                <p className="editorial-tt-turn-body">{t.body}</p>
+                {t.proposes ? (
+                  <p className="editorial-tt-turn-proposes">
+                    PROPOSES: {t.proposes}
+                  </p>
+                ) : null}
+              </li>
+            ))}
+          </ol>
+        )}
+        <div className="editorial-tt-discussion-input">
+          <input
+            type="text"
+            placeholder="Ask the panel — or @reference a note above…"
+            disabled
+          />
+          <div className="editorial-tt-discussion-mentions">
+            {['@ALL', '@A', '@R', '@M', '#NOTE'].map((m) => (
+              <span key={m} className="editorial-tt-discussion-mention">
+                {m}
+              </span>
+            ))}
+          </div>
+          <button
+            type="button"
+            className="editorial-chip-button editorial-chip-button-primary"
+            disabled
+          >
+            SEND ⌥↵
+          </button>
+        </div>
+      </section>
+    </article>
+  );
+}

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -4979,3 +4979,710 @@ a {
     display: none;
   }
 }
+
+/* ============================================================
+ * Editorial Room — Phase strip pill states (shared)
+ * ============================================================ */
+
+a.editorial-phase-pill {
+  text-decoration: none;
+  cursor: pointer;
+}
+
+a.editorial-phase-pill:hover {
+  background: #f4efe3;
+  color: #1d2433;
+}
+
+.editorial-phase-pill-disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* ============================================================
+ * Editorial Room — 02 THEME + TOPICS
+ * Spec: docs/design/02_theme_topics.md
+ * 4-column grid: Themes (140px) + Topics (155px) + Center + Sources (210px)
+ * ============================================================ */
+
+.editorial-tt-chipbar {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.55rem 1.25rem;
+  border-bottom: 1px solid #ddd6c8;
+  background: #fbf8f2;
+  flex-wrap: wrap;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  color: #1d2433;
+}
+
+.editorial-tt-chipbar-personas {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.editorial-tt-chipbar-text {
+  letter-spacing: 0.04em;
+}
+
+.editorial-tt-chipbar-sep {
+  color: #6c6655;
+  margin: 0 0.1rem;
+}
+
+.editorial-tt-chipbar-pip {
+  font-size: 0.65rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.45rem;
+  border: 1px solid #ddd6c8;
+  border-radius: 4px;
+  background: #fff;
+}
+
+.editorial-tt-chipbar-edit {
+  margin-left: auto;
+}
+
+.editorial-persona-avatar {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1d2433;
+  color: #fff;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.editorial-persona-avatar[data-persona='A'] {
+  background: #2e7d62;
+}
+.editorial-persona-avatar[data-persona='R'] {
+  background: #8a4b29;
+}
+.editorial-persona-avatar[data-persona='M'] {
+  background: #2c4a8b;
+}
+
+.editorial-persona-avatar-sm {
+  width: 18px;
+  height: 18px;
+  font-size: 0.62rem;
+}
+
+.editorial-tt-grid {
+  display: grid;
+  grid-template-columns: 160px 175px minmax(0, 1fr) 230px;
+  gap: 0;
+  overflow: hidden;
+}
+
+.editorial-tt-themes,
+.editorial-tt-topics {
+  border-right: 1px solid #ddd6c8;
+  padding: 0.85rem 0.7rem;
+  overflow-y: auto;
+  background: #fbf8f2;
+  display: flex;
+  flex-direction: column;
+}
+
+.editorial-rail-heading-count {
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: 400;
+  opacity: 0.65;
+}
+
+.editorial-rail-heading-counter {
+  color: #b7372a;
+}
+
+.editorial-tt-topics-theme {
+  display: block;
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  margin-top: 0.1rem;
+}
+
+.editorial-tt-theme-list,
+.editorial-tt-topic-list {
+  list-style: none;
+  margin: 0 0 0.4rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.editorial-tt-theme-card,
+.editorial-tt-topic-card {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.15rem 0.4rem;
+  padding: 0.5rem 0.55rem;
+  border: 1px solid #ddd6c8;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  color: inherit;
+}
+
+.editorial-tt-theme-card:hover,
+.editorial-tt-topic-card:hover {
+  background: #f4efe3;
+}
+
+.editorial-tt-theme-card-active,
+.editorial-tt-topic-card-active {
+  border-color: #1d2433;
+  background: #1d2433;
+  color: #fff;
+}
+
+.editorial-tt-theme-card-active:hover,
+.editorial-tt-topic-card-active:hover {
+  background: #1d2433;
+}
+
+.editorial-tt-topic-card-counter {
+  border-color: #b7372a;
+}
+
+.editorial-tt-topic-card-counter.editorial-tt-topic-card-active {
+  background: #b7372a;
+  border-color: #b7372a;
+}
+
+.editorial-tt-theme-name {
+  font-size: 0.85rem;
+  font-weight: 500;
+  grid-column: 1;
+}
+
+.editorial-tt-theme-meta {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.65;
+  grid-column: 1;
+}
+
+.editorial-tt-theme-score,
+.editorial-tt-topic-score {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.85rem;
+  font-weight: 600;
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  align-self: start;
+}
+
+.editorial-tt-topic-title {
+  font-size: 0.78rem;
+  line-height: 1.3;
+  grid-column: 1;
+}
+
+.editorial-tt-topic-score {
+  grid-row: 1;
+}
+
+.editorial-tt-propose-button {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.45rem 0.55rem;
+  border: 1px dashed #b9b09c;
+  background: transparent;
+  color: #6c6655;
+  border-radius: 6px;
+  cursor: pointer;
+  margin-top: 0.4rem;
+}
+
+.editorial-tt-propose-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.editorial-tt-empty {
+  font-size: 0.72rem;
+  color: #6c6655;
+  padding: 0.4rem 0.2rem;
+  font-style: italic;
+}
+
+.editorial-tt-center {
+  overflow-y: auto;
+  background: #fbf8f2;
+  padding: 1.2rem 1.5rem;
+}
+
+.editorial-tt-center-empty {
+  color: #6c6655;
+  font-style: italic;
+}
+
+.editorial-tt-topic-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.editorial-tt-topic-header {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.3rem 1rem;
+  align-items: start;
+}
+
+.editorial-tt-topic-eyebrow {
+  grid-column: 1;
+  display: inline-block;
+  width: max-content;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: #1d2433;
+  color: #fff;
+  padding: 0.18rem 0.45rem;
+  border-radius: 4px;
+}
+
+.editorial-tt-topic-heading {
+  grid-column: 1;
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-size: 1.6rem;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.editorial-tt-topic-actions {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  align-items: flex-end;
+}
+
+.editorial-tt-score-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.6rem;
+  border-top: 1px solid #ddd6c8;
+  border-bottom: 1px solid #ddd6c8;
+  padding: 0.85rem 0;
+}
+
+.editorial-tt-score-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.1rem 0.35rem;
+}
+
+.editorial-tt-score-cell-aggregate {
+  border-left: 1px solid #ddd6c8;
+}
+
+.editorial-tt-score-cell-head {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.editorial-tt-score-cell-name {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+}
+
+.editorial-tt-score-cell-number {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 1.85rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.editorial-tt-score-cell-number-low {
+  color: #b7372a;
+}
+
+.editorial-tt-score-cell-number-high {
+  color: #2e7d62;
+}
+
+.editorial-tt-score-cell-note {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.65rem;
+  font-style: italic;
+  color: #4a4738;
+  letter-spacing: 0.02em;
+}
+
+.editorial-tt-section-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.editorial-tt-oneliner-body {
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-style: italic;
+  font-size: 1rem;
+  line-height: 1.4;
+  margin: 0;
+  color: #1d2433;
+}
+
+.editorial-tt-notes-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.6rem;
+}
+
+.editorial-tt-notes-add {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.editorial-tt-note-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.editorial-tt-note-chip::before {
+  content: '';
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #6c6655;
+}
+
+.editorial-tt-note-chip-angle::before {
+  background: #2e7d62;
+}
+.editorial-tt-note-chip-concern::before {
+  background: #b7372a;
+}
+
+.editorial-tt-note-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.55rem;
+}
+
+.editorial-tt-note-card {
+  background: #fff;
+  border: 1px solid #ddd6c8;
+  border-left: 3px solid #6c6655;
+  border-radius: 6px;
+  padding: 0.6rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.editorial-tt-note-card-angle {
+  border-left-color: #2e7d62;
+}
+.editorial-tt-note-card-concern {
+  border-left-color: #b7372a;
+}
+
+.editorial-tt-note-head {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.editorial-tt-note-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #6c6655;
+}
+
+.editorial-tt-note-dot-angle {
+  background: #2e7d62;
+}
+.editorial-tt-note-dot-concern {
+  background: #b7372a;
+}
+
+.editorial-tt-note-type {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.editorial-tt-note-debated {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: #1d2433;
+  color: #fff;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  margin-left: auto;
+}
+
+.editorial-tt-note-body {
+  margin: 0;
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+.editorial-tt-discussion-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.5rem;
+}
+
+.editorial-tt-discussion-last {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.05em;
+  color: #6c6655;
+}
+
+.editorial-tt-turn-list {
+  list-style: none;
+  margin: 0 0 0.85rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.editorial-tt-turn {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.editorial-tt-turn-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.editorial-tt-turn-name {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.editorial-tt-turn-timestamp {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  color: #6c6655;
+}
+
+.editorial-tt-turn-noteref {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.1rem 0.35rem;
+  border: 1px solid #ddd6c8;
+  border-radius: 3px;
+  background: #fff;
+}
+
+.editorial-tt-turn-noteref-angle {
+  border-color: #2e7d62;
+  color: #2e7d62;
+}
+.editorial-tt-turn-noteref-concern {
+  border-color: #b7372a;
+  color: #b7372a;
+}
+
+.editorial-tt-turn-body {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.45;
+  padding-left: 1.85rem;
+}
+
+.editorial-tt-turn-proposes {
+  margin: 0 0 0 1.85rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  color: #b7372a;
+}
+
+.editorial-tt-discussion-input {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.55rem;
+  background: #fff;
+  border: 1px solid #ddd6c8;
+  border-radius: 6px;
+}
+
+.editorial-tt-discussion-input input {
+  grid-column: 1 / -1;
+  border: none;
+  outline: none;
+  font-family: inherit;
+  font-size: 0.85rem;
+  background: transparent;
+  padding: 0.25rem 0.1rem;
+}
+
+.editorial-tt-discussion-mentions {
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+.editorial-tt-discussion-mention {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.04em;
+  color: #6c6655;
+}
+
+.editorial-tt-sources {
+  border-left: 1px solid #ddd6c8;
+  padding: 0.85rem 0.85rem;
+  overflow-y: auto;
+  background: #fbf8f2;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.editorial-tt-sources-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.editorial-tt-source-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.editorial-tt-source-card {
+  background: #fff;
+  border: 1px solid #ddd6c8;
+  border-radius: 6px;
+  padding: 0.55rem 0.65rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+}
+
+.editorial-tt-source-row {
+  display: flex;
+  justify-content: space-between;
+}
+
+.editorial-tt-source-index,
+.editorial-tt-source-type {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+}
+
+.editorial-tt-source-title {
+  font-weight: 500;
+  font-size: 0.84rem;
+}
+
+.editorial-tt-source-detail {
+  font-size: 0.72rem;
+  color: #4a4738;
+  line-height: 1.35;
+}
+
+.editorial-tt-source-badges {
+  display: inline-flex;
+  gap: 0.35rem;
+  margin-top: 0.15rem;
+}
+
+.editorial-tt-source-badge {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.08rem 0.3rem;
+  border-radius: 3px;
+  border: 1px solid transparent;
+}
+
+.editorial-tt-source-badge-cited {
+  border-color: #2e7d62;
+  color: #2e7d62;
+}
+
+.editorial-tt-source-badge-disputed {
+  border-color: #b7372a;
+  color: #b7372a;
+}
+
+.editorial-tt-source-dropzone {
+  border: 1px dashed #b9b09c;
+  border-radius: 6px;
+  padding: 0.85rem 0.55rem;
+  text-align: center;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #6c6655;
+}
+
+@media (max-width: 1280px) {
+  .editorial-tt-grid {
+    grid-template-columns: 150px 165px minmax(0, 1fr);
+  }
+  .editorial-tt-sources {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
Second visible UI surface for Phase 0p. Renders the canonical 4-column Theme + Topics layout from `docs/design/02_theme_topics.md` (B++ design) and wires phase-strip navigation between Setup ↔ Theme/Topics.

## What's in the page
- **4 columns**: Themes (160px) + Topics (175px) + center detail + Sources rail (~230px)
- **Themes column**: 6 themes, click to switch active + drives Topics list
- **Topics column**: 3 topics under "AI Impact on Game Dev" + 1 counter-topic with red accent
- **Center detail** (active Topic):
  - Topic eyebrow + heading + action chips (`+ POINT`, `OPTIMIZE TOPIC →`)
  - **Per-persona score row as column headers** (3 personas + AGGREGATE) — each cell: letter avatar + name + big score + qualitative note. Score color: high=green, mid=neutral, low=red.
  - **One-liner** (Topic thesis) in italic serif
  - **Notes panel** with 5 typed boxes (`angle`/`stake`/`thought`/`concern`), color-coded dots and left-border accents, `DEBATED` badges where the Discussion has @-referenced them
  - **Panel Discussion** with 4 sample turns, persona avatars, note refs, `PROPOSES:` line where present, input + mention chips at the bottom
- **Sources rail**: 4 source cards with `PRIMARY`/`ANEC`/`SEC` type badges, `✓ CITED` / `! DISPUTED` status badges, drop zone
- **Setup chip bar** above the grid: persona avatars, length, audience tag, SSR/PMF gates, `edit setup` button

## Phase-strip navigation
- New shared `webapp/src/components/EditorialPhaseStrip.tsx` used by both Setup and Theme/Topics pages.
- Pills with implemented routes render as `<Link>`; unimplemented (`03`–`06`) render as muted `<span>` with `editorial-phase-pill-disabled`.
- Click `02 THEME + TOPICS` from Setup → navigates here. Click `01 SETUP` → back.

## Contract gap (flagged inline)
`design/02_theme_topics.md` §6.4 uses note types `{angle, stake, thought, concern, other}` for Topic-scoped notes; schema `PointNoteBlock.type` uses `{thought, claim, evidence, question, counterpoint}`. UI follows the design; code comment flags the mismatch for future reconciliation.

## Out of scope (next slices)
- All actions visual only (add note, send chat, optimize, add source)
- No persistence; refresh resets
- Sparklines on theme/topic cards (just numbers for now)
- Counter-Topic promotion / Counter-Point tab not wired
- Setup chip bar values hardcoded; will read from real SetupState when persistence lands

## How to view
\`\`\`bash
npm run dev      # terminal 1
npm run dev:web  # terminal 2
\`\`\`
Sign in, then either:
- `http://localhost:5173/editorial/setup` → click `02 THEME + TOPICS` pill, or
- Navigate directly to `http://localhost:5173/editorial/theme-topics`

## Test plan
- [x] `npm --prefix webapp run typecheck` clean
- [x] `npm --prefix webapp run build` clean (81 KB CSS, 647 KB JS)
- [x] `npm --prefix webapp run test` → 172 passing, 1 pre-existing skip
- [x] `npx prettier --check` clean
- [ ] Joseph eyeballs

🤖 Generated with [Claude Code](https://claude.com/claude-code)