### PR TITLE
feat: state-`b` chevron-toggle layout (notes-as-center + drawer)

### DIFF
--- a/webapp/src/pages/PointsOutlineWorkspacePage.tsx
+++ b/webapp/src/pages/PointsOutlineWorkspacePage.tsx
@@ -110,6 +110,13 @@ type DetailState = {
 type EditField = 'claim' | 'stake';
 type EditingTarget = { slug: string; field: EditField } | null;
 
+// Layout state per design/03_points_outline.md §1: 'a' = Notes-as-right-rail
+// + Discussion-in-center (default), 'b' = Notes-as-center + Discussion in a
+// quiet bottom drawer. Toggled by the chevron control on the divider, by
+// ⌘] / ⌘[, or by ⌘O (which always returns to state 'a' so the panel is
+// fully visible when the user wants to talk to it).
+type LayoutState = 'a' | 'b';
+
 const PRIMARY_PERSONAS: ReadonlyArray<Persona> = [
   {
     slug: 'persona/ankit-indie-dev',
@@ -646,6 +653,27 @@ function saveDetailStates(states: Record<string, DetailState>): void {
   }
 }
 
+const LAYOUT_STORAGE_KEY = 'editorial-room.points-outline.layout-state-v0';
+
+function loadLayoutState(): LayoutState {
+  if (typeof window === 'undefined') return 'a';
+  try {
+    const raw = window.localStorage.getItem(LAYOUT_STORAGE_KEY);
+    return raw === 'b' ? 'b' : 'a';
+  } catch {
+    return 'a';
+  }
+}
+
+function saveLayoutState(s: LayoutState): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(LAYOUT_STORAGE_KEY, s);
+  } catch {
+    // ignore
+  }
+}
+
 type Props = {
   onUnauthorized?: () => void;
 };
