### PR TITLE
feat: Outline tab content (filtered assembly view)

### DIFF
--- a/webapp/src/pages/PointsOutlineWorkspacePage.tsx
+++ b/webapp/src/pages/PointsOutlineWorkspacePage.tsx
@@ -124,7 +124,18 @@ type DetailState = {
   scoreRow: ScoreCell[];
   aggregate: { score: number; ssr: number; gatesPass: boolean };
   notes: Note[];
+  // Whether this Point is selected for the Outline. Optional for back-compat
+  // with v1-shaped storage; undefined defaults to true for main Points and
+  // false for counters (counters are argued against, never in the outline).
+  inOutline?: boolean;
 };
+
+// Outline target range — design/03_points_outline.md §13.6 says "5–7" is the
+// guide range for Points in the outline; the tab label shows current/range.
+const OUTLINE_TARGET_MIN = 5;
+const OUTLINE_TARGET_MAX = 7;
+
+type LeftRailTab = 'points' | 'outline';
 
 // State machine for adding a new note: `idle` → click `+` → `picking-type`
 // (filter chips become type-pickers) → click chip → `editing` (textarea
@@ -738,6 +749,27 @@ function saveLayoutState(s: LayoutState): void {
   }
 }
 
+const LEFT_RAIL_TAB_KEY = 'editorial-room.points-outline.left-rail-tab-v0';
+
+function loadLeftRailTab(): LeftRailTab {
+  if (typeof window === 'undefined') return 'points';
+  try {
+    const raw = window.localStorage.getItem(LEFT_RAIL_TAB_KEY);
+    return raw === 'outline' ? 'outline' : 'points';
+  } catch {
+    return 'points';
+  }
+}
+
+function saveLeftRailTab(t: LeftRailTab): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(LEFT_RAIL_TAB_KEY, t);
+  } catch {
+    // ignore
+  }
+}
+
 const ADDED_COUNTERS_KEY = 'editorial-room.points-outline.added-counters-v0';
 
 function isValidPoint(p: unknown): p is Point {
@@ -995,6 +1027,33 @@ export function PointsOutlineWorkspacePage(_props: Props) {
   function toggleLayout() {
     setLayoutState((s) => (s === 'a' ? 'b' : 'a'));
   }
+
+  const [leftRailTab, setLeftRailTab] = useState<LeftRailTab>(loadLeftRailTab);
+
+  useEffect(() => {
+    saveLeftRailTab(leftRailTab);
+  }, [leftRailTab]);
+
+  function isInOutline(slug: string, type: PointType): boolean {
+    if (type === 'COUNTER') return false;
+    const s = detailStates[slug];
+    return s?.inOutline ?? true;
+  }
+
+  function toggleInOutline(slug: string) {
+    setDetailStates((prev) => {
+      const cur = prev[slug];
+      if (!cur) return prev;
+      const current = cur.inOutline ?? true;
+      return { ...prev, [slug]: { ...cur, inOutline: !current } };
+    });
+  }
+
+  const outlinePoints = useMemo(
+    () => orderedMainPoints.filter((p) => isInOutline(p.slug, p.type)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [orderedMainPoints, detailStates],
+  );
 
   function selectPoint(slug: string) {
     if (editing && editing.slug !== slug) {
@@ -1307,15 +1366,33 @@ export function PointsOutlineWorkspacePage(_props: Props) {
           <div className="editorial-po-rail-tabs">
             <button
               type="button"
-              className="editorial-po-rail-tab editorial-po-rail-tab-active"
+              className={
+                'editorial-po-rail-tab' +
+                (leftRailTab === 'points'
+                  ? ' editorial-po-rail-tab-active'
+                  : '')
+              }
+              onClick={() => setLeftRailTab('points')}
             >
               Points{' '}
               <span className="editorial-po-rail-tab-count">
                 {allPoints.length}
               </span>
             </button>
-            <button type="button" className="editorial-po-rail-tab" disabled>
-              Outline <span className="editorial-po-rail-tab-count">5/5–7</span>
+            <button
+              type="button"
+              className={
+                'editorial-po-rail-tab' +
+                (leftRailTab === 'outline'
+                  ? ' editorial-po-rail-tab-active'
+                  : '')
+              }
+              onClick={() => setLeftRailTab('outline')}
+            >
+              Outline{' '}
+              <span className="editorial-po-rail-tab-count">
+                {outlinePoints.length}/{OUTLINE_TARGET_MIN}–{OUTLINE_TARGET_MAX}
+              </span>
             </button>
             <button
               type="button"
@@ -1333,69 +1410,117 @@ export function PointsOutlineWorkspacePage(_props: Props) {
             </button>
           </div>
 
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
-            onDragEnd={handlePointDragEnd}
-          >
-            <SortableContext
-              items={pointsOrder}
-              strategy={verticalListSortingStrategy}
-            >
-              <ul className="editorial-po-point-list">
-                {orderedMainPoints.map((p, idx) => (
-                  <SortablePointWrapper key={p.slug} slug={p.slug}>
-                    <PointCard
-                      point={{
-                        ...p,
-                        position: String(idx + 1).padStart(2, '0'),
-                      }}
-                      state={detailStates[p.slug]}
-                      isActive={p.slug === activePointSlug}
-                      onSelect={() => selectPoint(p.slug)}
-                    />
-                  </SortablePointWrapper>
-                ))}
-              </ul>
-            </SortableContext>
-          </DndContext>
-
-          {orderedCounters.length > 0 ? (
+          {leftRailTab === 'points' ? (
             <>
-              <h2 className="editorial-rail-heading editorial-rail-heading-spaced editorial-rail-heading-counter">
-                COUNTER-POINTS · {orderedCounters.length}
-              </h2>
               <DndContext
                 sensors={sensors}
                 collisionDetection={closestCenter}
-                onDragEnd={handleCounterDragEnd}
+                onDragEnd={handlePointDragEnd}
               >
                 <SortableContext
-                  items={counterOrder}
+                  items={pointsOrder}
                   strategy={verticalListSortingStrategy}
                 >
                   <ul className="editorial-po-point-list">
-                    {orderedCounters.map((p, idx) => (
+                    {orderedMainPoints.map((p, idx) => (
                       <SortablePointWrapper key={p.slug} slug={p.slug}>
                         <PointCard
                           point={{
                             ...p,
-                            position: String(
-                              orderedMainPoints.length + 1 + idx,
-                            ).padStart(2, '0'),
+                            position: String(idx + 1).padStart(2, '0'),
                           }}
                           state={detailStates[p.slug]}
                           isActive={p.slug === activePointSlug}
-                          isCounter
                           onSelect={() => selectPoint(p.slug)}
+                          inOutline={isInOutline(p.slug, p.type)}
+                          onToggleOutline={() => toggleInOutline(p.slug)}
                         />
                       </SortablePointWrapper>
                     ))}
                   </ul>
                 </SortableContext>
               </DndContext>
+
+              {orderedCounters.length > 0 ? (
+                <>
+                  <h2 className="editorial-rail-heading editorial-rail-heading-spaced editorial-rail-heading-counter">
+                    COUNTER-POINTS · {orderedCounters.length}
+                  </h2>
+                  <DndContext
+                    sensors={sensors}
+                    collisionDetection={closestCenter}
+                    onDragEnd={handleCounterDragEnd}
+                  >
+                    <SortableContext
+                      items={counterOrder}
+                      strategy={verticalListSortingStrategy}
+                    >
+                      <ul className="editorial-po-point-list">
+                        {orderedCounters.map((p, idx) => (
+                          <SortablePointWrapper key={p.slug} slug={p.slug}>
+                            <PointCard
+                              point={{
+                                ...p,
+                                position: String(
+                                  orderedMainPoints.length + 1 + idx,
+                                ).padStart(2, '0'),
+                              }}
+                              state={detailStates[p.slug]}
+                              isActive={p.slug === activePointSlug}
+                              isCounter
+                              onSelect={() => selectPoint(p.slug)}
+                            />
+                          </SortablePointWrapper>
+                        ))}
+                      </ul>
+                    </SortableContext>
+                  </DndContext>
+                </>
+              ) : null}
             </>
-          ) : null}
+          ) : (
+            // Outline tab: filtered, non-sortable list of inOutline main
+            // Points only. Drag-reorder happens in Points tab; Outline
+            // reflects that order.
+            <>
+              {outlinePoints.length === 0 ? (
+                <p className="editorial-tt-empty">
+                  No Points in the Outline yet — add some from the Points tab.
+                </p>
+              ) : (
+                <ul className="editorial-po-point-list">
+                  {outlinePoints.map((p) => {
+                    const idx = orderedMainPoints.findIndex(
+                      (m) => m.slug === p.slug,
+                    );
+                    return (
+                      <li key={p.slug} className="editorial-po-point-li">
+                        <PointCard
+                          point={{
+                            ...p,
+                            position: String(idx + 1).padStart(2, '0'),
+                          }}
+                          state={detailStates[p.slug]}
+                          isActive={p.slug === activePointSlug}
+                          onSelect={() => selectPoint(p.slug)}
+                          inOutline
+                          onToggleOutline={() => toggleInOutline(p.slug)}
+                        />
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+              <p className="editorial-po-outline-hint">
+                Target {OUTLINE_TARGET_MIN}–{OUTLINE_TARGET_MAX} Points.{' '}
+                {outlinePoints.length < OUTLINE_TARGET_MIN
+                  ? `Add ${OUTLINE_TARGET_MIN - outlinePoints.length} more.`
+                  : outlinePoints.length > OUTLINE_TARGET_MAX
+                    ? `${outlinePoints.length - OUTLINE_TARGET_MAX} over target.`
+                    : 'On target.'}
+              </p>
+            </>
+          )}
         </aside>
 
         {/* CENTER — ACTIVE POINT DETAIL + PANEL DISCUSSION */}
@@ -1442,12 +1567,16 @@ function PointCard({
   isActive,
   isCounter,
   onSelect,
+  inOutline,
+  onToggleOutline,
 }: {
   point: Point;
   state: DetailState | undefined;
   isActive: boolean;
   isCounter?: boolean;
   onSelect: () => void;
+  inOutline?: boolean;
+  onToggleOutline?: () => void;
 }) {
   const claim = state?.claim ?? point.claim;
   const stake = state?.stake ?? point.stake;
@@ -1472,10 +1601,38 @@ function PointCard({
       </div>
       <p className="editorial-po-point-claim">{claim}</p>
       {stake ? <p className="editorial-po-point-stake">{stake}</p> : null}
-      <span className="editorial-po-point-notes">
-        {state?.notes.length ?? point.noteCount} NOTES
-        {cardStale ? ' · STALE' : ''}
-      </span>
+      <div className="editorial-po-point-footer">
+        <span className="editorial-po-point-notes">
+          {state?.notes.length ?? point.noteCount} NOTES
+          {cardStale ? ' · STALE' : ''}
+        </span>
+        {!isCounter && onToggleOutline ? (
+          <span
+            role="button"
+            tabIndex={0}
+            className={
+              'editorial-po-point-outline-toggle' +
+              (inOutline
+                ? ' editorial-po-point-outline-toggle-in'
+                : ' editorial-po-point-outline-toggle-out')
+            }
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleOutline();
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                onToggleOutline();
+              }
+            }}
+            aria-label={inOutline ? 'Remove from outline' : 'Add to outline'}
+          >
+            {inOutline ? '✓ IN' : '+ ADD'}
+          </span>
+        ) : null}
+      </div>
     </button>
   );
 }

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -6379,6 +6379,65 @@ a.editorial-phase-pill:hover {
   box-shadow: 0 4px 12px rgba(31, 28, 20, 0.18);
 }
 
+/* ─── Outline tab — in-outline toggle + assembly view ─────────────────── */
+
+.editorial-po-point-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 0.1rem;
+  gap: 0.4rem;
+}
+
+.editorial-po-point-outline-toggle {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.04rem 0.35rem;
+  border-radius: 3px;
+  cursor: pointer;
+  user-select: none;
+  border: 1px solid transparent;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
+}
+
+.editorial-po-point-outline-toggle-in {
+  color: #2e7d62;
+  border-color: #2e7d62;
+}
+
+.editorial-po-point-outline-toggle-in:hover {
+  background: #2e7d62;
+  color: #fff;
+}
+
+.editorial-po-point-outline-toggle-out {
+  color: #8a8268;
+  border-color: #c9c0a8;
+}
+
+.editorial-po-point-outline-toggle-out:hover {
+  border-color: #1f1c14;
+  color: #1f1c14;
+  background: #efe9d8;
+}
+
+.editorial-po-outline-hint {
+  margin-top: 0.6rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6c6655;
+  padding: 0.3rem 0.4rem;
+  border-top: 1px dashed #ddd6c8;
+  text-align: center;
+}
+
 .editorial-po-note-timestamp {
   margin-left: auto;
   font-family: 'IBM Plex Mono', monospace;


### PR DESCRIPTION
## Summary
- Both left-rail tabs are now functional: **Points** (everything, sortable) and **Outline** (filtered to main Points selected for the outline)
- Each main-Point card has a small `+ ADD` / `✓ IN` chip in the footer that toggles outline membership; counters never have the chip (they're argued against, not part of the structure)
- Outline tab shows a target hint at the bottom: "Target 5–7 Points · On target." / "Add N more." / "N over target."
- Tab choice persists across reload

## Mechanics

- `DetailState.inOutline?: boolean` — optional for v1 storage compat; undefined defaults to `true` for main, `false` for counters via `isInOutline(slug, type)`
- Tab persisted at `editorial-room.points-outline.left-rail-tab-v0`
- Outline tab is read-mostly: filtered subset, non-sortable. Drag-reorder still happens in Points tab; Outline reflects that order
- Toggle chip stops propagation so clicking it doesn't also fire card-select; Enter/Space keyboard activation also guarded
- Target range 5–7 per `docs/design/03_points_outline.md` §13.6; hint adapts to count

## Deferred

- Drag-reorder inside the Outline tab
- Filter-chip filtering of notes
- Proposal-chip revalidation

## Validation

- typecheck / build / test 172+1 / prettier / contract 99/99 — all green

## Test plan

- [ ] Visit `/editorial/points-outline`; Points tab shows 5 main + 1 counter; tab labels read `Points 6` and `Outline 5/5–7`
- [ ] Hover footer of any main-Point card → `✓ IN` chip is green; click → toggles to grey `+ ADD`; Outline tab count drops to `4/5–7`
- [ ] Click Outline tab → only main Points with `✓ IN` show; bottom hint says "Add 1 more." after one removal; "On target." at 5–7; "N over target." over 7
- [ ] Reload → tab choice + outline membership preserved per Point
- [ ] Promote a counter note to a Counter-Point → switches active to the new Counter; in Points tab it appears in COUNTER-POINTS section without an outline chip; switching to Outline tab does not show it

🤖 Generated with [Claude Code](https://claude.com/claude-code)