### PR TITLE
feat: drag-reorder main Points (left rail)

### DIFF
--- a/webapp/src/pages/PointsOutlineWorkspacePage.tsx
+++ b/webapp/src/pages/PointsOutlineWorkspacePage.tsx
@@ -1,4 +1,19 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
 
@@ -764,6 +779,39 @@ function saveAddedCounters(points: Point[]): void {
   }
 }
 
+const POINTS_ORDER_KEY = 'editorial-room.points-outline.points-order-v0';
+
+function loadPointsOrder(): string[] {
+  const fixtureSlugs = POINTS.map((p) => p.slug);
+  if (typeof window === 'undefined') return fixtureSlugs;
+  try {
+    const raw = window.localStorage.getItem(POINTS_ORDER_KEY);
+    if (!raw) return fixtureSlugs;
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return fixtureSlugs;
+    const known = new Set(fixtureSlugs);
+    const filtered = parsed.filter(
+      (s): s is string => typeof s === 'string' && known.has(s),
+    );
+    // Append fixture slugs that weren't in storage (handles fixture growth
+    // by putting new Points at the end of the user's order).
+    const inStored = new Set(filtered);
+    const missing = fixtureSlugs.filter((s) => !inStored.has(s));
+    return [...filtered, ...missing];
+  } catch {
+    return fixtureSlugs;
+  }
+}
+
+function savePointsOrder(order: string[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(POINTS_ORDER_KEY, JSON.stringify(order));
+  } catch {
+    // ignore
+  }
+}
+
 type Props = {
   onUnauthorized?: () => void;
 };
@@ -784,12 +832,46 @@ export function PointsOutlineWorkspacePage(_props: Props) {
     saveAddedCounters(addedCounters);
   }, [addedCounters]);
 
+  const [pointsOrder, setPointsOrder] = useState<string[]>(loadPointsOrder);
+
+  useEffect(() => {
+    savePointsOrder(pointsOrder);
+  }, [pointsOrder]);
+
+  const orderedMainPoints = useMemo(
+    () =>
+      pointsOrder
+        .map((slug) => POINTS.find((p) => p.slug === slug))
+        .filter((p): p is Point => !!p),
+    [pointsOrder],
+  );
+
   const allCounters = useMemo(
     () => [...COUNTER_POINTS, ...addedCounters],
     [addedCounters],
   );
 
-  const allPoints = useMemo(() => [...POINTS, ...allCounters], [allCounters]);
+  const allPoints = useMemo(
+    () => [...orderedMainPoints, ...allCounters],
+    [orderedMainPoints, allCounters],
+  );
+
+  // PointerSensor with a small activation distance so a click selects the
+  // Point (no movement) but a drag past 5px triggers reorder.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  function handlePointDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    setPointsOrder((prev) => {
+      const oldIndex = prev.indexOf(String(active.id));
+      const newIndex = prev.indexOf(String(over.id));
+      if (oldIndex < 0 || newIndex < 0) return prev;
+      return arrayMove(prev, oldIndex, newIndex);
+    });
+  }
   const activePoint =
     allPoints.find((p) => p.slug === activePointSlug) ?? allPoints[0];
 
