### PR TITLE
feat: Phase 04 DRAFT markdown export — ↑ COPY MD button

### DIFF
--- a/webapp/src/lib/markdown-export.test.ts
+++ b/webapp/src/lib/markdown-export.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+
+import { serializeDocToMarkdown, type JSONNode } from './markdown-export';
+
+function doc(...content: JSONNode[]): JSONNode {
+  return { type: 'doc', content };
+}
+
+function p(...content: JSONNode[]): JSONNode {
+  return { type: 'paragraph', content };
+}
+
+function text(
+  value: string,
+  marks?: Array<{ type: string; attrs?: Record<string, unknown> }>,
+): JSONNode {
+  return marks
+    ? { type: 'text', text: value, marks }
+    : { type: 'text', text: value };
+}
+
+describe('serializeDocToMarkdown', () => {
+  it('returns empty string for null/undefined/non-doc', () => {
+    expect(serializeDocToMarkdown(null)).toBe('');
+    expect(serializeDocToMarkdown(undefined)).toBe('');
+    expect(serializeDocToMarkdown({ type: 'paragraph' })).toBe('');
+  });
+
+  it('serializes empty doc to empty string', () => {
+    expect(serializeDocToMarkdown(doc())).toBe('');
+  });
+
+  it('renders a heading at the requested level', () => {
+    const out = serializeDocToMarkdown(
+      doc({ type: 'heading', attrs: { level: 2 }, content: [text('Hello')] }),
+    );
+    expect(out).toBe('## Hello\n');
+  });
+
+  it('clamps heading levels to [1, 6]', () => {
+    const tooHigh = serializeDocToMarkdown(
+      doc({ type: 'heading', attrs: { level: 9 }, content: [text('X')] }),
+    );
+    expect(tooHigh).toBe('###### X\n');
+    const tooLow = serializeDocToMarkdown(
+      doc({ type: 'heading', attrs: { level: 0 }, content: [text('X')] }),
+    );
+    expect(tooLow).toBe('# X\n');
+  });
+
+  it('renders paragraphs separated by blank lines', () => {
+    const out = serializeDocToMarkdown(
+      doc(p(text('First.')), p(text('Second.'))),
+    );
+    expect(out).toBe('First.\n\nSecond.\n');
+  });
+
+  it('applies bold, italic, code, strike, and link marks', () => {
+    const out = serializeDocToMarkdown(
+      doc(
+        p(
+          text('plain '),
+          text('bold', [{ type: 'bold' }]),
+          text(' '),
+          text('italic', [{ type: 'italic' }]),
+          text(' '),
+          text('code', [{ type: 'code' }]),
+          text(' '),
+          text('strike', [{ type: 'strike' }]),
+          text(' '),
+          text('link', [
+            { type: 'link', attrs: { href: 'https://example.com' } },
+          ]),
+        ),
+      ),
+    );
+    expect(out).toBe(
+      'plain **bold** *italic* `code` ~~strike~~ [link](https://example.com)\n',
+    );
+  });
+
+  it('nests combined marks in a stable order', () => {
+    const out = serializeDocToMarkdown(
+      doc(p(text('hi', [{ type: 'bold' }, { type: 'italic' }]))),
+    );
+    // Italic is innermost (applied first), bold wraps it.
+    expect(out).toBe('***hi***\n');
+  });
+
+  it('drops link mark when href is missing', () => {
+    const out = serializeDocToMarkdown(
+      doc(p(text('orphan', [{ type: 'link', attrs: {} }]))),
+    );
+    expect(out).toBe('orphan\n');
+  });
+
+  it('renders hard breaks as two trailing spaces + newline', () => {
+    const out = serializeDocToMarkdown(
+      doc(p(text('line one'), { type: 'hardBreak' }, text('line two'))),
+    );
+    expect(out).toBe('line one  \nline two\n');
+  });
+
+  it('renders blockquotes with line prefixes', () => {
+    const out = serializeDocToMarkdown(
+      doc({
+        type: 'blockquote',
+        content: [p(text('First.')), p(text('Second.'))],
+      }),
+    );
+    expect(out).toBe('> First.\n>\n> Second.\n');
+  });
+
+  it('renders fenced code blocks with language', () => {
+    const out = serializeDocToMarkdown(
+      doc({
+        type: 'codeBlock',
+        attrs: { language: 'ts' },
+        content: [text('const x = 1;')],
+      }),
+    );
+    expect(out).toBe('```ts\nconst x = 1;\n```\n');
+  });
+
+  it('renders fenced code blocks without language', () => {
+    const out = serializeDocToMarkdown(
+      doc({ type: 'codeBlock', content: [text('plain')] }),
+    );
+    expect(out).toBe('```\nplain\n```\n');
+  });
+
+  it('renders bullet lists', () => {
+    const out = serializeDocToMarkdown(
+      doc({
+        type: 'bulletList',
+        content: [
+          { type: 'listItem', content: [p(text('one'))] },
+          { type: 'listItem', content: [p(text('two'))] },
+        ],
+      }),
+    );
+    expect(out).toBe('- one\n- two\n');
+  });
+
+  it('renders ordered lists with a custom start', () => {
+    const out = serializeDocToMarkdown(
+      doc({
+        type: 'orderedList',
+        attrs: { start: 3 },
+        content: [
+          { type: 'listItem', content: [p(text('three'))] },
+          { type: 'listItem', content: [p(text('four'))] },
+        ],
+      }),
+    );
+    expect(out).toBe('3. three\n4. four\n');
+  });
+
+  it('renders horizontal rules', () => {
+    const out = serializeDocToMarkdown(
+      doc(p(text('above')), { type: 'horizontalRule' }, p(text('below'))),
+    );
+    expect(out).toBe('above\n\n---\n\nbelow\n');
+  });
+
+  it('round-trips a small mixed document', () => {
+    const out = serializeDocToMarkdown(
+      doc(
+        { type: 'heading', attrs: { level: 1 }, content: [text('Title')] },
+        p(text('Intro paragraph.')),
+        {
+          type: 'bulletList',
+          content: [
+            { type: 'listItem', content: [p(text('First'))] },
+            { type: 'listItem', content: [p(text('Second'))] },
+          ],
+        },
+        {
+          type: 'blockquote',
+          content: [p(text('Quoted line.'))],
+        },
+        { type: 'horizontalRule' },
+        p(text('Closing.')),
+      ),
+    );
+    expect(out).toBe(
+      [
+        '# Title',
+        '',
+        'Intro paragraph.',
+        '',
+        '- First',
+        '- Second',
+        '',
+        '> Quoted line.',
+        '',
+        '---',
+        '',
+        'Closing.',
+        '',
+      ].join('\n'),
+    );
+  });
+});

