### PR TITLE
feat: RESCORE action on stale Points

### DIFF
--- a/webapp/src/pages/PointsOutlineWorkspacePage.tsx
+++ b/webapp/src/pages/PointsOutlineWorkspacePage.tsx
@@ -98,10 +98,13 @@ type DetailState = {
   claim: string;
   stake: string;
   discussion: DiscussionTurn[];
-  // Stale = current claim/stake hash differs from the hash that the
-  // score_snapshots were computed against. UI-only flag for now;
-  // recompute is a follow-up PR.
+  // Stale = current claim/stake hash differs from the hash that scoreRow /
+  // aggregate were computed against. Cleared by RESCORE; in production this
+  // would dispatch run_skill against the scoring_pipeline and append a fresh
+  // score_snapshots row (per EDITORIAL_ROOM_CONTRACT.md §4.2).
   stale: boolean;
+  scoreRow: ScoreCell[];
+  aggregate: { score: number; ssr: number; gatesPass: boolean };
 };
 
 type EditField = 'claim' | 'stake';
@@ -538,10 +541,50 @@ function buildInitialDetailStates(): Record<string, DetailState> {
       stake: d.stake,
       discussion: [...d.discussion],
       stale: false,
+      scoreRow: d.scoreRow.map((c) => ({ ...c })),
+      aggregate: { ...d.aggregate },
     };
   }
   return out;
 }
