### PR TITLE
feat: persist Point edits + scores to localStorage

### DIFF
--- a/webapp/src/pages/PointsOutlineWorkspacePage.tsx
+++ b/webapp/src/pages/PointsOutlineWorkspacePage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
 
@@ -586,6 +586,66 @@ function rescoreFromContent(state: DetailState): {
 
 const RESCORE_LATENCY_MS = 600;
 
+// localStorage persistence for the per-Point editable+scored state.
+// Bump the version suffix when DetailState gains required fields so older
+// stored shapes get discarded instead of merged into a partial value.
+const STORAGE_KEY = 'editorial-room.points-outline.detail-states-v0';
+
+function isValidStoredState(s: unknown): s is DetailState {
+  if (!s || typeof s !== 'object') return false;
+  const o = s as Record<string, unknown>;
+  return (
+    typeof o.claim === 'string' &&
+    typeof o.stake === 'string' &&
+    Array.isArray(o.discussion) &&
+    typeof o.stale === 'boolean' &&
+    Array.isArray(o.scoreRow) &&
+    !!o.aggregate &&
+    typeof o.aggregate === 'object'
+  );
+}
+
+function loadDetailStates(): Record<string, DetailState> {
+  const fresh = buildInitialDetailStates();
+  if (typeof window === 'undefined') return fresh;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return fresh;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      (parsed as { schema_version?: unknown }).schema_version !== '0'
+    ) {
+      return fresh;
+    }
+    const states = (parsed as { states?: unknown }).states;
+    if (!states || typeof states !== 'object') return fresh;
+    const merged: Record<string, DetailState> = { ...fresh };
+    for (const slug of Object.keys(fresh)) {
+      const candidate = (states as Record<string, unknown>)[slug];
+      if (isValidStoredState(candidate)) {
+        merged[slug] = candidate;
+      }
+    }
+    return merged;
+  } catch {
+    return fresh;
+  }
+}
+
+function saveDetailStates(states: Record<string, DetailState>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ schema_version: '0', states }),
+    );
+  } catch {
+    // Quota exceeded / private mode / disabled — degrade silently.
+  }
+}
+
 type Props = {
   onUnauthorized?: () => void;
 };
@@ -603,9 +663,12 @@ export function PointsOutlineWorkspacePage(_props: Props) {
   const activePoint =
     allPoints.find((p) => p.slug === activePointSlug) ?? allPoints[0];
 
-  const [detailStates, setDetailStates] = useState<Record<string, DetailState>>(
-    buildInitialDetailStates,
-  );
+  const [detailStates, setDetailStates] =
+    useState<Record<string, DetailState>>(loadDetailStates);
+
+  useEffect(() => {
+    saveDetailStates(detailStates);
+  }, [detailStates]);
 
   const [editing, setEditing] = useState<EditingTarget>(null);
   const [draft, setDraft] = useState<string>('');


### PR DESCRIPTION
## Summary
- Edits to CLAIM/STAKE, appended revision turns, the stale flag, and rescored scoreRow/aggregate survive a page reload
- Stored at `editorial-room.points-outline.detail-states-v0` with a versioned envelope
- Corrupt JSON / schema mismatch / missing fields → fall back to fixture init per slug

## Mechanics

- `loadDetailStates()` runs at `useState` init: parses the envelope, validates each slug's shape via `isValidStoredState`, merges valid entries onto a fresh fixture base
- `saveDetailStates()` runs in a `useEffect` on every `detailStates` change
- Transient state stays in memory only: `activePointSlug`, `editing` / `draft`, `rescoringSlug`
- Write failures (quota, private mode) swallowed silently — in-memory state still works
- Schema-version key bumps when `DetailState` gains required fields, so older shapes get discarded rather than partially-merged

## Deferred

- Proposal-chip revalidation when the claim they referenced changes
- Persisting `activePointSlug` (small ergonomic add, separate key)
- Reset-to-fixture button (handle via DevTools → localStorage clear for now)
- State `b` toggle, drag-reorder, Outline tab, counter-promotion, add-note flow

## Validation

- `npm --prefix webapp run typecheck` clean
- `npm --prefix webapp run build` clean
- `npm --prefix webapp run test` 172 passed / 1 skipped
- `npx prettier --check` clean
- `editorial-room.test.ts` 99/99

## Test plan

- [ ] Visit `/editorial/points-outline`; edit Point 1 CLAIM, save, RESCORE → fresh scores; reload → claim, revision turn, scores all preserved
- [ ] Edit several Points; reload → all preserved per Point
- [ ] In DevTools → Application → Local Storage, clear `editorial-room.points-outline.detail-states-v0`; reload → fixture defaults restored
- [ ] In DevTools, set the storage value to `{"schema_version":"99","states":{}}`; reload → fixture defaults (version mismatch)
- [ ] In DevTools, set value to `not-json`; reload → fixture defaults (parse fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)