### PR TITLE
feat: edit + delete existing notes inline

### DIFF
--- a/webapp/src/pages/PointsOutlineWorkspacePage.tsx
+++ b/webapp/src/pages/PointsOutlineWorkspacePage.tsx
@@ -135,6 +135,16 @@ type NoteAddProps = {
   onSave: () => void;
 };
 
+type NoteEditProps = {
+  editingId: { slug: string; noteId: string } | null;
+  draft: string;
+  onStart: (noteId: string) => void;
+  onCancel: () => void;
+  onSave: () => void;
+  onSetDraft: (v: string) => void;
+  onDelete: (noteId: string) => void;
+};
+
 const PRIMARY_PERSONAS: ReadonlyArray<Persona> = [
   {
     slug: 'persona/ankit-indie-dev',
@@ -733,6 +743,11 @@ export function PointsOutlineWorkspacePage(_props: Props) {
   const [noteAddState, setNoteAddState] = useState<NoteAddState>({
     kind: 'idle',
   });
+  const [editingNoteId, setEditingNoteId] = useState<{
+    slug: string;
+    noteId: string;
+  } | null>(null);
+  const [noteEditDraft, setNoteEditDraft] = useState<string>('');
 
   useEffect(() => {
     saveLayoutState(layoutState);
@@ -775,7 +790,66 @@ export function PointsOutlineWorkspacePage(_props: Props) {
     if (noteAddState.kind !== 'idle' && noteAddState.slug !== slug) {
       setNoteAddState({ kind: 'idle' });
     }
+    if (editingNoteId && editingNoteId.slug !== slug) {
+      setEditingNoteId(null);
+      setNoteEditDraft('');
+    }
     setActivePointSlug(slug);
+  }
+
+  function startEditNote(noteId: string) {
+    const cur = detailStates[activePoint.slug];
+    if (!cur) return;
+    const note = cur.notes.find((n) => n.id === noteId);
+    if (!note) return;
+    setNoteEditDraft(note.body);
+    setEditingNoteId({ slug: activePoint.slug, noteId });
+  }
+
+  function cancelEditNote() {
+    setEditingNoteId(null);
+    setNoteEditDraft('');
+  }
+
+  function saveEditNote() {
+    if (!editingNoteId) return;
+    const text = noteEditDraft.trim();
+    if (!text) return;
+    const { slug, noteId } = editingNoteId;
+    setDetailStates((prev) => {
+      const cur = prev[slug];
+      if (!cur) return prev;
+      return {
+        ...prev,
+        [slug]: {
+          ...cur,
+          notes: cur.notes.map((n) =>
+            n.id === noteId ? { ...n, body: text } : n,
+          ),
+        },
+      };
+    });
+    setEditingNoteId(null);
+    setNoteEditDraft('');
+  }
+
+  function deleteNote(noteId: string) {
+    const slug = activePoint.slug;
+    setDetailStates((prev) => {
+      const cur = prev[slug];
+      if (!cur) return prev;
+      return {
+        ...prev,
+        [slug]: {
+          ...cur,
+          notes: cur.notes.filter((n) => n.id !== noteId),
+        },
+      };
+    });
+    if (editingNoteId?.slug === slug && editingNoteId.noteId === noteId) {
+      setEditingNoteId(null);
+      setNoteEditDraft('');
+    }
   }
 
   function startAddingNote() {
@@ -831,6 +905,16 @@ export function PointsOutlineWorkspacePage(_props: Props) {
     onPickType: pickNoteType,
     onSetBody: setNoteDraftBody,
     onSave: saveNewNote,
+  };
+
+  const noteEditProps: NoteEditProps = {
+    editingId: editingNoteId,
+    draft: noteEditDraft,
+    onStart: startEditNote,
+    onCancel: cancelEditNote,
+    onSave: saveEditNote,
+    onSetDraft: setNoteEditDraft,
+    onDelete: deleteNote,
   };
 
   const fixture = POINT_DETAILS[activePoint.slug];
@@ -1023,6 +1107,7 @@ export function PointsOutlineWorkspacePage(_props: Props) {
               layoutState={layoutState}
               onToggleLayout={toggleLayout}
               noteAdd={noteAddProps}
+              noteEdit={noteEditProps}
             />
           ) : null}
         </main>
@@ -1030,7 +1115,11 @@ export function PointsOutlineWorkspacePage(_props: Props) {
         {/* RIGHT RAIL — NOTES (state `a` only; in state `b` notes move to center) */}
         {layoutState === 'a' ? (
           <aside className="editorial-po-notes-rail">
-            <NotesRail notes={detail?.notes ?? []} noteAdd={noteAddProps} />
+            <NotesRail
+              notes={detail?.notes ?? []}
+              noteAdd={noteAddProps}
+              noteEdit={noteEditProps}
+            />
           </aside>
         ) : null}
       </div>
@@ -1098,6 +1187,7 @@ function PointDetailView({
   layoutState,
   onToggleLayout,
   noteAdd,
+  noteEdit,
 }: {
   detail: PointDetail;
   stale: boolean;
@@ -1112,6 +1202,7 @@ function PointDetailView({
   layoutState: LayoutState;
   onToggleLayout: () => void;
   noteAdd: NoteAddProps;
+  noteEdit: NoteEditProps;
 }) {
   const editingClaim =
     editing?.slug === detail.slug && editing.field === 'claim';
@@ -1350,7 +1441,11 @@ function PointDetailView({
       ) : (
         <>
           <section className="editorial-po-notes-center">
-            <NotesRail notes={detail.notes} noteAdd={noteAdd} />
+            <NotesRail
+              notes={detail.notes}
+              noteAdd={noteAdd}
+              noteEdit={noteEdit}
+            />
           </section>
           <DiscussionDrawer
             lastTurnAt={lastTurnAt}
@@ -1507,9 +1602,11 @@ function ClaimStakeEditor({
 function NotesRail({
   notes,
   noteAdd,
+  noteEdit,
 }: {
   notes: ReadonlyArray<Note>;
   noteAdd: NoteAddProps;
+  noteEdit: NoteEditProps;
 }) {
   const isPicking = noteAdd.state.kind === 'picking-type';
   const isEditing = noteAdd.state.kind === 'editing';
@@ -1517,6 +1614,7 @@ function NotesRail({
     noteAdd.state.kind === 'editing' ? noteAdd.state.type : null;
   const editingBody =
     noteAdd.state.kind === 'editing' ? noteAdd.state.body : '';
+  const editingNoteId = noteEdit.editingId?.noteId ?? null;
 
   return (
     <>
@@ -1620,39 +1718,103 @@ function NotesRail({
         </p>
       ) : (
         <ul className="editorial-po-note-list">
-          {notes.map((n) => (
-            <li
-              key={n.id}
-              className={
-                `editorial-po-note-card editorial-po-note-card-${n.type}` +
-                (n.highlighted ? ' editorial-po-note-card-highlighted' : '')
-              }
-            >
-              <div className="editorial-po-note-head">
-                <span
-                  className={`editorial-po-note-code editorial-po-note-code-${n.type}`}
-                >
-                  {NOTE_TYPE_CODE[n.type]}
-                </span>
-                <span className="editorial-po-note-type">
-                  {NOTE_TYPE_LABEL[n.type]}
-                </span>
-                {n.promotable ? (
-                  <button
-                    type="button"
-                    className="editorial-po-note-promote"
-                    disabled
+          {notes.map((n) => {
+            const isEditingThis = editingNoteId === n.id;
+            const className =
+              `editorial-po-note-card editorial-po-note-card-${n.type}` +
+              (n.highlighted ? ' editorial-po-note-card-highlighted' : '') +
+              (isEditingThis ? ' editorial-po-note-card-editing' : '');
+            return (
+              <li key={n.id} className={className}>
+                <div className="editorial-po-note-head">
+                  <span
+                    className={`editorial-po-note-code editorial-po-note-code-${n.type}`}
                   >
-                    PROMOTE ›
-                  </button>
-                ) : null}
-                <span className="editorial-po-note-timestamp">
-                  {n.timestamp}
-                </span>
-              </div>
-              <p className="editorial-po-note-body">{n.body}</p>
-            </li>
-          ))}
+                    {NOTE_TYPE_CODE[n.type]}
+                  </span>
+                  <span className="editorial-po-note-type">
+                    {NOTE_TYPE_LABEL[n.type]}
+                  </span>
+                  {n.promotable ? (
+                    <button
+                      type="button"
+                      className="editorial-po-note-promote"
+                      disabled
+                    >
+                      PROMOTE ›
+                    </button>
+                  ) : null}
+                  <span className="editorial-po-note-timestamp">
+                    {n.timestamp}
+                  </span>
+                </div>
+                {isEditingThis ? (
+                  <>
+                    <textarea
+                      autoFocus
+                      value={noteEdit.draft}
+                      onChange={(e) => noteEdit.onSetDraft(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Escape') {
+                          e.preventDefault();
+                          noteEdit.onCancel();
+                        } else if (
+                          e.key === 'Enter' &&
+                          (e.metaKey || e.ctrlKey)
+                        ) {
+                          e.preventDefault();
+                          noteEdit.onSave();
+                        }
+                      }}
+                      rows={3}
+                      className="editorial-po-note-edit-textarea"
+                      aria-label={`Edit ${NOTE_TYPE_LABEL[n.type]} note`}
+                    />
+                    <div className="editorial-po-edit-actions editorial-po-edit-actions-with-delete">
+                      <button
+                        type="button"
+                        className="editorial-po-note-delete"
+                        onClick={() => noteEdit.onDelete(n.id)}
+                      >
+                        DELETE
+                      </button>
+                      <span className="editorial-po-edit-actions-spacer" />
+                      <button
+                        type="button"
+                        className="editorial-po-edit-save"
+                        onClick={noteEdit.onSave}
+                        disabled={!noteEdit.draft.trim()}
+                      >
+                        SAVE ⌘↵
+                      </button>
+                      <button
+                        type="button"
+                        className="editorial-po-edit-cancel"
+                        onClick={noteEdit.onCancel}
+                      >
+                        CANCEL · ESC
+                      </button>
+                    </div>
+                  </>
+                ) : (
+                  <p
+                    className="editorial-po-note-body editorial-po-note-body-clickable"
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => noteEdit.onStart(n.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        noteEdit.onStart(n.id);
+                      }
+                    }}
+                  >
+                    {n.body}
+                  </p>
+                )}
+              </li>
+            );
+          })}
         </ul>
       )}
 

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -6808,3 +6808,54 @@ a.editorial-phase-pill:hover {
   color: #b7372a;
   border-style: solid;
 }
+
+.editorial-po-note-body-clickable {
+  cursor: text;
+  border-radius: 3px;
+  padding: 0.15rem 0.25rem;
+  margin: 0;
+  margin-left: -0.25rem;
+  transition: background-color 120ms ease;
+}
+
+.editorial-po-note-body-clickable:hover {
+  background-color: #f4ecd8;
+}
+
+.editorial-po-note-body-clickable:focus-visible {
+  outline: 2px solid #1f1c14;
+  outline-offset: 2px;
+  background-color: #f4ecd8;
+}
+
+.editorial-po-note-card-editing {
+  border-color: #1f1c14;
+  border-width: 1.5px;
+  background: #fffdf5;
+}
+
+.editorial-po-edit-actions-with-delete {
+  justify-content: flex-start;
+}
+
+.editorial-po-edit-actions-spacer {
+  flex: 1;
+}
+
+.editorial-po-note-delete {
+  border: 1px solid transparent;
+  background: transparent;
+  color: #b7372a;
+  padding: 0.18rem 0.45rem;
+  border-radius: 3px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.editorial-po-note-delete:hover {
+  border-color: #b7372a;
+  background: #fbeae6;
+}


### PR DESCRIPTION
## Summary
- Click a note's body to edit in place; the card swaps its body for a textarea
- `SAVE ⌘↵` updates body + persists; `CANCEL · ESC` discards; `DELETE` removes the note
- Switching active Point cancels any in-flight note edit
- Closes the note CRUD loop (add/edit/delete) opened by the previous PR

## Mechanics

- New page state: `editingNoteId: {slug, noteId} | null` + `noteEditDraft: string`
- `NoteEditProps` bundles `{editingId, draft, onStart, onCancel, onSave, onSetDraft, onDelete}`, threaded through `PointDetailView` to `NotesRail` (works in both layouts)
- Click body / Enter / Space starts edit; the card replaces its `<p>` body with a textarea + actions row
- Delete sits on the left of the actions row, separated from SAVE/CANCEL by a flex spacer — needs explicit edit-mode entry, no one-click accidental deletes from rest state
- Type and timestamp are preserved on edit; only body is mutable in this slice
- Empty body disables save
- Persists via the existing `detail-states-v1` localStorage envelope

## Deferred

- Changing a note's type during edit
- Filter chips actually filtering visible notes (still only repurposed for type-pick)
- Counter-promotion (`PROMOTE ›` on `!` notes)
- Drag-reorder Points, Outline tab content, proposal-chip revalidation

## Validation

- `npm --prefix webapp run typecheck` clean
- `npm --prefix webapp run build` clean
- `npm --prefix webapp run test` 172 passed / 1 skipped
- `npx prettier --check` clean
- `editorial-room.test.ts` 99/99

## Test plan

- [ ] Visit `/editorial/points-outline`; hover a note's body — bg shifts subtly, cursor turns to text
- [ ] Click a note's body → it swaps to a textarea pre-filled with the body; SAVE / CANCEL / DELETE buttons appear
- [ ] Edit the body; click `SAVE ⌘↵` → editor closes, new body shown; reload → still there
- [ ] Edit again; press `Esc` → editor closes, body unchanged
- [ ] Click `DELETE` → note disappears; left-rail NOTES count drops; reload → still gone
- [ ] In the COUNTER note (Point 1), the `PROMOTE ›` chip is still present and disabled
- [ ] Add a new note, then edit it (full add/edit cycle on the same note)
- [ ] In state `b` (`⌘]`), the same edit/delete flow works in the center notes panel
- [ ] Switch to a different Point while editing → edit auto-cancels

🤖 Generated with [Claude Code](https://claude.com/claude-code)