+
+// Deterministic small drift on claim/stake content so RESCORE produces
+// realistic, repeatable score changes in the fixture-only slice. Real
+// rescore dispatches `run_skill` against the scoring_pipeline.
+function simpleHash(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+function rescoreFromContent(state: DetailState): {
+  scoreRow: ScoreCell[];
+  aggregate: DetailState['aggregate'];
+} {
+  const seed = simpleHash(state.claim + '|' + state.stake);
+  const scoreRow = state.scoreRow.map((cell, i) => {
+    const delta = ((((seed * (i + 7)) >>> 3) % 11) - 5) / 10; // -0.5..+0.5
+    const raw = cell.score + delta;
+    const clamped = Math.max(0, Math.min(10, raw));
+    return { ...cell, score: Math.round(clamped * 10) / 10 };
+  });
+  const mean = scoreRow.reduce((s, c) => s + c.score, 0) / scoreRow.length;
+  const aggScore = Math.round(mean * 10) / 10;
+  const ssrDelta = ((((seed * 13) >>> 5) % 11) - 5) / 100; // -0.05..+0.05
+  const ssr = Math.max(0, Math.min(1, state.aggregate.ssr + ssrDelta));
+  return {
+    scoreRow,
+    aggregate: {
+      score: aggScore,
+      ssr: Math.round(ssr * 100) / 100,
+      gatesPass: aggScore >= 6.0,
+    },
+  };
+}
+
+const RESCORE_LATENCY_MS = 600;
 
 type Props = {
   onUnauthorized?: () => void;
@@ -566,6 +609,7 @@ export function PointsOutlineWorkspacePage(_props: Props) {
 
   const [editing, setEditing] = useState<EditingTarget>(null);
   const [draft, setDraft] = useState<string>('');
+  const [rescoringSlug, setRescoringSlug] = useState<string | null>(null);
 
   function selectPoint(slug: string) {
     if (editing && editing.slug !== slug) {
@@ -585,9 +629,31 @@ export function PointsOutlineWorkspacePage(_props: Props) {
           claim: state.claim,
           stake: state.stake,
           discussion: state.discussion,
+          scoreRow: state.scoreRow,
+          aggregate: state.aggregate,
         }
       : null;
   const stale = state?.stale ?? false;
+  const rescoring = rescoringSlug === activePoint.slug;
+
+  function rescorePoint(slug: string) {
+    if (rescoringSlug) return;
+    const cur = detailStates[slug];
+    if (!cur || !cur.stale) return;
+    setRescoringSlug(slug);
+    setTimeout(() => {
+      setDetailStates((prev) => {
+        const s = prev[slug];
+        if (!s) return prev;
+        const next = rescoreFromContent(s);
+        return {
+          ...prev,
+          [slug]: { ...s, stale: false, ...next },
+        };
+      });
+      setRescoringSlug(null);
+    }, RESCORE_LATENCY_MS);
+  }
 
   function startEdit(field: EditField) {
     if (!detail) return;
@@ -730,12 +796,14 @@ export function PointsOutlineWorkspacePage(_props: Props) {
             <PointDetailView
               detail={detail}
               stale={stale}
+              rescoring={rescoring}
               editing={editing}
               draft={draft}
               setDraft={setDraft}
               onStartEdit={startEdit}
               onCancelEdit={cancelEdit}
               onSaveEdit={saveEdit}
+              onRescore={() => rescorePoint(activePoint.slug)}
             />
           ) : null}
         </main>
@@ -781,7 +849,7 @@ function PointCard({
             {POINT_TYPE_LABEL[point.type]}
           </span>
           <span className="editorial-po-point-score">
-            {point.score.toFixed(1)}
+            {(state?.aggregate.score ?? point.score).toFixed(1)}
           </span>
         </div>
         <p className="editorial-po-point-claim">{claim}</p>
@@ -798,21 +866,25 @@ function PointCard({
 function PointDetailView({
   detail,
   stale,
+  rescoring,
   editing,
   draft,
   setDraft,
   onStartEdit,
   onCancelEdit,
   onSaveEdit,
+  onRescore,
 }: {
   detail: PointDetail;
   stale: boolean;
+  rescoring: boolean;
   editing: EditingTarget;
   draft: string;
   setDraft: (v: string) => void;
   onStartEdit: (field: EditField) => void;
   onCancelEdit: () => void;
   onSaveEdit: () => void;
+  onRescore: () => void;
 }) {
   const editingClaim =
     editing?.slug === detail.slug && editing.field === 'claim';
@@ -829,21 +901,40 @@ function PointDetailView({
         <span className="editorial-po-detail-eyebrow">{detail.eyebrow}</span>
       </header>
 
-      {stale ? (
-        <div className="editorial-po-stale-banner" role="status">
+      {stale || rescoring ? (
+        <div
+          className={
+            'editorial-po-stale-banner' +
+            (rescoring ? ' editorial-po-stale-banner-rescoring' : '')
+          }
+          role="status"
+          aria-live="polite"
+        >
           <span className="editorial-po-stale-icon" aria-hidden="true">
-            ⚠
+            {rescoring ? '⟳' : '⚠'}
           </span>
           <span className="editorial-po-stale-text">
-            STALE — claim or stake changed since last score; recompute deferred
+            {rescoring
+              ? 'RESCORING…'
+              : 'STALE — claim or stake changed since last score'}
           </span>
+          {!rescoring ? (
+            <button
+              type="button"
+              className="editorial-po-stale-rescore"
+              onClick={onRescore}
+            >
+              RESCORE →
+            </button>
+          ) : null}
         </div>
       ) : null}
 
       <div
         className={
           'editorial-tt-score-row' +
-          (stale ? ' editorial-po-score-row-stale' : '')
+          (stale && !rescoring ? ' editorial-po-score-row-stale' : '') +
+          (rescoring ? ' editorial-po-score-row-rescoring' : '')
         }
       >
         {detail.scoreRow.map((cell) => (

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -6568,3 +6568,48 @@ a.editorial-phase-pill:hover {
   border-radius: 0 3px 3px 0;
   line-height: 1.45;
 }
+
+.editorial-po-stale-rescore {
+  margin-left: 0.45rem;
+  border: 1px solid #1f1c14;
+  background: #1f1c14;
+  color: #f7f3e8;
+  padding: 0.16rem 0.55rem;
+  border-radius: 3px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.editorial-po-stale-rescore:hover {
+  background: #2e7d62;
+  border-color: #2e7d62;
+}
+
+.editorial-po-stale-banner-rescoring {
+  border-color: #2e7d62;
+  background: #ecf5f0;
+  color: #1f4e3b;
+}
+
+.editorial-po-stale-banner-rescoring .editorial-po-stale-icon {
+  display: inline-block;
+  animation: editorial-po-spin 1.2s linear infinite;
+}
+
+.editorial-po-score-row-rescoring .editorial-tt-score-cell-number,
+.editorial-po-score-row-rescoring .editorial-tt-score-cell-note {
+  opacity: 0.35;
+  transition: opacity 200ms ease;
+}
+
+@keyframes editorial-po-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `RESCORE →` button to the stale banner on a Point's center detail
- Closes the loop opened by the prior PR: edit CLAIM/STAKE → STALE → RESCORE → fresh scores
- ~600ms RESCORING… state with a spinning ⟳ glyph, then per-persona scores + aggregate + SSR drift to new values, gates re-evaluate, stale flag clears
- Left-rail Point card's score updates in place

## Mechanics

- `DetailState` now owns `scoreRow` and `aggregate` (previously read from the const fixture); `buildInitialDetailStates` clones them in so rescore can mutate
- `rescoreFromContent(state)` derives a deterministic ±0.5 per-persona drift and ±0.05 SSR drift from a content-hash seed (claim + '|' + stake). Same edit ⇒ same scores, so demos are reproducible
- Aggregate = mean of new persona scores rounded to 1 decimal; gates pass if ≥ 6.0
- Page-level `rescoringSlug` state gates the action; concurrent rescores blocked
- During RESCORING…, score row fades to 35% opacity; banner morphs from amber to green
- Real production version dispatches `run_skill` against the `scoring_pipeline_slug` (per `EDITORIAL_ROOM_CONTRACT.md` §4.2 + §6.1) and appends a fresh `score_snapshots` row with the new `object_content_hash`

## Deferred

- Persisting edits + score history across reload (next PR — localStorage first, SQLite later)
- Pending proposal-chip revalidation when the claim they referenced changes
- State `b` toggle, drag-reorder, Outline tab, counter-promotion, add-note flow (carry-over from the original page-build backlog)

## Validation

- `npm --prefix webapp run typecheck` clean
- `npm --prefix webapp run build` clean (95.4 KB CSS, 670 KB JS)
- `npm --prefix webapp run test` 172 passed / 1 skipped
- `npx prettier --check` clean
- `editorial-room.test.ts` 99/99

## Test plan

- [ ] Visit `/editorial/points-outline`; edit Point 1 CLAIM → save; STALE banner appears with `RESCORE →` button
- [ ] Click RESCORE; banner turns green and reads `RESCORING…` with a spinning glyph; score numbers fade to 35% opacity
- [ ] After ~600ms: banner disappears, scores updated, gates re-evaluated, left-rail Point 1 card score also updated, `· STALE` suffix on the card cleared
- [ ] Edit Point 1 again; click RESCORE again; same behavior, scores drift again deterministically (same content ⇒ same numbers)
- [ ] Rescore button does nothing while another rescore is in flight (no double-click race)
- [ ] STAKE edit also triggers stale + same RESCORE flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)