@@ -1181,17 +1263,32 @@ export function PointsOutlineWorkspacePage(_props: Props) {
             </button>
           </div>
 
-          <ul className="editorial-po-point-list">
-            {POINTS.map((p) => (
-              <PointCard
-                key={p.slug}
-                point={p}
-                state={detailStates[p.slug]}
-                isActive={p.slug === activePointSlug}
-                onSelect={() => selectPoint(p.slug)}
-              />
-            ))}
-          </ul>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handlePointDragEnd}
+          >
+            <SortableContext
+              items={pointsOrder}
+              strategy={verticalListSortingStrategy}
+            >
+              <ul className="editorial-po-point-list">
+                {orderedMainPoints.map((p, idx) => (
+                  <SortablePointWrapper key={p.slug} slug={p.slug}>
+                    <PointCard
+                      point={{
+                        ...p,
+                        position: String(idx + 1).padStart(2, '0'),
+                      }}
+                      state={detailStates[p.slug]}
+                      isActive={p.slug === activePointSlug}
+                      onSelect={() => selectPoint(p.slug)}
+                    />
+                  </SortablePointWrapper>
+                ))}
+              </ul>
+            </SortableContext>
+          </DndContext>
 
           {allCounters.length > 0 ? (
             <>
@@ -1199,15 +1296,21 @@ export function PointsOutlineWorkspacePage(_props: Props) {
                 COUNTER-POINTS · {allCounters.length}
               </h2>
               <ul className="editorial-po-point-list">
-                {allCounters.map((p) => (
-                  <PointCard
-                    key={p.slug}
-                    point={p}
-                    state={detailStates[p.slug]}
-                    isActive={p.slug === activePointSlug}
-                    isCounter
-                    onSelect={() => selectPoint(p.slug)}
-                  />
+                {allCounters.map((p, idx) => (
+                  <li key={p.slug} className="editorial-po-point-li">
+                    <PointCard
+                      point={{
+                        ...p,
+                        position: String(
+                          orderedMainPoints.length + 1 + idx,
+                        ).padStart(2, '0'),
+                      }}
+                      state={detailStates[p.slug]}
+                      isActive={p.slug === activePointSlug}
+                      isCounter
+                      onSelect={() => selectPoint(p.slug)}
+                    />
+                  </li>
                 ))}
               </ul>
             </>
@@ -1273,26 +1376,68 @@ function PointCard({
     (isActive ? ' editorial-po-point-card-active' : '') +
     (cardStale ? ' editorial-po-point-card-stale' : '');
   return (
-    <li>
-      <button type="button" className={className} onClick={onSelect}>
-        <div className="editorial-po-point-row">
-          <span className="editorial-po-point-position">{point.position}</span>
-          <span
-            className={`editorial-po-point-type editorial-po-point-type-${point.type.toLowerCase()}`}
-          >
-            {POINT_TYPE_LABEL[point.type]}
-          </span>
-          <span className="editorial-po-point-score">
-            {(state?.aggregate.score ?? point.score).toFixed(1)}
-          </span>
-        </div>
-        <p className="editorial-po-point-claim">{claim}</p>
-        {stake ? <p className="editorial-po-point-stake">{stake}</p> : null}
-        <span className="editorial-po-point-notes">
-          {state?.notes.length ?? point.noteCount} NOTES
-          {cardStale ? ' · STALE' : ''}
+    <button type="button" className={className} onClick={onSelect}>
+      <div className="editorial-po-point-row">
+        <span className="editorial-po-point-position">{point.position}</span>
+        <span
+          className={`editorial-po-point-type editorial-po-point-type-${point.type.toLowerCase()}`}
+        >
+          {POINT_TYPE_LABEL[point.type]}
         </span>
+        <span className="editorial-po-point-score">
+          {(state?.aggregate.score ?? point.score).toFixed(1)}
+        </span>
+      </div>
+      <p className="editorial-po-point-claim">{claim}</p>
+      {stake ? <p className="editorial-po-point-stake">{stake}</p> : null}
+      <span className="editorial-po-point-notes">
+        {state?.notes.length ?? point.noteCount} NOTES
+        {cardStale ? ' · STALE' : ''}
+      </span>
+    </button>
+  );
+}
+
+function SortablePointWrapper({
+  slug,
+  children,
+}: {
+  slug: string;
+  children: ReactNode;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: slug });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.45 : undefined,
+    zIndex: isDragging ? 5 : undefined,
+  };
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={
+        'editorial-po-point-li' +
+        (isDragging ? ' editorial-po-point-li-dragging' : '')
+      }
+    >
+      <button
+        {...attributes}
+        {...listeners}
+        type="button"
+        className="editorial-po-point-handle"
+        aria-label="Drag to reorder"
+      >
+        ⋮⋮
       </button>
+      {children}
     </li>
   );
 }

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -6327,6 +6327,58 @@ a.editorial-phase-pill:hover {
   background: #efe9d8;
 }
 
+/* ─── Drag-reorder for main Points (left rail) ─────────────────────────── */
+
+.editorial-po-point-li {
+  display: flex;
+  align-items: stretch;
+  gap: 0.25rem;
+}
+
+.editorial-po-point-li > .editorial-po-point-card {
+  flex: 1;
+  min-width: 0;
+}
+
+.editorial-po-point-handle {
+  flex-shrink: 0;
+  width: 16px;
+  border: 0;
+  background: transparent;
+  color: #b9b09c;
+  cursor: grab;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  line-height: 1;
+  letter-spacing: -0.05em;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.4;
+  transition: opacity 120ms ease;
+  border-radius: 3px;
+  touch-action: none;
+}
+
+.editorial-po-point-li:hover .editorial-po-point-handle {
+  opacity: 1;
+}
+
+.editorial-po-point-handle:hover {
+  color: #1f1c14;
+  background: #efe9d8;
+}
+
+.editorial-po-point-handle:active {
+  cursor: grabbing;
+}
+
+.editorial-po-point-li-dragging .editorial-po-point-card {
+  border-color: #1f1c14;
+  box-shadow: 0 4px 12px rgba(31, 28, 20, 0.18);
+}
+
 .editorial-po-note-timestamp {
   margin-left: auto;
   font-family: 'IBM Plex Mono', monospace;


### PR DESCRIPTION
## Summary
- The "DRAG TO REORDER" hint in the meta bar is now real
- Hover-revealed `⋮⋮` handle on the left edge of each main Point card; grab + drop to reorder
- Position numbers (`01`/`02`/…) recompute live from display index
- Order persists at `editorial-room.points-outline.points-order-v0`
- Counter-Points stay non-sortable in this slice (single-section drag was the tight cut)

## Mechanics

- `@dnd-kit/core` + `@dnd-kit/sortable` (already in webapp deps); main list wrapped in `DndContext` + `SortableContext` with `verticalListSortingStrategy`
- `PointerSensor` with `activationConstraint: { distance: 5 }` so a click on the card body still selects the Point — only ≥5px pointer movement triggers a drag
- Drag listeners attach to the handle button only, not the card body, so card click vs drag are unambiguous
- Position is computed at render time: main = `String(idx + 1).padStart(2,'0')`, counter = `String(mainCount + 1 + counterIdx).padStart(2,'0')`. The fixture's `position` field is overridden in JSX
- `loadPointsOrder` filters stored slugs to known fixture slugs and appends any missing fixture Points at the end (handles fixture growth)
- `PointCard` now returns just the `<button>`; the `<li>` moves to the caller (`SortablePointWrapper` for main points, plain `<li>` for the counter list)
- Dragging: card opacity 0.45 + heavier shadow; handle changes cursor to grabbing

## Deferred

- Counter-Point reorder (would extend the same pattern — separate `DndContext`)
- Active-Point eyebrow ("POINT 1 · HOOK · …") still reflects fixture position, not display position — cosmetic, addressing in a follow-up
- Filter-chip filtering, Outline tab content, proposal-chip revalidation

## Validation

- typecheck / build / test 172+1 / prettier / contract 99/99 all clean

## Test plan

- [ ] Visit `/editorial/points-outline`; hover a Point card → ⋮⋮ handle becomes visible at the left edge
- [ ] Click on the card body (not the handle) → still selects (no drag)
- [ ] Grab handle of Point 1, drop after Point 3 → list reorders, position numbers update to `01..05` reflecting the new order, the dragged card briefly shows opacity 0.45 + heavier shadow during drag
- [ ] Reload → reordered order preserved
- [ ] Edit a Point's CLAIM after reorder → the saved revision turn lands in the discussion of the right Point (slug-keyed, not position-keyed); STALE banner + RESCORE → still work
- [ ] Promote a counter note → new Counter-Point appears at the next counter position (e.g., `07` if `06` already taken)
- [ ] Counter list does not have drag handles (counter reorder is deferred)
- [ ] In DevTools clear `editorial-room.points-outline.points-order-v0`; reload → original fixture order restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)