@@ -673,6 +701,39 @@ export function PointsOutlineWorkspacePage(_props: Props) {
   const [editing, setEditing] = useState<EditingTarget>(null);
   const [draft, setDraft] = useState<string>('');
   const [rescoringSlug, setRescoringSlug] = useState<string | null>(null);
+  const [layoutState, setLayoutState] = useState<LayoutState>(loadLayoutState);
+
+  useEffect(() => {
+    saveLayoutState(layoutState);
+  }, [layoutState]);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      // Don't hijack shortcuts while the user is typing in CLAIM/STAKE
+      // editor or any other text input.
+      if (tag === 'TEXTAREA' || tag === 'INPUT') return;
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.key === ']') {
+        e.preventDefault();
+        setLayoutState('b');
+      } else if (e.key === '[') {
+        e.preventDefault();
+        setLayoutState('a');
+      } else if (e.key === 'o' || e.key === 'O') {
+        // ⌘O always returns to state 'a' so the panel is fully visible.
+        e.preventDefault();
+        setLayoutState('a');
+      }
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  function toggleLayout() {
+    setLayoutState((s) => (s === 'a' ? 'b' : 'a'));
+  }
 
   function selectPoint(slug: string) {
     if (editing && editing.slug !== slug) {
@@ -788,7 +849,9 @@ export function PointsOutlineWorkspacePage(_props: Props) {
         </button>
       </div>
 
-      <div className="editorial-po-grid">
+      <div
+        className={`editorial-po-grid editorial-po-grid-state-${layoutState}`}
+      >
         {/* LEFT RAIL — POINTS LIST */}
         <aside className="editorial-po-rail">
           <div className="editorial-po-rail-tabs">
@@ -867,14 +930,18 @@ export function PointsOutlineWorkspacePage(_props: Props) {
               onCancelEdit={cancelEdit}
               onSaveEdit={saveEdit}
               onRescore={() => rescorePoint(activePoint.slug)}
+              layoutState={layoutState}
+              onToggleLayout={toggleLayout}
             />
           ) : null}
         </main>
 
-        {/* RIGHT RAIL — NOTES (state `a`) */}
-        <aside className="editorial-po-notes-rail">
-          <NotesRail notes={detail?.notes ?? []} />
-        </aside>
+        {/* RIGHT RAIL — NOTES (state `a` only; in state `b` notes move to center) */}
+        {layoutState === 'a' ? (
+          <aside className="editorial-po-notes-rail">
+            <NotesRail notes={detail?.notes ?? []} />
+          </aside>
+        ) : null}
       </div>
     </div>
   );
@@ -937,6 +1004,8 @@ function PointDetailView({
   onCancelEdit,
   onSaveEdit,
   onRescore,
+  layoutState,
+  onToggleLayout,
 }: {
   detail: PointDetail;
   stale: boolean;
@@ -948,6 +1017,8 @@ function PointDetailView({
   onCancelEdit: () => void;
   onSaveEdit: () => void;
   onRescore: () => void;
+  layoutState: LayoutState;
+  onToggleLayout: () => void;
 }) {
   const editingClaim =
     editing?.slug === detail.slug && editing.field === 'claim';
@@ -957,11 +1028,28 @@ function PointDetailView({
     detail.discussion.length > 0
       ? detail.discussion[detail.discussion.length - 1].timestamp
       : '—';
+  const lastAgentTurn = [...detail.discussion]
+    .reverse()
+    .find((t): t is AgentTurn => t.kind === 'agent');
 
   return (
     <article className="editorial-po-detail">
       <header className="editorial-po-detail-header">
         <span className="editorial-po-detail-eyebrow">{detail.eyebrow}</span>
+        <button
+          type="button"
+          className="editorial-po-layout-toggle"
+          onClick={onToggleLayout}
+          title={
+            layoutState === 'a'
+              ? 'Expand notes to center (⌘])'
+              : 'Collapse notes to rail (⌘[)'
+          }
+        >
+          {layoutState === 'a'
+            ? '‹ EXPAND NOTES · ⌘]'
+            : '› COLLAPSE TO RAIL · ⌘['}
+        </button>
       </header>
 
       {stale || rescoring ? (
@@ -1115,57 +1203,102 @@ function PointDetailView({
         </div>
       </section>
 
-      <section className="editorial-po-discussion">
-        <header className="editorial-po-discussion-header">
-          <h3 className="editorial-tt-section-label">
-            PANEL DISCUSSION · {detail.discussion.length} TURNS
-          </h3>
-          <div className="editorial-po-discussion-meta">
-            <span className="editorial-po-discussion-last">
-              LAST {lastTurnAt}
-            </span>
-            <span className="editorial-po-discussion-mentions">
-              {['@ALL', '@A', '@R', '@M'].map((m) => (
-                <span key={m} className="editorial-po-discussion-mention">
-                  {m}
-                </span>
-              ))}
-            </span>
+      {layoutState === 'a' ? (
+        <section className="editorial-po-discussion">
+          <header className="editorial-po-discussion-header">
+            <h3 className="editorial-tt-section-label">
+              PANEL DISCUSSION · {detail.discussion.length} TURNS
+            </h3>
+            <div className="editorial-po-discussion-meta">
+              <span className="editorial-po-discussion-last">
+                LAST {lastTurnAt}
+              </span>
+              <span className="editorial-po-discussion-mentions">
+                {['@ALL', '@A', '@R', '@M'].map((m) => (
+                  <span key={m} className="editorial-po-discussion-mention">
+                    {m}
+                  </span>
+                ))}
+              </span>
+            </div>
+          </header>
+
+          {detail.discussion.length === 0 ? (
+            <p className="editorial-tt-empty">
+              No discussion yet — ask the panel.
+            </p>
+          ) : (
+            <ol className="editorial-po-turn-list">
+              {detail.discussion.map((t) =>
+                t.kind === 'agent' ? (
+                  <AgentTurnView key={t.id} turn={t} />
+                ) : (
+                  <RevisionTurnView key={t.id} turn={t} />
+                ),
+              )}
+            </ol>
+          )}
+
+          <div className="editorial-po-discussion-input">
+            <input
+              type="text"
+              placeholder="Ask the panel — or @reference a note…"
+              disabled
+            />
+            <button
+              type="button"
+              className="editorial-chip-button editorial-chip-button-primary"
+              disabled
+            >
+              SEND ⌥↵
+            </button>
           </div>
-        </header>
-
-        {detail.discussion.length === 0 ? (
-          <p className="editorial-tt-empty">
-            No discussion yet — ask the panel.
-          </p>
-        ) : (
-          <ol className="editorial-po-turn-list">
-            {detail.discussion.map((t) =>
-              t.kind === 'agent' ? (
-                <AgentTurnView key={t.id} turn={t} />
-              ) : (
-                <RevisionTurnView key={t.id} turn={t} />
-              ),
-            )}
-          </ol>
-        )}
-
-        <div className="editorial-po-discussion-input">
-          <input
-            type="text"
-            placeholder="Ask the panel — or @reference a note…"
-            disabled
+        </section>
+      ) : (
+        <>
+          <section className="editorial-po-notes-center">
+            <NotesRail notes={detail.notes} />
+          </section>
+          <DiscussionDrawer
+            lastTurnAt={lastTurnAt}
+            lastAgentSummary={lastAgentTurn?.body ?? null}
+            onExpand={onToggleLayout}
           />
-          <button
-            type="button"
-            className="editorial-chip-button editorial-chip-button-primary"
-            disabled
-          >
-            SEND ⌥↵
-          </button>
-        </div>
-      </section>
+        </>
+      )}
     </article>
+  );
+}
+
+function DiscussionDrawer({
+  lastTurnAt,
+  lastAgentSummary,
+  onExpand,
+}: {
+  lastTurnAt: string;
+  lastAgentSummary: string | null;
+  onExpand: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="editorial-po-drawer"
+      onClick={onExpand}
+      aria-label="Expand panel discussion (⌘O)"
+    >
+      <span className="editorial-po-drawer-toggle" aria-hidden="true">
+        ▼
+      </span>
+      <span className="editorial-po-drawer-status">
+        PANEL DISCUSSION · last turn {lastTurnAt}
+      </span>
+      <span className="editorial-po-drawer-summary">
+        {lastAgentSummary
+          ? `“${lastAgentSummary}”`
+          : 'No panel turns yet — open the panel to ask.'}
+      </span>
+      <span className="editorial-po-drawer-hint">⌘O</span>
+    </button>
   );
 }
 

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -6613,3 +6613,117 @@ a.editorial-phase-pill:hover {
     transform: rotate(360deg);
   }
 }
+
+/* ─── Editorial Room · Points + Outline · state `b` chevron-toggle layout ── */
+
+.editorial-po-grid-state-b {
+  grid-template-columns: 220px minmax(0, 1fr);
+}
+
+.editorial-po-detail-header {
+  justify-content: space-between;
+}
+
+.editorial-po-layout-toggle {
+  border: 1px solid #c9c0a8;
+  background: transparent;
+  padding: 0.16rem 0.5rem;
+  border-radius: 3px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+  cursor: pointer;
+}
+
+.editorial-po-layout-toggle:hover {
+  border-color: #1f1c14;
+  color: #1f1c14;
+}
+
+.editorial-po-notes-center {
+  border-top: 1px solid #e2dccc;
+  padding-top: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+/* In state `b` the notes panel reuses NotesRail's inner markup, so the
+   internal class names (.editorial-po-notes-rail-header, etc.) still
+   render — they only refer to the inner header layout, not the outer rail
+   container. The center variant gives note cards more breathing room per
+   design §7.2: "compact cards still — but more breathing room — not
+   identical to PO4." */
+
+.editorial-po-notes-center .editorial-po-note-card {
+  padding: 0.7rem 0.85rem;
+}
+
+.editorial-po-notes-center .editorial-po-note-body {
+  font-size: 0.82rem;
+}
+
+.editorial-po-drawer {
+  margin-top: auto;
+  border: 1px solid #ddd6c8;
+  border-top-color: #b9b09c;
+  background: #f7f3e8;
+  padding: 0.45rem 0.85rem;
+  border-radius: 5px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.55rem;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  width: 100%;
+}
+
+.editorial-po-drawer:hover {
+  border-color: #1f1c14;
+  background: #efe9d8;
+}
+
+.editorial-po-drawer-toggle {
+  font-size: 0.72rem;
+  color: #6c6655;
+  line-height: 1;
+}
+
+.editorial-po-drawer-status {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.editorial-po-drawer-summary {
+  font-style: italic;
+  font-size: 0.78rem;
+  color: #1f1c14;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  grid-column: 2;
+  grid-row: 2;
+}
+
+.editorial-po-drawer-hint {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #8a8268;
+  border: 1px solid #c9c0a8;
+  border-radius: 3px;
+  padding: 0.05rem 0.3rem;
+  grid-column: 3;
+  grid-row: 1 / span 2;
+  align-self: center;
+}


### PR DESCRIPTION
## Summary
- Implements the PO5+ state `b` layout per `docs/design/03_points_outline.md` §1.3 + §7–8
- Toggle: chip in the detail header, `⌘]` (→ b), `⌘[` (→ a), `⌘O` (always → a)
- Persisted to localStorage at `editorial-room.points-outline.layout-state-v0`
- State `a` unchanged: Notes-as-right-rail, Discussion-in-center
- State `b`: right rail gone, Notes move into center with more breathing room, Panel Discussion collapses to a one-line bottom drawer (latest agent-turn summary + `⌘O` hint); click drawer = back to state `a` (the "snap back" path from design open-question §13.3)

## Mechanics

- New `LayoutState` type + `loadLayoutState` / `saveLayoutState` helpers, parallel to the existing detail-states persistence
- `useState` seeded from storage; `useEffect` writes back on change
- Window `keydown` listener bypasses when a `TEXTAREA` / `INPUT` is focused so the CLAIM/STAKE editor's `⌘↵` isn't hijacked
- Grid class `editorial-po-grid-state-{a,b}` flips column count from 3 to 2
- Right-rail `<aside>` is conditionally rendered (state `a` only)
- In state `b`, the same `NotesRail` body re-renders inside `.editorial-po-notes-center` with larger card padding per design §7.2 ("compact cards still — but more breathing room")
- `DiscussionDrawer` derives the summary from the latest agent turn (revisions skipped); empty discussions show a fallback line

## Deferred

- Drag-the-divider gesture (chevron + keyboard cover the cases)
- Drawer expand-in-place (snap-to-state-`a` is simpler and matches design's preferred path)
- Proposal-chip revalidation when the claim they reference changes
- Drag-reorder, Outline tab content, counter-promotion, add-note flow

## Validation

- `npm --prefix webapp run typecheck` clean
- `npm --prefix webapp run build` clean
- `npm --prefix webapp run test` 172 passed / 1 skipped
- `npx prettier --check` clean
- `editorial-room.test.ts` 99/99

## Test plan

- [ ] Visit `/editorial/points-outline`; chip in detail header reads `‹ EXPAND NOTES · ⌘]`
- [ ] Click chip → state `b`: right rail disappears, notes appear in center with looser padding, drawer at the bottom shows `PANEL DISCUSSION · last turn 11:47` + italic `"Ravi's right that this needs a person…"` + `⌘O` hint
- [ ] Press `⌘[` → state `a`; press `⌘]` → state `b`; press `⌘O` → state `a`
- [ ] Reload → previously chosen layout restored
- [ ] In state `b`, click anywhere on drawer → state `a`
- [ ] Open CLAIM editor, type — `⌘]` / `⌘[` / `⌘O` do NOT toggle layout while textarea is focused (so `⌘↵` to save still works cleanly)
- [ ] Edit Point's CLAIM in state `b`; save; STALE banner + RESCORE → still work; switching to state `a` shows the revision turn in the discussion list
- [ ] On a Point with no agent turns (e.g., Point 3), drawer in state `b` shows "No panel turns yet — open the panel to ask."

🤖 Generated with [Claude Code](https://claude.com/claude-code)