### PR TITLE
feat: Phase 04 DRAFT — three-column shell + Tiptap editor (first cut)

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -11,6 +11,9 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@tiptap/pm": "^2.27.2",
+        "@tiptap/react": "^2.27.2",
+        "@tiptap/starter-kit": "^2.27.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.28.0"
@@ -1143,6 +1146,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remirror/core-constants": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
+      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
+      "license": "MIT"
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -1606,6 +1625,391 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tiptap/core": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.27.2.tgz",
+      "integrity": "sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-2.27.2.tgz",
+      "integrity": "sha512-oIGZgiAeA4tG3YxbTDfrmENL4/CIwGuP3THtHsNhwRqwsl9SfMk58Ucopi2GXTQSdYXpRJ0ahE6nPqB5D6j/Zw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-2.27.2.tgz",
+      "integrity": "sha512-bR7J5IwjCGQ0s3CIxyMvOCnMFMzIvsc5OVZKscTN5UkXzFsaY6muUAIqtKxayBUucjtUskm5qZowJITCeCb1/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.27.2.tgz",
+      "integrity": "sha512-VkwlCOcr0abTBGzjPXklJ92FCowG7InU8+Od9FyApdLNmn0utRYGRhw0Zno6VgE9EYr1JY4BRnuSa5f9wlR72w==",
+      "license": "MIT",
+      "dependencies": {
+        "tippy.js": "^6.3.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-2.27.2.tgz",
+      "integrity": "sha512-gmFuKi97u5f8uFc/GQs+zmezjiulZmFiDYTh3trVoLRoc2SAHOjGEB7qxdx7dsqmMN7gwiAWAEVurLKIi1lnnw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-2.27.2.tgz",
+      "integrity": "sha512-7X9AgwqiIGXoZX7uvdHQsGsjILnN/JaEVtqfXZnPECzKGaWHeK/Ao4sYvIIIffsyZJA8k5DC7ny2/0sAgr2TuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.27.2.tgz",
+      "integrity": "sha512-KgvdQHS4jXr79aU3wZOGBIZYYl9vCB7uDEuRFV4so2rYrfmiYMw3T8bTnlNEEGe4RUeAms1i4fdwwvQp9nR1Dw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-2.27.2.tgz",
+      "integrity": "sha512-CFhAYsPnyYnosDC4639sCJnBUnYH4Cat9qH5NZWHVvdgtDwu8GZgZn2eSzaKSYXWH1vJ9DSlCK+7UyC3SNXIBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-2.27.2.tgz",
+      "integrity": "sha512-oEu/OrktNoQXq1x29NnH/GOIzQZm8ieTQl3FK27nxfBPA89cNoH4mFEUmBL5/OFIENIjiYG3qWpg6voIqzswNw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.27.2.tgz",
+      "integrity": "sha512-GUN6gPIGXS7ngRJOwdSmtBRBDt9Kt9CM/9pSwKebhLJ+honFoNA+Y6IpVyDvvDMdVNgBchiJLs6qA5H97gAePQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tippy.js": "^6.3.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-2.27.2.tgz",
+      "integrity": "sha512-/c9VF1HBxj+AP54XGVgCmD9bEGYc5w5OofYCFQgM7l7PB1J00A4vOke0oPkHJnqnOOyPlFaxO/7N6l3XwFcnKA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.27.2.tgz",
+      "integrity": "sha512-kSRVGKlCYK6AGR0h8xRkk0WOFGXHIIndod3GKgWU49APuIGDiXd8sziXsSlniUsWmqgDmDXcNnSzPcV7AQ8YNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-2.27.2.tgz",
+      "integrity": "sha512-iM3yeRWuuQR/IRQ1djwNooJGfn9Jts9zF43qZIUf+U2NY8IlvdNsk2wTOdBgh6E0CamrStPxYGuln3ZS4fuglw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-history": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-history/-/extension-history-2.27.2.tgz",
+      "integrity": "sha512-+hSyqERoFNTWPiZx4/FCyZ/0eFqB9fuMdTB4AC/q9iwu3RNWAQtlsJg5230bf/qmyO6bZxRUc0k8p4hrV6ybAw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-2.27.2.tgz",
+      "integrity": "sha512-WGWUSgX+jCsbtf9Y9OCUUgRZYuwjVoieW5n6mAUohJ9/6gc6sGIOrUpBShf+HHo6WD+gtQjRd+PssmX3NPWMpg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-2.27.2.tgz",
+      "integrity": "sha512-1OFsw2SZqfaqx5Fa5v90iNlPRcqyt+lVSjBwTDzuPxTPFY4Q0mL89mKgkq2gVHYNCiaRkXvFLDxaSvBWbmthgg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-2.27.2.tgz",
+      "integrity": "sha512-eJNee7IEGXMnmygM5SdMGDC8m/lMWmwNGf9fPCK6xk0NxuQRgmZHL6uApKcdH6gyNcRPHCqvTTkhEP7pbny/fg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-2.27.2.tgz",
+      "integrity": "sha512-M7A4tLGJcLPYdLC4CI2Gwl8LOrENQW59u3cMVa+KkwG1hzSJyPsbDpa1DI6oXPC2WtYiTf22zrbq3gVvH+KA2w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.27.2.tgz",
+      "integrity": "sha512-elYVn2wHJJ+zB9LESENWOAfI4TNT0jqEN34sMA/hCtA4im1ZG2DdLHwkHIshj/c4H0dzQhmsS/YmNC5Vbqab/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-2.27.2.tgz",
+      "integrity": "sha512-HHIjhafLhS2lHgfAsCwC1okqMsQzR4/mkGDm4M583Yftyjri1TNA7lzhzXWRFWiiMfJxKtdjHjUAQaHuteRTZw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.27.2.tgz",
+      "integrity": "sha512-Xk7nYcigljAY0GO9hAQpZ65ZCxqOqaAlTPDFcKerXmlkQZP/8ndx95OgUb1Xf63kmPOh3xypurGS2is3v0MXSA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-text-style": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.27.2.tgz",
+      "integrity": "sha512-Omk+uxjJLyEY69KStpCw5fA9asvV+MGcAX2HOxyISDFoLaL49TMrNjhGAuz09P1L1b0KGXo4ml7Q3v/Lfy4WPA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.27.2.tgz",
+      "integrity": "sha512-kaEg7BfiJPDQMKbjVIzEPO3wlcA+pZb2tlcK9gPrdDnEFaec2QTF1sXz2ak2IIb2curvnIrQ4yrfHgLlVA72wA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-collab": "^1.3.1",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-markdown": "^1.13.1",
+        "prosemirror-menu": "^1.2.4",
+        "prosemirror-model": "^1.23.0",
+        "prosemirror-schema-basic": "^1.2.3",
+        "prosemirror-schema-list": "^1.4.1",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-trailing-node": "^3.0.0",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.37.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-2.27.2.tgz",
+      "integrity": "sha512-0EAs8Cpkfbvben1PZ34JN2Nd79Dhioynm2jML27DBbf1VWPk+FFWFGTMLUT0bu+Np5iVxio8fqV9t0mc4D6thA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/extension-bubble-menu": "^2.27.2",
+        "@tiptap/extension-floating-menu": "^2.27.2",
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-deep-equal": "^3",
+        "use-sync-external-store": "^1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-2.27.2.tgz",
+      "integrity": "sha512-bb0gJvPoDuyRUQ/iuN52j1//EtWWttw+RXAv1uJxfR0uKf8X7uAqzaOOgwjknoCIDC97+1YHwpGdnRjpDkOBxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^2.27.2",
+        "@tiptap/extension-blockquote": "^2.27.2",
+        "@tiptap/extension-bold": "^2.27.2",
+        "@tiptap/extension-bullet-list": "^2.27.2",
+        "@tiptap/extension-code": "^2.27.2",
+        "@tiptap/extension-code-block": "^2.27.2",
+        "@tiptap/extension-document": "^2.27.2",
+        "@tiptap/extension-dropcursor": "^2.27.2",
+        "@tiptap/extension-gapcursor": "^2.27.2",
+        "@tiptap/extension-hard-break": "^2.27.2",
+        "@tiptap/extension-heading": "^2.27.2",
+        "@tiptap/extension-history": "^2.27.2",
+        "@tiptap/extension-horizontal-rule": "^2.27.2",
+        "@tiptap/extension-italic": "^2.27.2",
+        "@tiptap/extension-list-item": "^2.27.2",
+        "@tiptap/extension-ordered-list": "^2.27.2",
+        "@tiptap/extension-paragraph": "^2.27.2",
+        "@tiptap/extension-strike": "^2.27.2",
+        "@tiptap/extension-text": "^2.27.2",
+        "@tiptap/extension-text-style": "^2.27.2",
+        "@tiptap/pm": "^2.27.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -1684,6 +2088,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1717,6 +2143,12 @@
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1857,6 +2289,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -2089,6 +2527,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -2342,6 +2786,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2361,6 +2817,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2714,6 +3176,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2757,6 +3228,35 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2766,6 +3266,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -2939,6 +3445,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
     "node_modules/outvariant": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
@@ -3038,11 +3550,215 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-collab": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
+      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
+      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-menu": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.2.tgz",
+      "integrity": "sha512-6VgUJTYod0nMBlCaYJGhXGLu7Gt4AvcwcOq0YfJCY/6Uh+3S7UsWhpy6rJFCBFOmonq1hD8KyWOtZhkppd4YPg==",
+      "license": "MIT",
+      "dependencies": {
+        "crelt": "^1.0.0",
+        "prosemirror-commands": "^1.0.0",
+        "prosemirror-history": "^1.0.0",
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-basic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
+      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-trailing-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
+      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remirror/core-constants": "3.0.0",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3198,6 +3914,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
     },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
@@ -3411,6 +4133,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.9.0"
+      }
+    },
     "node_modules/tldts": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
