### PR TITLE
feat: add-note flow on the Notes panel

### DIFF
--- a/webapp/src/pages/PointsOutlineWorkspacePage.tsx
+++ b/webapp/src/pages/PointsOutlineWorkspacePage.tsx
@@ -105,7 +105,16 @@ type DetailState = {
   stale: boolean;
   scoreRow: ScoreCell[];
   aggregate: { score: number; ssr: number; gatesPass: boolean };
+  notes: Note[];
 };
+
+// State machine for adding a new note: `idle` → click `+` → `picking-type`
+// (filter chips become type-pickers) → click chip → `editing` (textarea
+// appears at top of notes list) → SAVE / CANCEL → `idle`.
+type NoteAddState =
+  | { kind: 'idle' }
+  | { kind: 'picking-type'; slug: string }
+  | { kind: 'editing'; slug: string; type: NoteType; body: string };
 
 type EditField = 'claim' | 'stake';
 type EditingTarget = { slug: string; field: EditField } | null;
@@ -116,6 +125,15 @@ type EditingTarget = { slug: string; field: EditField } | null;
 // ⌘] / ⌘[, or by ⌘O (which always returns to state 'a' so the panel is
 // fully visible when the user wants to talk to it).
 type LayoutState = 'a' | 'b';
+
+type NoteAddProps = {
+  state: NoteAddState;
+  onStart: () => void;
+  onCancel: () => void;
+  onPickType: (t: NoteType) => void;
+  onSetBody: (b: string) => void;
+  onSave: () => void;
+};
 
 const PRIMARY_PERSONAS: ReadonlyArray<Persona> = [
   {
@@ -550,9 +568,14 @@ function buildInitialDetailStates(): Record<string, DetailState> {
       stale: false,
       scoreRow: d.scoreRow.map((c) => ({ ...c })),
       aggregate: { ...d.aggregate },
+      notes: d.notes.map((n) => ({ ...n })),
     };
   }
   return out;
+}
+
+function makeNoteId(slug: string): string {
+  return `note-${slug}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
 }
 
 // Deterministic small drift on claim/stake content so RESCORE produces
@@ -596,7 +619,11 @@ const RESCORE_LATENCY_MS = 600;
 // localStorage persistence for the per-Point editable+scored state.
 // Bump the version suffix when DetailState gains required fields so older
 // stored shapes get discarded instead of merged into a partial value.
-const STORAGE_KEY = 'editorial-room.points-outline.detail-states-v0';
+// v1 = adds Note[] to DetailState. Older stored shapes from v0 fail
+// per-slug validation and fall back to the fixture defaults for that slug,
+// which is acceptable in v0p prototyping (CLAUDE.md treats stored data as
+// disposable).
+const STORAGE_KEY = 'editorial-room.points-outline.detail-states-v1';
 
 function isValidStoredState(s: unknown): s is DetailState {
   if (!s || typeof s !== 'object') return false;
@@ -608,7 +635,8 @@ function isValidStoredState(s: unknown): s is DetailState {
     typeof o.stale === 'boolean' &&
     Array.isArray(o.scoreRow) &&
     !!o.aggregate &&
-    typeof o.aggregate === 'object'
+    typeof o.aggregate === 'object' &&
+    Array.isArray(o.notes)
   );
 }
 
@@ -702,6 +730,9 @@ export function PointsOutlineWorkspacePage(_props: Props) {
   const [draft, setDraft] = useState<string>('');
   const [rescoringSlug, setRescoringSlug] = useState<string | null>(null);
   const [layoutState, setLayoutState] = useState<LayoutState>(loadLayoutState);
+  const [noteAddState, setNoteAddState] = useState<NoteAddState>({
+    kind: 'idle',
+  });
 
   useEffect(() => {
     saveLayoutState(layoutState);
@@ -741,8 +772,66 @@ export function PointsOutlineWorkspacePage(_props: Props) {
       setEditing(null);
       setDraft('');
     }
+    if (noteAddState.kind !== 'idle' && noteAddState.slug !== slug) {
+      setNoteAddState({ kind: 'idle' });
+    }
     setActivePointSlug(slug);
   }
+
+  function startAddingNote() {
+    setNoteAddState({ kind: 'picking-type', slug: activePoint.slug });
+  }
+
+  function cancelAddingNote() {
+    setNoteAddState({ kind: 'idle' });
+  }
+
+  function pickNoteType(type: NoteType) {
+    if (noteAddState.kind !== 'picking-type') return;
+    setNoteAddState({
+      kind: 'editing',
+      slug: noteAddState.slug,
+      type,
+      body: '',
+    });
+  }
+
+  function setNoteDraftBody(body: string) {
+    setNoteAddState((prev) =>
+      prev.kind === 'editing' ? { ...prev, body } : prev,
+    );
+  }
+
+  function saveNewNote() {
+    if (noteAddState.kind !== 'editing') return;
+    const text = noteAddState.body.trim();
+    if (!text) return;
+    const slug = noteAddState.slug;
+    const newNote: Note = {
+      id: makeNoteId(slug),
+      type: noteAddState.type,
+      timestamp: nowHHMM(),
+      body: text,
+    };
+    setDetailStates((prev) => {
+      const cur = prev[slug];
+      if (!cur) return prev;
+      return {
+        ...prev,
+        [slug]: { ...cur, notes: [newNote, ...cur.notes] },
+      };
+    });
+    setNoteAddState({ kind: 'idle' });
+  }
+
+  const noteAddProps: NoteAddProps = {
+    state: noteAddState,
+    onStart: startAddingNote,
+    onCancel: cancelAddingNote,
+    onPickType: pickNoteType,
+    onSetBody: setNoteDraftBody,
+    onSave: saveNewNote,
+  };
 
   const fixture = POINT_DETAILS[activePoint.slug];
   const state = detailStates[activePoint.slug];
@@ -755,6 +844,7 @@ export function PointsOutlineWorkspacePage(_props: Props) {
           discussion: state.discussion,
           scoreRow: state.scoreRow,
           aggregate: state.aggregate,
+          notes: state.notes,
         }
       : null;
   const stale = state?.stale ?? false;
@@ -932,6 +1022,7 @@ export function PointsOutlineWorkspacePage(_props: Props) {
               onRescore={() => rescorePoint(activePoint.slug)}
               layoutState={layoutState}
               onToggleLayout={toggleLayout}
+              noteAdd={noteAddProps}
             />
           ) : null}
         </main>
@@ -939,7 +1030,7 @@ export function PointsOutlineWorkspacePage(_props: Props) {
         {/* RIGHT RAIL — NOTES (state `a` only; in state `b` notes move to center) */}
         {layoutState === 'a' ? (
           <aside className="editorial-po-notes-rail">
-            <NotesRail notes={detail?.notes ?? []} />
+            <NotesRail notes={detail?.notes ?? []} noteAdd={noteAddProps} />
           </aside>
         ) : null}
       </div>
@@ -985,7 +1076,7 @@ function PointCard({
         <p className="editorial-po-point-claim">{claim}</p>
         {stake ? <p className="editorial-po-point-stake">{stake}</p> : null}
         <span className="editorial-po-point-notes">
-          {point.noteCount} NOTES
+          {state?.notes.length ?? point.noteCount} NOTES
           {cardStale ? ' · STALE' : ''}
         </span>
       </button>
@@ -1006,6 +1097,7 @@ function PointDetailView({
   onRescore,
   layoutState,
   onToggleLayout,
+  noteAdd,
 }: {
   detail: PointDetail;
   stale: boolean;
@@ -1019,6 +1111,7 @@ function PointDetailView({
   onRescore: () => void;
   layoutState: LayoutState;
   onToggleLayout: () => void;
+  noteAdd: NoteAddProps;
 }) {
   const editingClaim =
     editing?.slug === detail.slug && editing.field === 'claim';
@@ -1257,7 +1350,7 @@ function PointDetailView({
       ) : (
         <>
           <section className="editorial-po-notes-center">
-            <NotesRail notes={detail.notes} />
+            <NotesRail notes={detail.notes} noteAdd={noteAdd} />
           </section>
           <DiscussionDrawer
             lastTurnAt={lastTurnAt}
@@ -1411,7 +1504,20 @@ function ClaimStakeEditor({
   );
 }
 
-function NotesRail({ notes }: { notes: ReadonlyArray<Note> }) {
+function NotesRail({
+  notes,
+  noteAdd,
+}: {
+  notes: ReadonlyArray<Note>;
+  noteAdd: NoteAddProps;
+}) {
+  const isPicking = noteAdd.state.kind === 'picking-type';
+  const isEditing = noteAdd.state.kind === 'editing';
+  const editingType =
+    noteAdd.state.kind === 'editing' ? noteAdd.state.type : null;
+  const editingBody =
+    noteAdd.state.kind === 'editing' ? noteAdd.state.body : '';
+
   return (
     <>
       <div className="editorial-po-notes-rail-header">
@@ -1419,29 +1525,96 @@ function NotesRail({ notes }: { notes: ReadonlyArray<Note> }) {
         <span className="editorial-po-notes-sort">↓ CHRONO</span>
       </div>
 
-      <div className="editorial-po-notes-filter">
+      <div
+        className={
+          'editorial-po-notes-filter' +
+          (isPicking ? ' editorial-po-notes-filter-picking' : '')
+        }
+      >
         {NOTE_FILTER_ORDER.map((nt) => (
           <button
             key={nt}
             type="button"
             className={`editorial-po-notes-filter-chip editorial-po-notes-filter-chip-${nt}`}
-            disabled
-            title={NOTE_TYPE_LABEL[nt]}
+            disabled={!isPicking}
+            onClick={isPicking ? () => noteAdd.onPickType(nt) : undefined}
+            title={
+              isPicking
+                ? `Add a ${NOTE_TYPE_LABEL[nt]} note`
+                : NOTE_TYPE_LABEL[nt]
+            }
           >
             {NOTE_TYPE_CODE[nt]}
           </button>
         ))}
         <button
           type="button"
-          className="editorial-po-notes-filter-chip editorial-po-notes-filter-chip-add"
-          disabled
-          aria-label="Add note"
+          className={
+            'editorial-po-notes-filter-chip editorial-po-notes-filter-chip-add' +
+            (isPicking ? ' editorial-po-notes-filter-chip-add-active' : '')
+          }
+          onClick={isPicking ? noteAdd.onCancel : noteAdd.onStart}
+          disabled={isEditing}
+          aria-label={isPicking ? 'Cancel add note' : 'Add note'}
         >
-          +
+          {isPicking ? '×' : '+'}
         </button>
       </div>
 
-      {notes.length === 0 ? (
+      {isEditing && editingType ? (
+        <div
+          className={`editorial-po-note-card editorial-po-note-card-new editorial-po-note-card-${editingType}`}
+        >
+          <div className="editorial-po-note-head">
+            <span
+              className={`editorial-po-note-code editorial-po-note-code-${editingType}`}
+            >
+              {NOTE_TYPE_CODE[editingType]}
+            </span>
+            <span className="editorial-po-note-type">
+              {NOTE_TYPE_LABEL[editingType]}
+            </span>
+            <span className="editorial-po-note-timestamp">NEW</span>
+          </div>
+          <textarea
+            autoFocus
+            value={editingBody}
+            onChange={(e) => noteAdd.onSetBody(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                noteAdd.onCancel();
+              } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                noteAdd.onSave();
+              }
+            }}
+            placeholder={`New ${NOTE_TYPE_LABEL[editingType]} note…`}
+            rows={3}
+            className="editorial-po-note-edit-textarea"
+            aria-label={`New ${NOTE_TYPE_LABEL[editingType]} note`}
+          />
+          <div className="editorial-po-edit-actions">
+            <button
+              type="button"
+              className="editorial-po-edit-save"
+              onClick={noteAdd.onSave}
+              disabled={!editingBody.trim()}
+            >
+              SAVE ⌘↵
+            </button>
+            <button
+              type="button"
+              className="editorial-po-edit-cancel"
+              onClick={noteAdd.onCancel}
+            >
+              CANCEL · ESC
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {notes.length === 0 && !isEditing ? (
         <p className="editorial-tt-empty">
           No notes yet — pick a type to start.
         </p>
@@ -1483,8 +1656,18 @@ function NotesRail({ notes }: { notes: ReadonlyArray<Note> }) {
         </ul>
       )}
 
-      <button type="button" className="editorial-po-note-add" disabled>
-        + NOTE · PICK TYPE ABOVE
+      <button
+        type="button"
+        className={
+          'editorial-po-note-add' +
+          (isPicking ? ' editorial-po-note-add-picking' : '')
+        }
+        onClick={isPicking ? noteAdd.onCancel : noteAdd.onStart}
+        disabled={isEditing}
+      >
+        {isPicking
+          ? '× CANCEL · PICK A TYPE ABOVE'
+          : '+ NOTE · PICK TYPE ABOVE'}
       </button>
     </>
   );

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -6727,3 +6727,84 @@ a.editorial-phase-pill:hover {
   grid-row: 1 / span 2;
   align-self: center;
 }
+
+/* ─── Editorial Room · Points + Outline · add-note flow ──────────────── */
+
+.editorial-po-notes-filter-picking {
+  background: #fdf3df;
+  padding: 0.3rem;
+  margin: -0.3rem -0.3rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid #c98a2c;
+  position: relative;
+}
+
+.editorial-po-notes-filter-picking::before {
+  content: 'PICK A TYPE →';
+  position: absolute;
+  top: -0.65rem;
+  left: 0.4rem;
+  background: #fdf3df;
+  padding: 0 0.3rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.55rem;
+  letter-spacing: 0.06em;
+  color: #7a4a08;
+}
+
+.editorial-po-notes-filter-picking .editorial-po-notes-filter-chip {
+  cursor: pointer;
+  opacity: 1;
+  transform: scale(1.05);
+  transition:
+    transform 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.editorial-po-notes-filter-picking .editorial-po-notes-filter-chip:hover {
+  box-shadow: 0 0 0 2px rgba(31, 28, 20, 0.18);
+}
+
+.editorial-po-notes-filter-chip-add-active {
+  border-color: #b7372a;
+  color: #b7372a;
+  border-style: solid;
+  font-weight: 700;
+}
+
+.editorial-po-note-card-new {
+  border-color: #1f1c14;
+  border-width: 1.5px;
+  background: #fffdf5;
+}
+
+.editorial-po-note-edit-textarea {
+  font-family: inherit;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: #1f1c14;
+  background: #fff;
+  border: 1px solid #c9c0a8;
+  border-radius: 4px;
+  padding: 0.4rem 0.5rem;
+  resize: vertical;
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 0.25rem;
+}
+
+.editorial-po-note-edit-textarea:focus {
+  outline: none;
+  border-color: #b7372a;
+  box-shadow: 0 0 0 2px rgba(183, 55, 42, 0.18);
+}
+
+.editorial-po-note-card-new .editorial-po-edit-actions {
+  margin-top: 0.4rem;
+}
+
+.editorial-po-note-add-picking {
+  border-color: #b7372a;
+  color: #b7372a;
+  border-style: solid;
+}


### PR DESCRIPTION
## Summary
- Click `+` on the chip row (or the footer button) to enter pick-a-type mode; type chips T/C/E/Q/!/O become clickable
- Click a chip → new-note editor card with that type at the top of the notes list (textarea + `SAVE ⌘↵` + `CANCEL · ESC`)
- Save appends the note + bumps the left-rail Point card's NOTES count + persists to localStorage
- Works in both layout state `a` (right rail) and state `b` (center)

## Mechanics

- `DetailState` gains `notes: Note[]`; storage key bumps to `detail-states-v1` and `isValidStoredState` requires the field. Older v0 data falls back per-slug to the fixture (acceptable in v0p prototyping per CLAUDE.md "stored data disposable")
- `NoteAddState` is a discriminated union: `idle` | `picking-type` | `editing`. Switching active Point cancels in-flight add
- `NoteAddProps` bundles `{state, onStart, onCancel, onPickType, onSetBody, onSave}` and threads through `PointDetailView` to `NotesRail` (single component, used in both layouts)
- In picking-type mode the chip row gets an amber "PICK A TYPE →" prompt and the chips' `disabled` flips off; the `+` chip mirrors the footer button (start/cancel)
- Editor card: full-width textarea inside a note-card-shaped container, type code+label at top, NEW timestamp pill. ESC = cancel, `⌘↵` = save, empty body disables save
- New notes prepend to `notes[]` so the user sees their addition without scrolling
- Left-rail `PointCard` derives note count from `state.notes.length`

## Deferred

- Note editing (click an existing note to revise body) — same shape, not in this slice
- Note deletion
- Filter chips actually filtering visible notes (only repurposed for type-pick when in picking-type mode)
- Counter-promotion (`PROMOTE ›` on `!` notes)
- Drag-reorder Points, Outline tab content, proposal-chip revalidation

## Validation

- `npm --prefix webapp run typecheck` clean
- `npm --prefix webapp run build` clean
- `npm --prefix webapp run test` 172 passed / 1 skipped
- `npx prettier --check` clean
- `editorial-room.test.ts` 99/99

## Test plan

- [ ] Visit `/editorial/points-outline`; click `+` chip on the right of the filter row → amber "PICK A TYPE →" header appears, chips become clickable
- [ ] Click `T` (thought) → editor card appears at top with `T · THOUGHT · NEW` header and an empty textarea, autofocused
- [ ] Type a note body; `SAVE ⌘↵` enables; click → editor disappears, the note appears at the top of the list with the current time, the chip row reverts to filter-disabled mode, and the left-rail `4 NOTES` badge becomes `5 NOTES`
- [ ] Reload → new note still there
- [ ] Click `+` chip again, click `× CANCEL · PICK A TYPE ABOVE` footer → exits picking mode
- [ ] Click `+` chip → click `E` → editor opens; press `Escape` → editor closes, no note added
- [ ] Click `+` → pick `Q` → type something → press `Cmd-Enter` (or Ctrl-Enter) → saved
- [ ] Switch to a different Point while in picking-type mode → mode auto-cancels
- [ ] Toggle to state `b` (`⌘]`); add-note flow still works in the center notes panel
- [ ] In DevTools clear the v1 storage; reload → fixture defaults restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)