--- a/webapp/src/lib/markdown-export.ts
+++ b/webapp/src/lib/markdown-export.ts
@@ -1,0 +1,180 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Tiptap-JSON → Markdown serializer (StarterKit subset).
+//
+// Used by the Editorial Room Draft phase to export a Tiptap document to
+// Substack-paste-ready markdown without round-tripping through the LLM.
+// Handles the StarterKit node and mark types we actually emit:
+//   nodes:  doc, paragraph, heading, blockquote, codeBlock, bulletList,
+//           orderedList, listItem, horizontalRule, hardBreak, text
+//   marks:  bold, italic, strike, code, link
+// Unknown nodes/marks fall through to their content (best-effort, no throw).
+// ───────────────────────────────────────────────────────────────────────────
+
+export type JSONMark = {
+  type: string;
+  attrs?: Record<string, unknown>;
+};
+
+export type JSONNode = {
+  type: string;
+  attrs?: Record<string, unknown>;
+  content?: JSONNode[];
+  text?: string;
+  marks?: JSONMark[];
+};
+
+const MARK_ORDER: Record<string, number> = {
+  // Apply outermost-first so the rendered string nests correctly.
+  // E.g. for [bold, italic] we want `**_text_**`, so italic wraps first.
+  link: 0,
+  bold: 1,
+  italic: 2,
+  strike: 3,
+  code: 4,
+};
+
+function applyMark(text: string, mark: JSONMark): string {
+  switch (mark.type) {
+    case 'bold':
+      return `**${text}**`;
+    case 'italic':
+      return `*${text}*`;
+    case 'strike':
+      return `~~${text}~~`;
+    case 'code':
+      return `\`${text}\``;
+    case 'link': {
+      const href =
+        typeof mark.attrs?.href === 'string' ? mark.attrs.href : null;
+      if (!href) return text;
+      return `[${text}](${href})`;
+    }
+    default:
+      return text;
+  }
+}
+
+function serializeText(text: string, marks: JSONMark[] | undefined): string {
+  if (!marks || marks.length === 0) return text;
+  // Apply marks innermost → outermost so the outermost wrapper is applied last.
+  const sorted = [...marks].sort(
+    (a, b) => (MARK_ORDER[b.type] ?? 99) - (MARK_ORDER[a.type] ?? 99),
+  );
+  let out = text;
+  for (const mark of sorted) {
+    out = applyMark(out, mark);
+  }
+  return out;
+}
+
+function serializeInline(content: JSONNode[] | undefined): string {
+  if (!content || content.length === 0) return '';
+  let out = '';
+  for (const node of content) {
+    if (node.type === 'text') {
+      out += serializeText(node.text ?? '', node.marks);
+    } else if (node.type === 'hardBreak') {
+      out += '  \n';
+    } else if (node.content) {
+      // Unexpected nested block inside inline — fall through to its inline.
+      out += serializeInline(node.content);
+    }
+  }
+  return out;
+}
+
+function serializeListItem(node: JSONNode, marker: string): string {
+  // List items contain block children (usually a single paragraph). Render the
+  // first child inline, and subsequent blocks indented as continuation lines.
+  const children = node.content ?? [];
+  if (children.length === 0) return `${marker} \n`;
+  const indentSize = marker.length + 1;
+  const indent = ' '.repeat(indentSize);
+  const parts: string[] = [];
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    const block = serializeBlock(child).trimEnd();
+    const lines = block.split('\n');
+    if (i === 0) {
+      parts.push(`${marker} ${lines[0] ?? ''}`);
+      for (let l = 1; l < lines.length; l++) {
+        parts.push(`${indent}${lines[l]}`);
+      }
+    } else {
+      parts.push('');
+      for (const line of lines) {
+        parts.push(line === '' ? '' : `${indent}${line}`);
+      }
+    }
+  }
+  return parts.join('\n') + '\n';
+}
+
+function serializeBlock(node: JSONNode): string {
+  switch (node.type) {
+    case 'paragraph':
+      return `${serializeInline(node.content)}\n`;
+    case 'heading': {
+      const rawLevel =
+        typeof node.attrs?.level === 'number' ? node.attrs.level : 1;
+      const level = Math.max(1, Math.min(6, rawLevel));
+      const hashes = '#'.repeat(level);
+      return `${hashes} ${serializeInline(node.content)}\n`;
+    }
+    case 'blockquote': {
+      const inner = (node.content ?? [])
+        .map((n) => serializeBlock(n))
+        .join('\n')
+        .trim();
+      if (!inner) return '> \n';
+      return (
+        inner
+          .split('\n')
+          .map((l) => (l === '' ? '>' : `> ${l}`))
+          .join('\n') + '\n'
+      );
+    }
+    case 'codeBlock': {
+      const language =
+        typeof node.attrs?.language === 'string' ? node.attrs.language : '';
+      const text = (node.content ?? [])
+        .map((n) => n.text ?? '')
+        .join('')
+        .replace(/\n$/, '');
+      return `\`\`\`${language}\n${text}\n\`\`\`\n`;
+    }
+    case 'bulletList': {
+      const items = (node.content ?? [])
+        .filter((n) => n.type === 'listItem')
+        .map((n) => serializeListItem(n, '-').trimEnd());
+      return items.join('\n') + '\n';
+    }
+    case 'orderedList': {
+      const start =
+        typeof node.attrs?.start === 'number' ? node.attrs.start : 1;
+      const items = (node.content ?? [])
+        .filter((n) => n.type === 'listItem')
+        .map((n, idx) => serializeListItem(n, `${start + idx}.`).trimEnd());
+      return items.join('\n') + '\n';
+    }
+    case 'horizontalRule':
+      return '---\n';
+    case 'listItem':
+      // Stray listItem outside a list — render as a bullet.
+      return serializeListItem(node, '-');
+    default:
+      // Unknown block — best-effort: serialize children as blocks.
+      return (node.content ?? []).map((n) => serializeBlock(n)).join('');
+  }
+}
+
+export function serializeDocToMarkdown(
+  doc: JSONNode | null | undefined,
+): string {
+  if (!doc || doc.type !== 'doc') return '';
+  const blocks = doc.content ?? [];
+  // Join blocks with a blank line so paragraphs/headings/etc. are
+  // separated as readers expect.
+  const out = blocks.map((n) => serializeBlock(n).trimEnd()).join('\n\n');
+  return out.trim() + (out.trim() ? '\n' : '');
+}