@@ -3493,6 +4224,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/until-async": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
@@ -3532,6 +4269,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {
@@ -3713,6 +4459,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -15,6 +15,9 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@tiptap/pm": "^2.27.2",
+    "@tiptap/react": "^2.27.2",
+    "@tiptap/starter-kit": "^2.27.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0"

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -31,6 +31,7 @@ import {
 } from './lib/api';
 import { AiAgentsPage } from './pages/AiAgentsPage';
 import { DataConnectorsPage } from './pages/DataConnectorsPage';
+import { DraftWorkspacePage } from './pages/DraftWorkspacePage';
 import { EditorialSetupPage } from './pages/EditorialSetupPage';
 import { PointsOutlineWorkspacePage } from './pages/PointsOutlineWorkspacePage';
 import { ThemeTopicsWorkspacePage } from './pages/ThemeTopicsWorkspacePage';
@@ -701,6 +702,10 @@ export function App() {
           element={
             <PointsOutlineWorkspacePage onUnauthorized={handleUnauthorized} />
           }
+        />
+        <Route
+          path="/editorial/draft"
+          element={<DraftWorkspacePage onUnauthorized={handleUnauthorized} />}
         />
         <Route
           path="/editorial/*"

--- a/webapp/src/components/EditorialPhaseStrip.tsx
+++ b/webapp/src/components/EditorialPhaseStrip.tsx
@@ -26,7 +26,7 @@ const PHASES: ReadonlyArray<Phase> = [
     label: '03 POINTS + OUTLINE',
     path: '/editorial/points-outline',
   },
-  { id: 'draft', label: '04 DRAFT', path: null },
+  { id: 'draft', label: '04 DRAFT', path: '/editorial/draft' },
   { id: 'polish', label: '05 POLISH', path: null },
   { id: 'ship', label: '06 SHIP', path: null },
 ];

--- a/webapp/src/pages/DraftWorkspacePage.tsx
+++ b/webapp/src/pages/DraftWorkspacePage.tsx
@@ -1,0 +1,463 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEditor, EditorContent, type Content } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+
+import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
+
+// ───────────────────────────────────────────────────────────────────────────
+// Phase 04 DRAFT — first cut.
+// Three-column shell + a basic Tiptap editor (StarterKit only). The Outline
+// rail (left) reads the same localStorage written by the Points + Outline
+// workspace, so the user's claims/stakes show up here automatically. Editor
+// content autosaves to its own localStorage key; word count and a fake
+// "LAST AUTOSAVE" timestamp render in the sub-meta bar.
+//
+// Deferred to follow-up PRs (per kickoff item 17 + design/04_draft.md):
+// - Tabs in left rail (Outline / Sources / Versions); right now only Outline
+// - Per-segment scoring inside the editor
+// - Active segment selection + Panel chat scoped to it (right rail is a
+//   placeholder card for now)
+// - Top action toolbar's quick chips (FULL DRAFT / POLISH / EXPAND / →
+//   CONTINUE / ? MISSING) — rendered but disabled
+// - + OPTIMIZE popover with cost preview + customize panel + run
+// - Voice-lock banner, mechanical scorer, suggestion overlay, source-map
+// - Markdown export (Substack/Google Doc), revision history
+// - Tiptap → Markdown round-trip + canonical subset (0p-b1 spike)
+//
+// NOTE on the Outline-rail data source: the Points workspace owns its
+// state in its own localStorage envelope. To avoid threading a shared
+// module, we read the same keys directly and reconstruct the section
+// grouping inline. The fixture-only fallback for slugs without an
+// explicit `pointType` override is hardcoded below — the same five
+// fixture slugs as in PointsOutlineWorkspacePage.tsx. When the fixture
+// grows or both pages move to a real backend, factor this into a shared
+// module.
+// ───────────────────────────────────────────────────────────────────────────
+
+type PointType = 'HOOK' | 'ARG' | 'CLOSE' | 'COUNTER';
+
+type OutlineSection = 'HOOK' | 'BODY' | 'CLOSE';
+
+type OutlineEntry = {
+  slug: string;
+  type: 'HOOK' | 'ARG' | 'CLOSE';
+  claim: string;
+  stake: string;
+  score: number;
+  stale: boolean;
+};
+
+type OutlineGroups = Record<OutlineSection, OutlineEntry[]>;
+
+const SECTION_ORDER: ReadonlyArray<OutlineSection> = ['HOOK', 'BODY', 'CLOSE'];
+
+const SECTION_LABEL: Record<OutlineSection, string> = {
+  HOOK: 'HOOK',
+  BODY: 'BODY',
+  CLOSE: 'CLOSE',
+};
+
+const POINTS_DETAIL_STATES_KEY =
+  'editorial-room.points-outline.detail-states-v1';
+const POINTS_ORDER_KEY = 'editorial-room.points-outline.points-order-v0';
+const DRAFT_CONTENT_KEY = 'editorial-room.draft.content-v0';
+
+const FIXTURE_POINT_TYPES: Record<string, 'HOOK' | 'ARG' | 'CLOSE'> = {
+  'p1-deal-term-lockdown': 'HOOK',
+  'p2-mg-conditional-liability': 'ARG',
+  'p3-cohort-split': 'ARG',
+  'p4-eighteen-month-lockin': 'ARG',
+  'p5-recoupment-creep': 'CLOSE',
+};
+
+const FIXTURE_POINT_DEFAULTS: Record<
+  string,
+  { claim: string; stake: string; score: number }
+> = {
+  'p1-deal-term-lockdown': {
+    claim:
+      'Deal-term lockdown: 2022-rate MGs are now the ceiling, not the floor.',
+    stake: 'Hook — open with reclassification.',
+    score: 8.1,
+  },
+  'p2-mg-conditional-liability': {
+    claim: 'MG-as-conditional-liability is the load-bearing accounting change.',
+    stake: 'The accounting that holds the lockdown in place.',
+    score: 7.6,
+  },
+  'p3-cohort-split': {
+    claim: 'Mid-tier studios pay; sub-10-person studios get a tailwind.',
+    stake: 'Stakes paragraph — name the cohort split.',
+    score: 7.2,
+  },
+  'p4-eighteen-month-lockin': {
+    claim: 'The 18-month lock-in is structural, not cyclical.',
+    stake: 'Counter the cyclical read.',
+    score: 6.8,
+  },
+  'p5-recoupment-creep': {
+    claim: 'Recoupment-rate creep is the next shoe to drop.',
+    stake: 'Forward-looking close.',
+    score: 6.2,
+  },
+};
+
+const FIXTURE_SLUGS_IN_ORDER: ReadonlyArray<string> = [
+  'p1-deal-term-lockdown',
+  'p2-mg-conditional-liability',
+  'p3-cohort-split',
+  'p4-eighteen-month-lockin',
+  'p5-recoupment-creep',
+];
+
+function pointTypeToSection(t: PointType): OutlineSection | null {
+  if (t === 'HOOK') return 'HOOK';
+  if (t === 'ARG') return 'BODY';
+  if (t === 'CLOSE') return 'CLOSE';
+  return null;
+}
+
+function loadOutlineGroups(): OutlineGroups {
+  const groups: OutlineGroups = { HOOK: [], BODY: [], CLOSE: [] };
+  if (typeof window === 'undefined') {
+    // SSR fallback — seed from fixture so the rail isn't empty.
+    for (const slug of FIXTURE_SLUGS_IN_ORDER) {
+      const t = FIXTURE_POINT_TYPES[slug];
+      const def = FIXTURE_POINT_DEFAULTS[slug];
+      const sec = pointTypeToSection(t);
+      if (sec) {
+        groups[sec].push({
+          slug,
+          type: t,
+          claim: def.claim,
+          stake: def.stake,
+          score: def.score,
+          stale: false,
+        });
+      }
+    }
+    return groups;
+  }
+  let order: string[] = [];
+  let states: Record<string, unknown> = {};
+  try {
+    const orderRaw = window.localStorage.getItem(POINTS_ORDER_KEY);
+    if (orderRaw) {
+      const parsed = JSON.parse(orderRaw);
+      if (Array.isArray(parsed)) {
+        order = parsed.filter((s): s is string => typeof s === 'string');
+      }
+    }
+  } catch {
+    // ignore
+  }
+  if (order.length === 0) {
+    order = [...FIXTURE_SLUGS_IN_ORDER];
+  }
+  try {
+    const statesRaw = window.localStorage.getItem(POINTS_DETAIL_STATES_KEY);
+    if (statesRaw) {
+      const parsed = JSON.parse(statesRaw);
+      if (parsed && typeof parsed === 'object') {
+        const obj = (parsed as { states?: unknown }).states;
+        if (obj && typeof obj === 'object') {
+          states = obj as Record<string, unknown>;
+        }
+      }
+    }
+  } catch {
+    // ignore
+  }
+  for (const slug of order) {
+    if (!FIXTURE_POINT_TYPES[slug]) continue;
+    const stored = states[slug] as Record<string, unknown> | undefined;
+    const inOutline =
+      stored && typeof stored.inOutline === 'boolean' ? stored.inOutline : true;
+    if (!inOutline) continue;
+    const overrideType = stored?.pointType as PointType | undefined;
+    const fixtureType = FIXTURE_POINT_TYPES[slug];
+    const effective: PointType = overrideType ?? fixtureType;
+    if (effective === 'COUNTER') continue;
+    const sec = pointTypeToSection(effective);
+    if (!sec) continue;
+    const def = FIXTURE_POINT_DEFAULTS[slug];
+    const claim = (stored?.claim as string | undefined) ?? def.claim;
+    const stake = (stored?.stake as string | undefined) ?? def.stake;
+    const aggregate = stored?.aggregate as { score?: unknown } | undefined;
+    const score =
+      typeof aggregate?.score === 'number' ? aggregate.score : def.score;
+    const stale = stored && stored.stale === true ? true : false;
+    groups[sec].push({
+      slug,
+      type: effective === 'ARG' ? 'ARG' : effective,
+      claim,
+      stake,
+      score,
+      stale,
+    });
+  }
+  return groups;
+}
+
+const DEFAULT_DRAFT_CONTENT = {
+  type: 'doc',
+  content: [
+    {
+      type: 'heading',
+      attrs: { level: 1 },
+      content: [
+        {
+          type: 'text',
+          text: "How Embracer's $2.1B writedown changed indie publishing terms",
+        },
+      ],
+    },
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'Start drafting from your Outline on the left. Markdown shortcuts work: ⌘B bold, ⌘I italic, ## heading, * bullet, ` code.',
+        },
+      ],
+    },
+  ],
+};
+
+function loadDraftContent(): Content {
+  if (typeof window === 'undefined') return DEFAULT_DRAFT_CONTENT as Content;
+  try {
+    const raw = window.localStorage.getItem(DRAFT_CONTENT_KEY);
+    if (!raw) return DEFAULT_DRAFT_CONTENT as Content;
+    const parsed = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      (parsed as { type?: unknown }).type === 'doc'
+    ) {
+      return parsed as Content;
+    }
+    return DEFAULT_DRAFT_CONTENT as Content;
+  } catch {
+    return DEFAULT_DRAFT_CONTENT as Content;
+  }
+}
+
+function saveDraftContent(content: unknown): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(DRAFT_CONTENT_KEY, JSON.stringify(content));
+  } catch {
+    // ignore
+  }
+}
+
+function formatHHMM(d: Date): string {
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
+function countWords(text: string): number {
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).filter(Boolean).length;
+}
+
+const WORD_TARGET_MIN = 1200;
+const WORD_TARGET_MAX = 1400;
+
+type Props = {
+  onUnauthorized?: () => void;
+};
+
+export function DraftWorkspacePage(_props: Props) {
+  // Outline data is read once on mount. Switching to Points and back
+  // refreshes via a remount. Live updates are deferred.
+  const [outlineGroups] = useState<OutlineGroups>(loadOutlineGroups);
+  const [wordCount, setWordCount] = useState<number>(0);
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+  const saveTimerRef = useRef<number | null>(null);
+
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content: loadDraftContent(),
+    onCreate: ({ editor }) => {
+      setWordCount(countWords(editor.state.doc.textContent));
+    },
+    onUpdate: ({ editor }) => {
+      setWordCount(countWords(editor.state.doc.textContent));
+      // Debounced save
+      if (saveTimerRef.current !== null) {
+        window.clearTimeout(saveTimerRef.current);
+      }
+      saveTimerRef.current = window.setTimeout(() => {
+        saveDraftContent(editor.getJSON());
+        setLastSavedAt(new Date());
+        saveTimerRef.current = null;
+      }, 500);
+    },
+  });
+
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current !== null) {
+        window.clearTimeout(saveTimerRef.current);
+      }
+    };
+  }, []);
+
+  const totalOutlinePoints = useMemo(
+    () =>
+      outlineGroups.HOOK.length +
+      outlineGroups.BODY.length +
+      outlineGroups.CLOSE.length,
+    [outlineGroups],
+  );
+
+  const wordTargetStatus = (() => {
+    if (wordCount < WORD_TARGET_MIN) return 'editorial-po-draft-words-under';
+    if (wordCount > WORD_TARGET_MAX) return 'editorial-po-draft-words-over';
+    return 'editorial-po-draft-words-on';
+  })();
+
+  return (
+    <div className="editorial-room">
+      <EditorialPhaseStrip activePhase="draft" />
+
+      <div className="editorial-po-draft-meta">
+        <span className={`editorial-po-draft-words ${wordTargetStatus}`}>
+          {wordCount.toLocaleString()} / {WORD_TARGET_MIN.toLocaleString()}–
+          {WORD_TARGET_MAX.toLocaleString()} WORDS
+        </span>
+        <span className="editorial-po-meta-sep">·</span>
+        <span className="editorial-po-draft-autosave">
+          {lastSavedAt
+            ? `LAST AUTOSAVE ${formatHHMM(lastSavedAt)}`
+            : 'NO CHANGES SINCE LOAD'}
+        </span>
+      </div>
+
+      <div className="editorial-po-draft-toolbar">
+        <button type="button" className="editorial-chip-button" disabled>
+          FULL DRAFT ⌘D
+        </button>
+        <button type="button" className="editorial-chip-button" disabled>
+          POLISH ⌘P
+        </button>
+        <button type="button" className="editorial-chip-button" disabled>
+          EXPAND ⌘E
+        </button>
+        <button type="button" className="editorial-chip-button" disabled>
+          → CONTINUE ⌘\
+        </button>
+        <button type="button" className="editorial-chip-button" disabled>
+          ? MISSING ⌘M
+        </button>
+        <span className="editorial-po-draft-toolbar-sep">┃</span>
+        <button
+          type="button"
+          className="editorial-chip-button editorial-chip-button-primary"
+          disabled
+        >
+          + OPTIMIZE ⌘O
+        </button>
+        <span className="editorial-po-draft-scope">SCOPE: WHOLE DRAFT</span>
+      </div>
+
+      <div className="editorial-po-draft-grid">
+        {/* LEFT RAIL — OUTLINE */}
+        <aside className="editorial-po-draft-rail">
+          <div className="editorial-po-rail-tabs">
+            <button
+              type="button"
+              className="editorial-po-rail-tab editorial-po-rail-tab-active"
+            >
+              Outline{' '}
+              <span className="editorial-po-rail-tab-count">
+                {totalOutlinePoints}/5–7
+              </span>
+            </button>
+            <button type="button" className="editorial-po-rail-tab" disabled>
+              Sources <span className="editorial-po-rail-tab-count">—</span>
+            </button>
+            <button type="button" className="editorial-po-rail-tab" disabled>
+              Versions <span className="editorial-po-rail-tab-count">—</span>
+            </button>
+          </div>
+
+          {totalOutlinePoints === 0 ? (
+            <p className="editorial-tt-empty">
+              No Points in the Outline yet. Visit{' '}
+              <a href="/editorial/points-outline">03 POINTS + OUTLINE</a> to add
+              some.
+            </p>
+          ) : (
+            (() => {
+              let runningPos = 0;
+              return SECTION_ORDER.map((section) => {
+                const points = outlineGroups[section];
+                const startPos = runningPos + 1;
+                runningPos += points.length;
+                if (points.length === 0) return null;
+                return (
+                  <section key={section} className="editorial-po-draft-section">
+                    <h3 className="editorial-po-outline-section-header">
+                      <span className="editorial-po-outline-section-label">
+                        {SECTION_LABEL[section]}
+                      </span>
+                      <span className="editorial-po-outline-section-count">
+                        {points.length}
+                      </span>
+                    </h3>
+                    <ul className="editorial-po-draft-outline-list">
+                      {points.map((p, idx) => (
+                        <li
+                          key={p.slug}
+                          className="editorial-po-draft-outline-item"
+                        >
+                          <div className="editorial-po-draft-outline-row">
+                            <span className="editorial-po-point-position">
+                              {String(startPos + idx).padStart(2, '0')}
+                            </span>
+                            <span
+                              className={`editorial-po-point-type editorial-po-point-type-${p.type.toLowerCase()}`}
+                            >
+                              {p.type === 'ARG' ? 'ARGUMENT' : p.type}
+                            </span>
+                            <span className="editorial-po-point-score">
+                              {p.score.toFixed(1)}
+                              {p.stale ? '·' : ''}
+                            </span>
+                          </div>
+                          <p className="editorial-po-draft-outline-claim">
+                            {p.claim}
+                          </p>
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                );
+              });
+            })()
+          )}
+        </aside>
+
+        {/* CENTER — TIPTAP EDITOR */}
+        <main className="editorial-po-draft-center">
+          <div className="editorial-po-draft-editor">
+            <EditorContent editor={editor} />
+          </div>
+        </main>
+
+        {/* RIGHT RAIL — PANEL CHAT (placeholder) */}
+        <aside className="editorial-po-draft-panel">
+          <h2 className="editorial-rail-heading">PANEL CHAT</h2>
+          <p className="editorial-tt-empty">
+            Panel chat scoped to the active draft segment lands in a follow-up
+            PR. Use 03 POINTS + OUTLINE to discuss a Point with the panel for
+            now.
+          </p>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -6517,6 +6517,242 @@ a.editorial-phase-pill:hover {
   background: #fdf3df;
 }
 
+/* ─── Editorial Room · Phase 04 DRAFT — three-column shell ─────────────── */
+
+.editorial-po-draft-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 1rem;
+  border-bottom: 1px solid #e2dccc;
+  background: #f7f3e8;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #5b5644;
+}
+
+.editorial-po-draft-words-on {
+  color: #2e7d62;
+}
+
+.editorial-po-draft-words-under {
+  color: #6c6655;
+}
+
+.editorial-po-draft-words-over {
+  color: #c98a2c;
+}
+
+.editorial-po-draft-autosave {
+  color: #6c6655;
+}
+
+.editorial-po-draft-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 1rem;
+  border-bottom: 1px solid #e2dccc;
+  background: #fbf8f2;
+  flex-wrap: wrap;
+}
+
+.editorial-po-draft-toolbar-sep {
+  color: #c9c0a8;
+  font-size: 0.85rem;
+  padding: 0 0.2rem;
+}
+
+.editorial-po-draft-scope {
+  margin-left: auto;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+  border: 1px solid #c9c0a8;
+  border-radius: 3px;
+  padding: 0.16rem 0.5rem;
+}
+
+.editorial-po-draft-grid {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr) 280px;
+  height: calc(100vh - 170px);
+  background: #fbf8f2;
+  overflow: hidden;
+}
+
+.editorial-po-draft-rail {
+  border-right: 1px solid #e2dccc;
+  padding: 0.85rem 0.6rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  background: #f7f3e8;
+}
+
+.editorial-po-draft-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.editorial-po-draft-outline-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.editorial-po-draft-outline-item {
+  background: #fff;
+  border: 1px solid #ddd6c8;
+  border-radius: 5px;
+  padding: 0.4rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+}
+
+.editorial-po-draft-outline-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.editorial-po-draft-outline-claim {
+  margin: 0;
+  font-size: 0.74rem;
+  font-weight: 500;
+  color: #1f1c14;
+  line-height: 1.35;
+}
+
+.editorial-po-draft-center {
+  overflow-y: auto;
+  padding: 1.2rem 1.6rem 3rem;
+  background: #fbf8f2;
+  display: flex;
+  justify-content: center;
+}
+
+.editorial-po-draft-editor {
+  width: 100%;
+  max-width: 720px;
+}
+
+.editorial-po-draft-editor .ProseMirror {
+  outline: none;
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-size: 1rem;
+  line-height: 1.7;
+  color: #1f1c14;
+  caret-color: #b7372a;
+  min-height: 60vh;
+}
+
+.editorial-po-draft-editor .ProseMirror h1 {
+  font-size: 1.65rem;
+  font-weight: 700;
+  margin: 1.2rem 0 0.8rem;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+.editorial-po-draft-editor .ProseMirror h2 {
+  font-size: 1.3rem;
+  font-weight: 700;
+  margin: 1.4rem 0 0.5rem;
+  line-height: 1.3;
+}
+
+.editorial-po-draft-editor .ProseMirror h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 1.1rem 0 0.4rem;
+}
+
+.editorial-po-draft-editor .ProseMirror p {
+  margin: 0 0 1rem;
+}
+
+.editorial-po-draft-editor .ProseMirror ul,
+.editorial-po-draft-editor .ProseMirror ol {
+  margin: 0 0 1rem;
+  padding-left: 1.4rem;
+}
+
+.editorial-po-draft-editor .ProseMirror blockquote {
+  border-left: 3px solid #b7372a;
+  margin: 0 0 1rem;
+  padding: 0.3rem 0.9rem;
+  color: #4a4738;
+  font-style: italic;
+  background: rgba(247, 243, 232, 0.5);
+}
+
+.editorial-po-draft-editor .ProseMirror code {
+  background: #efe9d8;
+  border-radius: 3px;
+  padding: 0.05rem 0.3rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.88em;
+}
+
+.editorial-po-draft-editor .ProseMirror pre {
+  background: #1f1c14;
+  color: #f7f3e8;
+  border-radius: 5px;
+  padding: 0.7rem 0.9rem;
+  margin: 0 0 1rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.85rem;
+  overflow-x: auto;
+}
+
+.editorial-po-draft-editor .ProseMirror pre code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+}
+
+.editorial-po-draft-editor .ProseMirror hr {
+  border: 0;
+  border-top: 1px solid #c9c0a8;
+  margin: 1.5rem 0;
+}
+
+.editorial-po-draft-panel {
+  border-left: 1px solid #e2dccc;
+  padding: 0.85rem 0.7rem;
+  overflow-y: auto;
+  background: #faf6ec;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+@media (max-width: 1280px) {
+  .editorial-po-draft-grid {
+    grid-template-columns: 200px minmax(0, 1fr) 240px;
+  }
+}
+
+@media (max-width: 1080px) {
+  .editorial-po-draft-grid {
+    grid-template-columns: 200px minmax(0, 1fr);
+  }
+  .editorial-po-draft-panel {
+    display: none;
+  }
+}
+
 .editorial-po-note-timestamp {
   margin-left: auto;
   font-family: 'IBM Plex Mono', monospace;


### PR DESCRIPTION
## Summary
- Mounts `/editorial/draft` and flips phase pill 04 from disabled to active
- Three-column shell: Outline rail (left, reads from the Points workspace's localStorage) + Tiptap editor (center, StarterKit) + Panel chat (right, placeholder)
- Sub-meta bar: live word count vs target range (1,200–1,400) + LAST AUTOSAVE timestamp
- Top action toolbar: FULL DRAFT / POLISH / EXPAND / → CONTINUE / ? MISSING + OPTIMIZE — all disabled
- Editor content autosaves on a 500ms debounce to `editorial-room.draft.content-v0`
- Adds `@tiptap/react` + `@tiptap/pm` + `@tiptap/starter-kit` (^2)

## Mechanics

- `loadOutlineGroups()` reads `points-order-v0` and `detail-states-v1` and reconstructs the same HOOK / BODY / CLOSE section grouping the Outline tab uses; updates appear on page mount (no live cross-tab sync yet)
- Section + position numbers use the same logic as the Points workspace, so `01 HOOK` / `02 ARGUMENT` / etc. line up across phases
- Editor uses StarterKit (paragraph, headings, bold/italic, lists, code, blockquote, hr, hard-break, history)
- Word count updates on `onUpdate`; status chip switches green when in target range, amber over, neutral under
- Default content seeds the editor with the Topic title as `<h1>` plus a one-line markdown-shortcut hint paragraph

## Bundle

- JS: ~670 KB → ~1 MB (Tiptap brings ProseMirror). Acceptable for v0p; chunk-splitting can come later

## Deferred (multi-PR plan per design/04_draft.md)

- Tabs in left rail (Sources / Versions); only Outline is real now
- Per-segment scoring + active-segment selection
- Panel chat scoped to active segment
- + OPTIMIZE popover with cost preview + customize panel + run
- Quick chips wired to single-pass Skill calls
- Voice-lock banner, mechanical scorer, suggestion overlay, source-map
- Markdown export (Substack/Google Doc), revision history
- Tiptap → Markdown round-trip + canonical subset (0p-b1 spike)

## Validation

- `npm --prefix webapp run typecheck` clean
- `npm --prefix webapp run build` clean (1.0 MB JS, 106 KB CSS)
- `npm --prefix webapp run test` 172 passed / 1 skipped
- `npx prettier --check` clean
- `editorial-room.test.ts` 99/99

## Test plan

- [ ] Visit `/editorial/setup` → click `04 DRAFT` pill → lands on `/editorial/draft`
- [ ] Outline rail shows the same Points-in-outline as the Points workspace, grouped HOOK / BODY / CLOSE with position numbers and aggregate scores; if a Point is STALE in Points workspace, the score row shows a `·` indicator
- [ ] Type into the editor; word count updates live; LAST AUTOSAVE timestamp updates after ~500ms idle
- [ ] Try markdown shortcuts: `## ` → H2, `* ` → bullet, `> ` → blockquote, `` ` `` → inline code, `---` → hr
- [ ] Reload → editor content preserved
- [ ] Navigate to Points workspace, edit a CLAIM, save, return to Draft → edited claim shows in Outline rail
- [ ] DevTools clear `editorial-room.draft.content-v0` → reload → default content (Topic title h1 + intro paragraph) restores
- [ ] At ≥1281px viewport: 3-column layout. ≤1280: tighter columns. ≤1080: right rail collapses

🤖 Generated with [Claude Code](https://claude.com/claude-code)