### PR TITLE
feat: Points + Outline workspace state `a` (0p-a)

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -32,6 +32,7 @@ import {
 import { AiAgentsPage } from './pages/AiAgentsPage';
 import { DataConnectorsPage } from './pages/DataConnectorsPage';
 import { EditorialSetupPage } from './pages/EditorialSetupPage';
+import { PointsOutlineWorkspacePage } from './pages/PointsOutlineWorkspacePage';
 import { ThemeTopicsWorkspacePage } from './pages/ThemeTopicsWorkspacePage';
 import { MainChannelPage } from './pages/MainChannelPage';
 import { TalkDetailPage } from './pages/TalkDetailPage';
@@ -693,6 +694,12 @@ export function App() {
           path="/editorial/theme-topics"
           element={
             <ThemeTopicsWorkspacePage onUnauthorized={handleUnauthorized} />
+          }
+        />
+        <Route
+          path="/editorial/points-outline"
+          element={
+            <PointsOutlineWorkspacePage onUnauthorized={handleUnauthorized} />
           }
         />
         <Route

--- a/webapp/src/components/EditorialPhaseStrip.tsx
+++ b/webapp/src/components/EditorialPhaseStrip.tsx
@@ -21,7 +21,11 @@ const PHASES: ReadonlyArray<Phase> = [
     label: '02 THEME + TOPICS',
     path: '/editorial/theme-topics',
   },
-  { id: 'points-outline', label: '03 POINTS + OUTLINE', path: null },
+  {
+    id: 'points-outline',
+    label: '03 POINTS + OUTLINE',
+    path: '/editorial/points-outline',
+  },
   { id: 'draft', label: '04 DRAFT', path: null },
   { id: 'polish', label: '05 POLISH', path: null },
   { id: 'ship', label: '06 SHIP', path: null },

--- a/webapp/src/pages/PointsOutlineWorkspacePage.tsx
+++ b/webapp/src/pages/PointsOutlineWorkspacePage.tsx
@@ -1,0 +1,870 @@
+import { useMemo, useState } from 'react';
+
+import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
+
+// ───────────────────────────────────────────────────────────────────────────
+// Fixture-shaped data, hardcoded inline for the 0p-a vertical slice. Real
+// loads come from rocketorchestra `point` page reads + clawrocket
+// score_snapshots / discussion_sessions / point_note_blocks once those are
+// wired up. This slice ships state `a` only (Notes-as-right-rail,
+// Discussion-in-center). State `b` toggle, drag-reorder, Outline tab,
+// counter-promotion, and add-note flow follow in separate PRs.
+//
+// NOTE on the note-type enum (contract gap #4): design/03_points_outline.md
+// uses {claim, evidence, thought, question, counter, other}; the schema's
+// PointNoteBlock.type uses {thought, claim, evidence, question, counterpoint}
+// — `counterpoint` vs `counter`, and the schema is missing `other`. The UI
+// follows the design (filter chips T/C/E/Q/!/O) because that's the
+// user-facing contract. Reconciliation is the deferred doc-only PR.
+// ───────────────────────────────────────────────────────────────────────────
+
+type Persona = { slug: string; letter: string; name: string; role: string };
+
+type ScoreCell = { persona: Persona; score: number; note: string };
+
+type PointType = 'HOOK' | 'ARG' | 'CLOSE' | 'COUNTER';
+
+type Point = {
+  slug: string;
+  position: string;
+  type: PointType;
+  score: number;
+  claim: string;
+  stake: string;
+  noteCount: number;
+};
+
+type NoteType =
+  | 'claim'
+  | 'evidence'
+  | 'thought'
+  | 'question'
+  | 'counter'
+  | 'other';
+
+type Note = {
+  id: string;
+  type: NoteType;
+  timestamp: string;
+  body: string;
+  bodyExpanded?: string;
+  promotable?: boolean;
+  highlighted?: boolean;
+};
+
+type DiscussionTurn = {
+  id: string;
+  agent: Persona;
+  timestamp: string;
+  body: string;
+  proposes: string | null;
+};
+
+type PointDetail = {
+  slug: string;
+  eyebrow: string;
+  scoreRow: ScoreCell[];
+  aggregate: { score: number; ssr: number; gatesPass: boolean };
+  claim: string;
+  stake: string;
+  notes: Note[];
+  discussion: DiscussionTurn[];
+  lastTurnAt: string;
+};
+
+const PRIMARY_PERSONAS: ReadonlyArray<Persona> = [
+  {
+    slug: 'persona/ankit-indie-dev',
+    letter: 'A',
+    name: 'ANKIT',
+    role: 'STRATEGIST',
+  },
+  {
+    slug: 'persona/ravi-studio-lead',
+    letter: 'R',
+    name: 'RAVI',
+    role: 'NARRATIVE',
+  },
+  {
+    slug: 'persona/mei-publisher',
+    letter: 'M',
+    name: 'MEI',
+    role: 'ANALYST',
+  },
+];
+
+const TOPIC_TITLE =
+  "How Embracer's $2.1B writedown changed indie publishing terms";
+
+const POINT_COUNTS = { points: 5, counter: 1, rejected: 2 };
+
+const POINTS: ReadonlyArray<Point> = [
+  {
+    slug: 'p1-deal-term-lockdown',
+    position: '01',
+    type: 'HOOK',
+    score: 8.1,
+    claim:
+      'Deal-term lockdown: 2022-rate MGs are now the ceiling, not the floor.',
+    stake: 'Hook — open with reclassification.',
+    noteCount: 4,
+  },
+  {
+    slug: 'p2-mg-conditional-liability',
+    position: '02',
+    type: 'ARG',
+    score: 7.6,
+    claim: 'MG-as-conditional-liability is the load-bearing accounting change.',
+    stake: 'The accounting that holds the lockdown in place.',
+    noteCount: 3,
+  },
+  {
+    slug: 'p3-cohort-split',
+    position: '03',
+    type: 'ARG',
+    score: 7.2,
+    claim: 'Mid-tier studios pay; sub-10-person studios get a tailwind.',
+    stake: 'Stakes paragraph — name the cohort split.',
+    noteCount: 2,
+  },
+  {
+    slug: 'p4-eighteen-month-lockin',
+    position: '04',
+    type: 'ARG',
+    score: 6.8,
+    claim: 'The 18-month lock-in is structural, not cyclical.',
+    stake: 'Counter the cyclical read.',
+    noteCount: 2,
+  },
+  {
+    slug: 'p5-recoupment-creep',
+    position: '05',
+    type: 'CLOSE',
+    score: 6.2,
+    claim: 'Recoupment-rate creep is the next shoe to drop.',
+    stake: 'Forward-looking close.',
+    noteCount: 1,
+  },
+];
+
+const COUNTER_POINTS: ReadonlyArray<Point> = [
+  {
+    slug: 'cp1-one-off',
+    position: '06',
+    type: 'COUNTER',
+    score: 3.4,
+    claim: "Embracer's writedown is a one-off; nothing structural changed.",
+    stake: 'Steel-man the cyclical read.',
+    noteCount: 0,
+  },
+];
+
+const POINT_DETAILS: Record<string, PointDetail> = {
+  'p1-deal-term-lockdown': {
+    slug: 'p1-deal-term-lockdown',
+    eyebrow: 'POINT 1 · HOOK · SCOPED TO → DEBATE ACTIVE',
+    scoreRow: [
+      {
+        persona: PRIMARY_PERSONAS[0],
+        score: 8,
+        note: 'lead-with material — strongest hook',
+      },
+      {
+        persona: PRIMARY_PERSONAS[1],
+        score: 8,
+        note: 'Make the deal-shape concrete.',
+      },
+      {
+        persona: PRIMARY_PERSONAS[2],
+        score: 8,
+        note: '8-K supports it cleanly. Cite pp.14-16.',
+      },
+    ],
+    aggregate: { score: 8.1, ssr: 0.81, gatesPass: true },
+    claim:
+      'Deal-term lockdown: 2022-rate MGs are now the ceiling, not the floor.',
+    stake: 'Hook — open with reclassification.',
+    notes: [
+      {
+        id: 'n1',
+        type: 'claim',
+        timestamp: '11:32',
+        body: 'MG itself is now reclassified as a conditional liability under the post-Embracer framework.',
+        bodyExpanded:
+          "MG itself is now reclassified as a conditional liability under the post-Embracer accounting framework. That's the structural change, not the writedown itself.",
+      },
+      {
+        id: 'n2',
+        type: 'evidence',
+        timestamp: '11:38',
+        body: 'Embracer Q3 8-K · pp.14-16: explicit reclassification language. Devolver Q4 prelim $5 echoes.',
+        bodyExpanded:
+          'Embracer Q3 8-K · pp.14-16: explicit reclassification language. Devolver Q4 prelim $5 echoes the change. Take-Two K-1 silent (different acct treatment).',
+      },
+      {
+        id: 'n3',
+        type: 'counter',
+        timestamp: '11:41',
+        body: 'Annapurna staffer (background): this is overstated — still signing pre-Embracer-shape deals.',
+        bodyExpanded:
+          "Annapurna staffer (background): this is overstated — they're still signing pre-Embracer-shape deals at unchanged MG ratios. The reclassification may not be universal.",
+        promotable: true,
+        highlighted: true,
+      },
+      {
+        id: 'n4',
+        type: 'question',
+        timestamp: '11:43',
+        body: 'Holds for sub-$200K MG deals, or only mid-tier where Embracer was active?',
+        bodyExpanded:
+          'Does this hold for sub-$200K MG deals, or only mid-tier where Embracer was active? Worth a sidebar to a small-studio publisher.',
+      },
+    ],
+    discussion: [
+      {
+        id: 't1',
+        agent: PRIMARY_PERSONAS[0],
+        timestamp: '11:42',
+        body: 'The reclassification is the right load-bearing hook. Make sure §1 names it explicitly — readers will skim the others.',
+        proposes: 'OPEN WITH THE RECLASSIFICATION',
+      },
+      {
+        id: 't2',
+        agent: PRIMARY_PERSONAS[1],
+        timestamp: '11:43',
+        body: 'Pushing back: I want a person in this paragraph. The reclassification is correct but bloodless. The Annapurna note is the human edge — use it.',
+        proposes: null,
+      },
+      {
+        id: 't3',
+        agent: PRIMARY_PERSONAS[2],
+        timestamp: '11:45',
+        body: "Devolver prelim $5 is ambiguous — I'd cite Embracer 8-K only and add Devolver as 'see also'.",
+        proposes: 'DOWNGRADE DEVOLVER TO SEE-ALSO',
+      },
+      {
+        id: 't4',
+        agent: PRIMARY_PERSONAS[0],
+        timestamp: '11:47',
+        body: "Ravi's right that this needs a person. But promote that note as a Counter, not as the lead — the lead is the deal shape.",
+        proposes: 'PROMOTE ANNAPURNA NOTE → COUNTER',
+      },
+    ],
+    lastTurnAt: '11:47',
+  },
+  'p2-mg-conditional-liability': {
+    slug: 'p2-mg-conditional-liability',
+    eyebrow: 'POINT 2 · ARGUMENT · SCOPED TO → IDLE',
+    scoreRow: [
+      {
+        persona: PRIMARY_PERSONAS[0],
+        score: 8,
+        note: 'accounting framing is sharp',
+      },
+      {
+        persona: PRIMARY_PERSONAS[1],
+        score: 7,
+        note: 'needs a one-line plain-english gloss',
+      },
+      {
+        persona: PRIMARY_PERSONAS[2],
+        score: 8,
+        note: '8-K language matches your read',
+      },
+    ],
+    aggregate: { score: 7.6, ssr: 0.74, gatesPass: true },
+    claim: 'MG-as-conditional-liability is the load-bearing accounting change.',
+    stake: 'The accounting that holds the lockdown in place.',
+    notes: [
+      {
+        id: 'n1',
+        type: 'evidence',
+        timestamp: '10:51',
+        body: 'FASB ASC 450 framing — conditional liability recognition tightens after Q3.',
+      },
+      {
+        id: 'n2',
+        type: 'thought',
+        timestamp: '10:54',
+        body: 'Plain-english version: publishers can no longer pretend MGs are pure expense.',
+      },
+      {
+        id: 'n3',
+        type: 'question',
+        timestamp: '11:02',
+        body: 'Do non-US publishers get a different treatment under IFRS 15?',
+      },
+    ],
+    discussion: [
+      {
+        id: 't1',
+        agent: PRIMARY_PERSONAS[2],
+        timestamp: '11:05',
+        body: 'Worth one paragraph on IFRS 15 vs ASC 450 — even if you cut it later, the structural read should be globally true or you flag it.',
+        proposes: null,
+      },
+    ],
+    lastTurnAt: '11:05',
+  },
+  'p3-cohort-split': {
+    slug: 'p3-cohort-split',
+    eyebrow: 'POINT 3 · ARGUMENT · SCOPED TO → IDLE',
+    scoreRow: [
+      {
+        persona: PRIMARY_PERSONAS[0],
+        score: 7,
+        note: 'cohort split is the stakes line',
+      },
+      {
+        persona: PRIMARY_PERSONAS[1],
+        score: 7,
+        note: 'name the cohorts concretely',
+      },
+      {
+        persona: PRIMARY_PERSONAS[2],
+        score: 7,
+        note: 'sub-10 tailwind is real but evidence is thin',
+      },
+    ],
+    aggregate: { score: 7.2, ssr: 0.7, gatesPass: true },
+    claim: 'Mid-tier studios pay; sub-10-person studios get a tailwind.',
+    stake: 'Stakes paragraph — name the cohort split.',
+    notes: [
+      {
+        id: 'n1',
+        type: 'thought',
+        timestamp: '09:48',
+        body: 'Mid-tier = 11–60 person studios with one shipped title. They have the worst BATNA.',
+      },
+      {
+        id: 'n2',
+        type: 'question',
+        timestamp: '09:53',
+        body: 'What about the 60–200 band? They might be in either bucket depending on past hits.',
+      },
+    ],
+    discussion: [],
+    lastTurnAt: '—',
+  },
+  'p4-eighteen-month-lockin': {
+    slug: 'p4-eighteen-month-lockin',
+    eyebrow: 'POINT 4 · ARGUMENT · SCOPED TO → IDLE',
+    scoreRow: [
+      {
+        persona: PRIMARY_PERSONAS[0],
+        score: 7,
+        note: 'structural-not-cyclical is the contrarian lever',
+      },
+      {
+        persona: PRIMARY_PERSONAS[1],
+        score: 6,
+        note: '18 months is precise — back it up',
+      },
+      {
+        persona: PRIMARY_PERSONAS[2],
+        score: 7,
+        note: 'next-pub-cycle is roughly Q3 2027',
+      },
+    ],
+    aggregate: { score: 6.8, ssr: 0.66, gatesPass: true },
+    claim: 'The 18-month lock-in is structural, not cyclical.',
+    stake: 'Counter the cyclical read.',
+    notes: [
+      {
+        id: 'n1',
+        type: 'thought',
+        timestamp: '08:30',
+        body: 'Structural = the accounting framework. Cyclical = funding climate. Conflating these is the common publisher pushback.',
+      },
+      {
+        id: 'n2',
+        type: 'evidence',
+        timestamp: '08:42',
+        body: 'Pub-cycle data: Embracer/Devolver/Take-Two earnings calls Q4 2025 → Q3 2027 next normalization window.',
+      },
+    ],
+    discussion: [],
+    lastTurnAt: '—',
+  },
+  'p5-recoupment-creep': {
+    slug: 'p5-recoupment-creep',
+    eyebrow: 'POINT 5 · CLOSE · SCOPED TO → IDLE',
+    scoreRow: [
+      {
+        persona: PRIMARY_PERSONAS[0],
+        score: 7,
+        note: 'forward-looking close — keep punchy',
+      },
+      {
+        persona: PRIMARY_PERSONAS[1],
+        score: 6,
+        note: 'recoupment creep is jargon — define it',
+      },
+      {
+        persona: PRIMARY_PERSONAS[2],
+        score: 6,
+        note: 'one paragraph max',
+      },
+    ],
+    aggregate: { score: 6.2, ssr: 0.6, gatesPass: false },
+    claim: 'Recoupment-rate creep is the next shoe to drop.',
+    stake: 'Forward-looking close.',
+    notes: [
+      {
+        id: 'n1',
+        type: 'thought',
+        timestamp: '07:14',
+        body: 'Recoupment-rate creep: the % of revenue assigned to MG recovery before royalty splits kick in.',
+      },
+    ],
+    discussion: [],
+    lastTurnAt: '—',
+  },
+  'cp1-one-off': {
+    slug: 'cp1-one-off',
+    eyebrow: 'POINT 6 · COUNTER · SCOPED TO → IDLE',
+    scoreRow: [
+      {
+        persona: PRIMARY_PERSONAS[0],
+        score: 4,
+        note: 'steel-man — but argue it down',
+      },
+      {
+        persona: PRIMARY_PERSONAS[1],
+        score: 3,
+        note: 'this is the publisher pushback',
+      },
+      {
+        persona: PRIMARY_PERSONAS[2],
+        score: 3,
+        note: 'falsifiable; you can address',
+      },
+    ],
+    aggregate: { score: 3.4, ssr: 0.35, gatesPass: false },
+    claim: "Embracer's writedown is a one-off; nothing structural changed.",
+    stake: 'Steel-man the cyclical read.',
+    notes: [],
+    discussion: [],
+    lastTurnAt: '—',
+  },
+};
+
+// One-letter codes per design §6: T(thought) / C(claim) / E(evidence) /
+// Q(question) / !(counter) / O(other).
+const NOTE_TYPE_CODE: Record<NoteType, string> = {
+  claim: 'C',
+  evidence: 'E',
+  thought: 'T',
+  question: 'Q',
+  counter: '!',
+  other: 'O',
+};
+
+const NOTE_TYPE_LABEL: Record<NoteType, string> = {
+  claim: 'CLAIM',
+  evidence: 'EVIDENCE',
+  thought: 'THOUGHT',
+  question: 'QUESTION',
+  counter: 'COUNTER',
+  other: 'OTHER',
+};
+
+// Order matches the design filter row: T C E Q ! O
+const NOTE_FILTER_ORDER: ReadonlyArray<NoteType> = [
+  'thought',
+  'claim',
+  'evidence',
+  'question',
+  'counter',
+  'other',
+];
+
+const POINT_TYPE_LABEL: Record<PointType, string> = {
+  HOOK: 'HOOK',
+  ARG: 'ARGUMENT',
+  CLOSE: 'CLOSE',
+  COUNTER: 'COUNTER',
+};
+
+type Props = {
+  onUnauthorized?: () => void;
+};
+
+export function PointsOutlineWorkspacePage(_props: Props) {
+  // Default active = Point 01 to match the design's center-detail content.
+  // (Design §1.1 left-rail draws "(active)" on Point 03 but §1.2 detail content
+  // is Point 01 — the center detail wins because it carries the panel
+  // discussion fixtures.)
+  const [activePointSlug, setActivePointSlug] = useState<string>(
+    'p1-deal-term-lockdown',
+  );
+
+  const allPoints = useMemo(() => [...POINTS, ...COUNTER_POINTS], []);
+  const activePoint =
+    allPoints.find((p) => p.slug === activePointSlug) ?? allPoints[0];
+  const detail = POINT_DETAILS[activePoint.slug];
+
+  return (
+    <div className="editorial-room">
+      <EditorialPhaseStrip activePhase="points-outline" />
+
+      <div className="editorial-po-meta">
+        <span className="editorial-po-meta-eyebrow">UNDER TOPIC:</span>
+        <span className="editorial-po-meta-title">{TOPIC_TITLE}</span>
+        <span className="editorial-po-meta-pip">
+          {POINT_COUNTS.points} POINTS
+        </span>
+        <span className="editorial-po-meta-sep">·</span>
+        <span className="editorial-po-meta-pip">
+          {POINT_COUNTS.counter} COUNTER
+        </span>
+        <span className="editorial-po-meta-sep">·</span>
+        <span className="editorial-po-meta-pip">
+          {POINT_COUNTS.rejected} REJECTED
+        </span>
+        <span className="editorial-po-meta-sep">·</span>
+        <span className="editorial-po-meta-hint">DRAG TO REORDER</span>
+        <button type="button" className="editorial-po-meta-back" disabled>
+          ← BACK
+        </button>
+      </div>
+
+      <div className="editorial-po-grid">
+        {/* LEFT RAIL — POINTS LIST */}
+        <aside className="editorial-po-rail">
+          <div className="editorial-po-rail-tabs">
+            <button
+              type="button"
+              className="editorial-po-rail-tab editorial-po-rail-tab-active"
+            >
+              Points{' '}
+              <span className="editorial-po-rail-tab-count">
+                {allPoints.length}
+              </span>
+            </button>
+            <button type="button" className="editorial-po-rail-tab" disabled>
+              Outline <span className="editorial-po-rail-tab-count">5/5–7</span>
+            </button>
+            <button
+              type="button"
+              className="editorial-po-rail-tab editorial-po-rail-tab-action"
+              disabled
+            >
+              + POINT
+            </button>
+            <button
+              type="button"
+              className="editorial-po-rail-tab editorial-po-rail-tab-action"
+              disabled
+            >
+              OPT…
+            </button>
+          </div>
+
+          <ul className="editorial-po-point-list">
+            {POINTS.map((p) => (
+              <li key={p.slug}>
+                <button
+                  type="button"
+                  className={
+                    'editorial-po-point-card' +
+                    (p.slug === activePointSlug
+                      ? ' editorial-po-point-card-active'
+                      : '')
+                  }
+                  onClick={() => setActivePointSlug(p.slug)}
+                >
+                  <div className="editorial-po-point-row">
+                    <span className="editorial-po-point-position">
+                      {p.position}
+                    </span>
+                    <span
+                      className={`editorial-po-point-type editorial-po-point-type-${p.type.toLowerCase()}`}
+                    >
+                      {POINT_TYPE_LABEL[p.type]}
+                    </span>
+                    <span className="editorial-po-point-score">
+                      {p.score.toFixed(1)}
+                    </span>
+                  </div>
+                  <p className="editorial-po-point-claim">{p.claim}</p>
+                  <p className="editorial-po-point-stake">{p.stake}</p>
+                  <span className="editorial-po-point-notes">
+                    {p.noteCount} NOTES
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+
+          {COUNTER_POINTS.length > 0 ? (
+            <>
+              <h2 className="editorial-rail-heading editorial-rail-heading-spaced editorial-rail-heading-counter">
+                COUNTER-POINTS · {COUNTER_POINTS.length}
+              </h2>
+              <ul className="editorial-po-point-list">
+                {COUNTER_POINTS.map((p) => (
+                  <li key={p.slug}>
+                    <button
+                      type="button"
+                      className={
+                        'editorial-po-point-card editorial-po-point-card-counter' +
+                        (p.slug === activePointSlug
+                          ? ' editorial-po-point-card-active'
+                          : '')
+                      }
+                      onClick={() => setActivePointSlug(p.slug)}
+                    >
+                      <div className="editorial-po-point-row">
+                        <span className="editorial-po-point-position">
+                          {p.position}
+                        </span>
+                        <span
+                          className={`editorial-po-point-type editorial-po-point-type-${p.type.toLowerCase()}`}
+                        >
+                          {POINT_TYPE_LABEL[p.type]}
+                        </span>
+                        <span className="editorial-po-point-score">
+                          {p.score.toFixed(1)}
+                        </span>
+                      </div>
+                      <p className="editorial-po-point-claim">{p.claim}</p>
+                      {p.stake ? (
+                        <p className="editorial-po-point-stake">{p.stake}</p>
+                      ) : null}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : null}
+        </aside>
+
+        {/* CENTER — ACTIVE POINT DETAIL + PANEL DISCUSSION */}
+        <main className="editorial-po-center">
+          {detail ? <PointDetailView detail={detail} /> : null}
+        </main>
+
+        {/* RIGHT RAIL — NOTES (state `a`) */}
+        <aside className="editorial-po-notes-rail">
+          <NotesRail notes={detail?.notes ?? []} />
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function PointDetailView({ detail }: { detail: PointDetail }) {
+  return (
+    <article className="editorial-po-detail">
+      <header className="editorial-po-detail-header">
+        <span className="editorial-po-detail-eyebrow">{detail.eyebrow}</span>
+      </header>
+
+      <div className="editorial-tt-score-row">
+        {detail.scoreRow.map((cell) => (
+          <div key={cell.persona.slug} className="editorial-tt-score-cell">
+            <div className="editorial-tt-score-cell-head">
+              <span
+                className="editorial-persona-avatar editorial-persona-avatar-sm"
+                data-persona={cell.persona.letter}
+              >
+                {cell.persona.letter}
+              </span>
+              <span className="editorial-tt-score-cell-name">
+                {cell.persona.name}
+              </span>
+            </div>
+            <div
+              className={
+                'editorial-tt-score-cell-number' +
+                (cell.score < 5
+                  ? ' editorial-tt-score-cell-number-low'
+                  : cell.score >= 7
+                    ? ' editorial-tt-score-cell-number-high'
+                    : '')
+              }
+            >
+              {cell.score}
+            </div>
+            <div className="editorial-tt-score-cell-note">{cell.note}</div>
+          </div>
+        ))}
+        <div className="editorial-tt-score-cell editorial-tt-score-cell-aggregate">
+          <div className="editorial-tt-score-cell-head">
+            <span className="editorial-tt-score-cell-name">AGGREGATE</span>
+          </div>
+          <div className="editorial-tt-score-cell-number">
+            {detail.aggregate.score.toFixed(1)}
+          </div>
+          <div className="editorial-tt-score-cell-note">
+            SSR {detail.aggregate.ssr.toFixed(2)} ·{' '}
+            {detail.aggregate.gatesPass ? '✓ GATES' : '✗ GATES'}
+          </div>
+        </div>
+      </div>
+
+      <section className="editorial-po-claim-stake">
+        <h3 className="editorial-tt-section-label">CLAIM</h3>
+        <p className="editorial-po-claim-body">{detail.claim}</p>
+        <div className="editorial-po-stake-row">
+          <span className="editorial-po-stake-label">STAKE</span>
+          <p className="editorial-po-stake-body">{detail.stake}</p>
+          <span className="editorial-po-notes-badge">
+            {detail.notes.length} NOTES
+          </span>
+        </div>
+      </section>
+
+      <section className="editorial-po-discussion">
+        <header className="editorial-po-discussion-header">
+          <h3 className="editorial-tt-section-label">
+            PANEL DISCUSSION · {detail.discussion.length} TURNS
+          </h3>
+          <div className="editorial-po-discussion-meta">
+            <span className="editorial-po-discussion-last">
+              LAST {detail.lastTurnAt}
+            </span>
+            <span className="editorial-po-discussion-mentions">
+              {['@ALL', '@A', '@R', '@M'].map((m) => (
+                <span key={m} className="editorial-po-discussion-mention">
+                  {m}
+                </span>
+              ))}
+            </span>
+          </div>
+        </header>
+
+        {detail.discussion.length === 0 ? (
+          <p className="editorial-tt-empty">
+            No discussion yet — ask the panel.
+          </p>
+        ) : (
+          <ol className="editorial-po-turn-list">
+            {detail.discussion.map((t) => (
+              <li key={t.id} className="editorial-po-turn">
+                <div className="editorial-po-turn-head">
+                  <span
+                    className="editorial-persona-avatar editorial-persona-avatar-sm"
+                    data-persona={t.agent.letter}
+                  >
+                    {t.agent.letter}
+                  </span>
+                  <span className="editorial-po-turn-name">{t.agent.name}</span>
+                  <span className="editorial-po-turn-role">{t.agent.role}</span>
+                  <span className="editorial-po-turn-timestamp">
+                    {t.timestamp}
+                  </span>
+                </div>
+                <p className="editorial-po-turn-body">{t.body}</p>
+                {t.proposes ? (
+                  <button
+                    type="button"
+                    className="editorial-po-turn-proposes"
+                    disabled
+                  >
+                    + {t.proposes}
+                  </button>
+                ) : null}
+              </li>
+            ))}
+          </ol>
+        )}
+
+        <div className="editorial-po-discussion-input">
+          <input
+            type="text"
+            placeholder="Ask the panel — or @reference a note…"
+            disabled
+          />
+          <button
+            type="button"
+            className="editorial-chip-button editorial-chip-button-primary"
+            disabled
+          >
+            SEND ⌥↵
+          </button>
+        </div>
+      </section>
+    </article>
+  );
+}
+
+function NotesRail({ notes }: { notes: ReadonlyArray<Note> }) {
+  return (
+    <>
+      <div className="editorial-po-notes-rail-header">
+        <h2 className="editorial-rail-heading">NOTES · {notes.length}</h2>
+        <span className="editorial-po-notes-sort">↓ CHRONO</span>
+      </div>
+
+      <div className="editorial-po-notes-filter">
+        {NOTE_FILTER_ORDER.map((nt) => (
+          <button
+            key={nt}
+            type="button"
+            className={`editorial-po-notes-filter-chip editorial-po-notes-filter-chip-${nt}`}
+            disabled
+            title={NOTE_TYPE_LABEL[nt]}
+          >
+            {NOTE_TYPE_CODE[nt]}
+          </button>
+        ))}
+        <button
+          type="button"
+          className="editorial-po-notes-filter-chip editorial-po-notes-filter-chip-add"
+          disabled
+          aria-label="Add note"
+        >
+          +
+        </button>
+      </div>
+
+      {notes.length === 0 ? (
+        <p className="editorial-tt-empty">
+          No notes yet — pick a type to start.
+        </p>
+      ) : (
+        <ul className="editorial-po-note-list">
+          {notes.map((n) => (
+            <li
+              key={n.id}
+              className={
+                `editorial-po-note-card editorial-po-note-card-${n.type}` +
+                (n.highlighted ? ' editorial-po-note-card-highlighted' : '')
+              }
+            >
+              <div className="editorial-po-note-head">
+                <span
+                  className={`editorial-po-note-code editorial-po-note-code-${n.type}`}
+                >
+                  {NOTE_TYPE_CODE[n.type]}
+                </span>
+                <span className="editorial-po-note-type">
+                  {NOTE_TYPE_LABEL[n.type]}
+                </span>
+                {n.promotable ? (
+                  <button
+                    type="button"
+                    className="editorial-po-note-promote"
+                    disabled
+                  >
+                    PROMOTE ›
+                  </button>
+                ) : null}
+                <span className="editorial-po-note-timestamp">
+                  {n.timestamp}
+                </span>
+              </div>
+              <p className="editorial-po-note-body">{n.body}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <button type="button" className="editorial-po-note-add" disabled>
+        + NOTE · PICK TYPE ABOVE
+      </button>
+    </>
+  );
+}

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -5686,3 +5686,674 @@ a.editorial-phase-pill:hover {
     display: none;
   }
 }
+
+/* ─── Editorial Room · Points + Outline workspace (state `a`) ─────────── */
+
+.editorial-po-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.55rem 1rem;
+  border-bottom: 1px solid #e2dccc;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #5b5644;
+  background: #f7f3e8;
+  flex-wrap: wrap;
+}
+
+.editorial-po-meta-eyebrow {
+  color: #6c6655;
+  font-weight: 600;
+}
+
+.editorial-po-meta-title {
+  font-family: 'IBM Plex Serif', serif;
+  font-size: 0.82rem;
+  letter-spacing: 0;
+  text-transform: none;
+  color: #1f1c14;
+  font-weight: 500;
+  margin-right: 0.4rem;
+}
+
+.editorial-po-meta-pip {
+  color: #4a4738;
+}
+
+.editorial-po-meta-sep {
+  color: #b9b09c;
+}
+
+.editorial-po-meta-hint {
+  color: #8a8268;
+}
+
+.editorial-po-meta-back {
+  margin-left: auto;
+  border: 1px solid #c9c0a8;
+  background: transparent;
+  padding: 0.18rem 0.55rem;
+  border-radius: 4px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #6c6655;
+  cursor: pointer;
+}
+
+.editorial-po-meta-back:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.editorial-po-grid {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr) 280px;
+  height: calc(100vh - 110px);
+  background: #fbf8f2;
+  overflow: hidden;
+}
+
+.editorial-po-rail {
+  border-right: 1px solid #e2dccc;
+  padding: 0.85rem 0.6rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  background: #f7f3e8;
+}
+
+.editorial-po-rail-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  padding-bottom: 0.35rem;
+  border-bottom: 1px solid #e2dccc;
+}
+
+.editorial-po-rail-tab {
+  border: 1px solid transparent;
+  background: transparent;
+  padding: 0.18rem 0.4rem;
+  border-radius: 4px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.64rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #6c6655;
+  cursor: pointer;
+}
+
+.editorial-po-rail-tab-active {
+  background: #1f1c14;
+  color: #f7f3e8;
+}
+
+.editorial-po-rail-tab-action {
+  border-color: #c9c0a8;
+  color: #4a4738;
+}
+
+.editorial-po-rail-tab:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.editorial-po-rail-tab-count {
+  margin-left: 0.2rem;
+  opacity: 0.75;
+}
+
+.editorial-po-point-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.editorial-po-point-card {
+  width: 100%;
+  text-align: left;
+  background: #fff;
+  border: 1px solid #ddd6c8;
+  border-radius: 6px;
+  padding: 0.5rem 0.55rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.editorial-po-point-card:hover {
+  border-color: #b9b09c;
+}
+
+.editorial-po-point-card-active {
+  border-color: #b7372a;
+  border-width: 1.5px;
+  background: #fdf8f6;
+}
+
+.editorial-po-point-card-counter {
+  border-color: #b7372a;
+}
+
+.editorial-po-point-card-counter.editorial-po-point-card-active {
+  background: #fbeae6;
+}
+
+.editorial-po-point-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.editorial-po-point-position {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #4a4738;
+}
+
+.editorial-po-point-type {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+  background: #efe9d8;
+  color: #4a4738;
+}
+
+.editorial-po-point-type-hook {
+  background: #2e7d62;
+  color: #fff;
+}
+
+.editorial-po-point-type-arg {
+  background: #efe9d8;
+  color: #4a4738;
+}
+
+.editorial-po-point-type-close {
+  background: #4a3a8a;
+  color: #fff;
+}
+
+.editorial-po-point-type-counter {
+  background: #b7372a;
+  color: #fff;
+}
+
+.editorial-po-point-score {
+  margin-left: auto;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #1f1c14;
+}
+
+.editorial-po-point-claim {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: #1f1c14;
+  margin: 0.1rem 0 0;
+  line-height: 1.3;
+}
+
+.editorial-po-point-stake {
+  font-style: italic;
+  font-size: 0.7rem;
+  color: #5b5644;
+  margin: 0;
+  line-height: 1.3;
+}
+
+.editorial-po-point-notes {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.05em;
+  color: #8a8268;
+  margin-top: 0.1rem;
+}
+
+.editorial-po-center {
+  overflow-y: auto;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  background: #fbf8f2;
+}
+
+.editorial-po-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.editorial-po-detail-header {
+  display: flex;
+  align-items: center;
+}
+
+.editorial-po-detail-eyebrow {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+}
+
+.editorial-po-claim-stake {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  border-bottom: 1px solid #e2dccc;
+  padding-bottom: 0.85rem;
+}
+
+.editorial-po-claim-body {
+  font-family: 'IBM Plex Serif', serif;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1f1c14;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.editorial-po-stake-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+
+.editorial-po-stake-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+  flex-shrink: 0;
+}
+
+.editorial-po-stake-body {
+  font-style: italic;
+  font-size: 0.85rem;
+  color: #4a4738;
+  margin: 0;
+  flex: 1;
+}
+
+.editorial-po-notes-badge {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  color: #8a8268;
+  flex-shrink: 0;
+}
+
+.editorial-po-discussion {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.editorial-po-discussion-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.editorial-po-discussion-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.editorial-po-discussion-last {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  color: #6c6655;
+}
+
+.editorial-po-discussion-mentions {
+  display: inline-flex;
+  gap: 0.25rem;
+}
+
+.editorial-po-discussion-mention {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.04em;
+  color: #6c6655;
+  border: 1px solid #c9c0a8;
+  border-radius: 3px;
+  padding: 0.05rem 0.3rem;
+}
+
+.editorial-po-turn-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.editorial-po-turn {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.55rem 0.6rem;
+  background: #fff;
+  border: 1px solid #e2dccc;
+  border-radius: 6px;
+}
+
+.editorial-po-turn-head {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.editorial-po-turn-name {
+  font-weight: 600;
+  font-size: 0.78rem;
+  color: #1f1c14;
+}
+
+.editorial-po-turn-role {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+  border: 1px solid #c9c0a8;
+  border-radius: 3px;
+  padding: 0.05rem 0.3rem;
+}
+
+.editorial-po-turn-timestamp {
+  margin-left: auto;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  color: #8a8268;
+}
+
+.editorial-po-turn-body {
+  font-size: 0.85rem;
+  color: #1f1c14;
+  margin: 0;
+  line-height: 1.45;
+}
+
+.editorial-po-turn-proposes {
+  align-self: flex-start;
+  border: 1px solid #2e7d62;
+  background: transparent;
+  color: #2e7d62;
+  padding: 0.18rem 0.5rem;
+  border-radius: 4px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.64rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+  margin-top: 0.1rem;
+}
+
+.editorial-po-turn-proposes:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.editorial-po-discussion-input {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-top: 0.4rem;
+  border-top: 1px solid #e2dccc;
+}
+
+.editorial-po-discussion-input input {
+  flex: 1;
+  border: 1px solid #c9c0a8;
+  border-radius: 4px;
+  padding: 0.32rem 0.5rem;
+  font-family: inherit;
+  font-size: 0.8rem;
+  background: #fff;
+  color: #1f1c14;
+}
+
+.editorial-po-notes-rail {
+  border-left: 1px solid #e2dccc;
+  padding: 0.85rem 0.7rem;
+  overflow-y: auto;
+  background: #faf6ec;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.editorial-po-notes-rail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.editorial-po-notes-sort {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.05em;
+  color: #6c6655;
+}
+
+.editorial-po-notes-filter {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+  padding-bottom: 0.35rem;
+  border-bottom: 1px dashed #e2dccc;
+}
+
+.editorial-po-notes-filter-chip {
+  width: 22px;
+  height: 22px;
+  border: 1px solid #c9c0a8;
+  background: #fff;
+  border-radius: 3px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #4a4738;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.editorial-po-notes-filter-chip:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.editorial-po-notes-filter-chip-claim {
+  border-color: #2766b2;
+  color: #2766b2;
+}
+
+.editorial-po-notes-filter-chip-evidence {
+  border-color: #2e7d62;
+  color: #2e7d62;
+}
+
+.editorial-po-notes-filter-chip-question {
+  border-color: #6c4ea6;
+  color: #6c4ea6;
+}
+
+.editorial-po-notes-filter-chip-counter {
+  border-color: #b7372a;
+  color: #b7372a;
+}
+
+.editorial-po-notes-filter-chip-add {
+  border-style: dashed;
+  color: #6c6655;
+}
+
+.editorial-po-note-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.editorial-po-note-card {
+  background: #fff;
+  border: 1px solid #ddd6c8;
+  border-radius: 5px;
+  padding: 0.45rem 0.55rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+}
+
+.editorial-po-note-card-highlighted {
+  border-color: #b7372a;
+}
+
+.editorial-po-note-card-counter {
+  border-color: #b7372a;
+}
+
+.editorial-po-note-head {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.editorial-po-note-code {
+  width: 18px;
+  height: 18px;
+  border-radius: 3px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  font-weight: 700;
+  background: #efe9d8;
+  color: #4a4738;
+}
+
+.editorial-po-note-code-claim {
+  background: #e3eef9;
+  color: #2766b2;
+}
+
+.editorial-po-note-code-evidence {
+  background: #e3f2eb;
+  color: #2e7d62;
+}
+
+.editorial-po-note-code-question {
+  background: #ece3f5;
+  color: #6c4ea6;
+}
+
+.editorial-po-note-code-counter {
+  background: #fbe5e1;
+  color: #b7372a;
+}
+
+.editorial-po-note-type {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #4a4738;
+  font-weight: 600;
+}
+
+.editorial-po-note-promote {
+  border: 1px solid #b7372a;
+  background: transparent;
+  color: #b7372a;
+  padding: 0.04rem 0.3rem;
+  border-radius: 3px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.editorial-po-note-promote:disabled {
+  opacity: 0.85;
+  cursor: not-allowed;
+}
+
+.editorial-po-note-timestamp {
+  margin-left: auto;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  color: #8a8268;
+}
+
+.editorial-po-note-body {
+  font-size: 0.74rem;
+  color: #1f1c14;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.editorial-po-note-add {
+  margin-top: 0.4rem;
+  border: 1px dashed #b9b09c;
+  background: transparent;
+  padding: 0.4rem 0.5rem;
+  border-radius: 5px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.64rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #6c6655;
+  cursor: pointer;
+}
+
+.editorial-po-note-add:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+@media (max-width: 1280px) {
+  .editorial-po-grid {
+    grid-template-columns: 200px minmax(0, 1fr) 240px;
+  }
+}
+
+@media (max-width: 1080px) {
+  .editorial-po-grid {
+    grid-template-columns: 200px minmax(0, 1fr);
+  }
+  .editorial-po-notes-rail {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Mounts `/editorial/points-outline` per `docs/design/03_points_outline.md` (PO5+ direction); flips phase pill 03 from disabled to active link
- Ships state `a` only — Notes-as-right-rail, Discussion-in-center
- Inline TS-const fixtures (5 main Points + 1 Counter-Point under "Embracer writedown" topic, with full per-Point detail for Point 1 and lighter detail for the rest)

## Layout

Common shell:
- Sub-meta bar: `UNDER TOPIC: <title> · 5 POINTS · 1 COUNTER · 2 REJECTED · DRAG TO REORDER · ← BACK`
- Left rail: Points/Outline tabs (Outline disabled this PR), 5 main Points + 1 Counter section, drag-handle styling but no behavior yet
- Center: per-persona score row (reusing `editorial-tt-score-*`), CLAIM (bold serif) + STAKE (italic) + N NOTES badge, then PANEL DISCUSSION with 4 turns and three proposal chips
- Right rail: NOTES · 4 with sort indicator, T/C/E/Q/!/O filter chips (color-coded), 4 compact note cards (claim/evidence/counter/question), `PROMOTE ›` chip on the counter note, `+ NOTE · PICK TYPE ABOVE` footer

## Note-type enum

UI uses the design enum `claim/evidence/thought/question/counter/other`. Schema's `PointNoteBlock.type` uses `thought/claim/evidence/question/counterpoint` (no `other`, `counterpoint` instead of `counter`). This is contract gap #4 — the schema description already flags it; reconciliation is the deferred doc-only PR. A code comment at the top of `PointsOutlineWorkspacePage.tsx` calls out the gap.

## Deferred to follow-up PRs

- State `b` toggle: chevron + `⌘]` / `⌘[` + drag divider + bottom drawer + `editorial-room.points-outline.layout-state` localStorage
- Drag-reorder Points (using `@dnd-kit`, already in deps)
- Outline tab content (the `5/5-7` filtered view)
- Counter-Point promotion flow (the `PROMOTE ›` chip click)
- Add-note flow (filter chip + click → instantiate)
- Full per-Point details for Points 2–6 (currently lighter than Point 1)

## Validation

- `npm --prefix webapp run typecheck` clean
- `npm --prefix webapp run build` clean (665 KB JS, 91 KB CSS)
- `npm --prefix webapp run test` 172 passed / 1 skipped
- `npx prettier --check` clean on changed files
- `NANOCLAW_ALLOW_UNSUPPORTED_NODE=1 node scripts/run-vitest.mjs run src/clawrocket/contracts/editorial-room.test.ts` 99/99
- **Browser smoke test not run:** vite dev returned 404 on `/` itself in this session (env issue, not the new code). Verified via successful production build instead.

## Test plan

- [ ] Visit `/editorial/setup`, confirm phase pill 03 is now an active `<Link>`
- [ ] Click 03 POINTS + OUTLINE; lands on `/editorial/points-outline`
- [ ] Click each of 5 main Points and the Counter-Point; center detail and right-rail notes update for Point 1; other Points show lighter detail
- [ ] Confirm phase strip + sub-meta bar + 3-column grid render at ≥1280px; right rail collapses below 1080px

🤖 Generated with [Claude Code](https://claude.com/claude-code)