--- a/webapp/src/pages/DraftWorkspacePage.tsx
+++ b/webapp/src/pages/DraftWorkspacePage.tsx
@@ -8,21 +8,20 @@ import {
 import StarterKit from '@tiptap/starter-kit';
 
 import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
+import { serializeDocToMarkdown, type JSONNode } from '../lib/markdown-export';
 
 // ───────────────────────────────────────────────────────────────────────────
-// Phase 04 DRAFT — versions tab + ⌘S manual save.
-// Builds on the cursor-aware navigation cut (PR #270) by adding the Versions
-// rail tab per design/04_draft.md §10.4:
-//   • Named snapshots: manual_save (⌘S), phase_entry (mount), restore_from_snapshot
-//     — durable, never auto-pruned at v0p
-//   • Auto snapshots: every 60s if changed since last snapshot — last 20 retained
-//     (FIFO prune)
-//   • Restore replaces the current draft body and captures pre-restore state
-//     as a named snapshot so the user can recover from a misclick
+// Phase 04 DRAFT — markdown export cut.
+// Adds a `↑ COPY MD` button in the sub-meta bar that serializes the editor
+// JSON to Substack-paste-ready markdown via `lib/markdown-export.ts`. This
+// closes the loop on "draft → ship" without any LLM dependency at v0p — the
+// user can write in the Editorial Room and paste directly into Substack /
+// Google Doc / etc.
 //
 // Earlier cuts in this page:
 //   • PR #269: three-column shell + Tiptap editor + outline rail + word count
 //   • PR #270: cursor-aware status bar + scope chip + outline jump-to-segment
+//   • PR #271: Versions tab + ⌘S manual save + 60s autosave snapshots
 //
 // Still deferred (per design/04_draft.md):
 // - Sources tab (left rail) — scoped citation tracker
@@ -30,7 +29,7 @@ import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
 // - Quick-action chips wired to handlers (FULL DRAFT / POLISH / etc.)
 // - + OPTIMIZE popover with cost preview + customize panel + run
 // - Voice-lock banner, mechanical scorer, suggestion overlay
-// - Markdown export, source-map round-trip
+// - Markdown round-trip + source-map (0p-b1 spike: Tiptap → MD → Tiptap)
 // - Compressed-diff snapshot storage (currently full JSON per snapshot)
 //
 // NOTE on the Outline-rail data source: the Points workspace owns its
@@ -590,7 +589,11 @@ export function DraftWorkspacePage(_props: Props) {
   const [versions, setVersions] = useState<VersionEntry[]>(loadVersions);
   const [activeRailTab, setActiveRailTab] = useState<RailTab>('outline');
   const [showAutosaves, setShowAutosaves] = useState<boolean>(false);
+  const [exportState, setExportState] = useState<'idle' | 'copied' | 'error'>(
+    'idle',
+  );
   const saveTimerRef = useRef<number | null>(null);
+  const exportResetTimerRef = useRef<number | null>(null);
   // Bumped on every editor onUpdate. Compared against `lastSnapshotVersionRef`
   // by the auto-snapshot interval to skip no-op snapshots.
   const editorVersionRef = useRef<number>(0);
@@ -626,6 +629,9 @@ export function DraftWorkspacePage(_props: Props) {
     return () => {
       if (saveTimerRef.current !== null) {
         window.clearTimeout(saveTimerRef.current);
+      }
+      if (exportResetTimerRef.current !== null) {
+        window.clearTimeout(exportResetTimerRef.current);
       }
     };
   }, []);
@@ -738,6 +744,45 @@ export function DraftWorkspacePage(_props: Props) {
     [versions],
   );
 
+  const handleExportMarkdown = async (): Promise<void> => {
+    if (!editor) return;
+    const json = editor.getJSON() as JSONNode;
+    const md = serializeDocToMarkdown(json);
+    const finish = (state: 'copied' | 'error'): void => {
+      setExportState(state);
+      if (exportResetTimerRef.current !== null) {
+        window.clearTimeout(exportResetTimerRef.current);
+      }
+      exportResetTimerRef.current = window.setTimeout(() => {
+        setExportState('idle');
+        exportResetTimerRef.current = null;
+      }, 1500);
+    };
+    try {
+      if (
+        typeof navigator !== 'undefined' &&
+        navigator.clipboard &&
+        typeof navigator.clipboard.writeText === 'function'
+      ) {
+        await navigator.clipboard.writeText(md);
+        finish('copied');
+        return;
+      }
+      // Older-browser fallback: textarea + execCommand. Best-effort only.
+      const textarea = document.createElement('textarea');
+      textarea.value = md;
+      textarea.style.position = 'fixed';
+      textarea.style.left = '-9999px';
+      document.body.appendChild(textarea);
+      textarea.select();
+      const ok = document.execCommand('copy');
+      document.body.removeChild(textarea);
+      finish(ok ? 'copied' : 'error');
+    } catch {
+      finish('error');
+    }
+  };
+
   const handleRestoreVersion = (version: VersionEntry): void => {
     if (!editor) return;
     // Per design/04_draft.md §10.4: capture pre-restore state as a named
@@ -780,6 +825,24 @@ export function DraftWorkspacePage(_props: Props) {
             ? `LAST AUTOSAVE ${formatHHMM(lastSavedAt)}`
             : 'NO CHANGES SINCE LOAD'}
         </span>
+        <button
+          type="button"
+          className={`editorial-po-draft-export${
+            exportState === 'copied' ? ' editorial-po-draft-export-copied' : ''
+          }${
+            exportState === 'error' ? ' editorial-po-draft-export-error' : ''
+          }`}
+          onClick={() => {
+            void handleExportMarkdown();
+          }}
+          disabled={!editor}
+          aria-live="polite"
+          title="Copy the draft as Substack-ready markdown"
+        >
+          {exportState === 'copied' && 'COPIED ✓'}
+          {exportState === 'error' && 'COPY FAILED'}
+          {exportState === 'idle' && '↑ COPY MD'}
+        </button>
       </div>
 
       <div className="editorial-po-draft-toolbar">

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -6549,6 +6549,49 @@ a.editorial-phase-pill:hover {
   color: #6c6655;
 }
 
+.editorial-po-draft-export {
+  margin-left: auto;
+  background: none;
+  border: 1px solid #c9c0a8;
+  border-radius: 3px;
+  padding: 0.2rem 0.6rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #5b5644;
+  cursor: pointer;
+  transition:
+    background 100ms,
+    color 100ms,
+    border-color 100ms;
+}
+
+.editorial-po-draft-export:hover:not(:disabled) {
+  background: #fff8e7;
+  border-color: #b7372a;
+  color: #b7372a;
+}
+
+.editorial-po-draft-export:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.editorial-po-draft-export-copied,
+.editorial-po-draft-export-copied:hover {
+  background: #ddf0e1;
+  border-color: #2e7d62;
+  color: #2e7d62;
+}
+
+.editorial-po-draft-export-error,
+.editorial-po-draft-export-error:hover {
+  background: #fbe5e1;
+  border-color: #b7372a;
+  color: #b7372a;
+}
+
 .editorial-po-draft-toolbar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Closes the loop on "draft → ship" without any LLM dependency at v0p — the user can write in the Editorial Room and paste straight into Substack / Google Doc.

## What's new

- `webapp/src/lib/markdown-export.ts` — Tiptap-JSON → markdown serializer covering the StarterKit subset
  - **nodes:** doc, paragraph, heading, blockquote, codeBlock, bulletList, orderedList, listItem, horizontalRule, hardBreak, text
  - **marks:** bold, italic, strike, code, link
- `↑ COPY MD` button in the Draft sub-meta bar
  - Click serializes editor body and copies to clipboard
  - Label flips to `COPIED ✓` (green) or `COPY FAILED` (red) for ~1.5s
  - Older-browser fallback uses textarea + execCommand

## Test plan

- [ ] `/editorial/draft` shows `↑ COPY MD` chip on the right side of the sub-meta bar.
- [ ] Click → label flips to `COPIED ✓` and reverts after ~1.5s. Pasting into a markdown editor reproduces the doc structure.
- [ ] Headings render as `#`/`##`/etc., paragraphs as plain lines with blank-line separators, lists as `-` / `1.`, blockquotes as `> `, code blocks as fenced, marks correctly nested.
- [ ] 16 new unit tests pass: `markdown-export.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)