### PR TITLE
feat: Phase 04 DRAFT Sources tab — fixture-only cite tracker

### DIFF
--- a/webapp/src/pages/DraftWorkspacePage.tsx
+++ b/webapp/src/pages/DraftWorkspacePage.tsx
@@ -11,26 +11,27 @@ import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
 import { serializeDocToMarkdown, type JSONNode } from '../lib/markdown-export';
 
 // ───────────────────────────────────────────────────────────────────────────
-// Phase 04 DRAFT — markdown export cut.
-// Adds a `↑ COPY MD` button in the sub-meta bar that serializes the editor
-// JSON to Substack-paste-ready markdown via `lib/markdown-export.ts`. This
-// closes the loop on "draft → ship" without any LLM dependency at v0p — the
-// user can write in the Editorial Room and paste directly into Substack /
-// Google Doc / etc.
+// Phase 04 DRAFT — Sources tab cut.
+// Wires the Sources rail tab per design/04_draft.md §6.1: a draft-scoped
+// view of the source_blocks the panel can cite. Fixture-only at v0p; real
+// `clawrocket.source_blocks filtered by Outline ancestry` lookup lands when
+// the autoresearch pipeline plugs in.
 //
 // Earlier cuts in this page:
 //   • PR #269: three-column shell + Tiptap editor + outline rail + word count
 //   • PR #270: cursor-aware status bar + scope chip + outline jump-to-segment
 //   • PR #271: Versions tab + ⌘S manual save + 60s autosave snapshots
+//   • PR #272: ↑ COPY MD export (Tiptap-JSON → markdown serializer)
 //
 // Still deferred (per design/04_draft.md):
-// - Sources tab (left rail) — scoped citation tracker
 // - Panel chat scoped to active segment (right rail)
 // - Quick-action chips wired to handlers (FULL DRAFT / POLISH / etc.)
 // - + OPTIMIZE popover with cost preview + customize panel + run
 // - Voice-lock banner, mechanical scorer, suggestion overlay
 // - Markdown round-trip + source-map (0p-b1 spike: Tiptap → MD → Tiptap)
 // - Compressed-diff snapshot storage (currently full JSON per snapshot)
+// - Real Sources data: currently fixture-only; cite-on-click into editor
+//   + per-segment source filter deferred to autoresearch wiring
 //
 // NOTE on the Outline-rail data source: the Points workspace owns its
 // state in its own localStorage envelope. To avoid threading a shared
@@ -92,7 +93,71 @@ type VersionEntry = {
   body: unknown;
 };
 
-type RailTab = 'outline' | 'versions';
+type RailTab = 'outline' | 'sources' | 'versions';
+
+type SourceKind = 'filing' | 'article' | 'transcript' | 'page-ref' | 'social';
+
+type SourceEntry = {
+  id: string;
+  index: number;
+  kind: SourceKind;
+  title: string;
+  publication?: string;
+  date?: string;
+  citation: string;
+  url?: string;
+};
+
+const SOURCE_KIND_LABELS: Record<SourceKind, string> = {
+  filing: 'FILING',
+  article: 'ARTICLE',
+  transcript: 'TRANSCRIPT',
+  'page-ref': 'PAGE',
+  social: 'SOCIAL',
+};
+
+// Fixture sources matching the Embracer hero example. Replaced by
+// `clawrocket.source_blocks filtered by Outline ancestry` once autoresearch
+// is wired up.
+const FIXTURE_SOURCES: ReadonlyArray<SourceEntry> = [
+  {
+    id: 's1',
+    index: 1,
+    kind: 'filing',
+    title: 'Embracer Group AB · Form 8-K',
+    publication: 'SEC EDGAR',
+    date: '2025-08-14',
+    citation: 'Item 2.06 (impairment), pp.14–16',
+    url: 'https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK=0001877787',
+  },
+  {
+    id: 's2',
+    index: 2,
+    kind: 'article',
+    title: "Embracer's $2.1B writedown reshapes indie publishing terms",
+    publication: 'GamesIndustry.biz',
+    date: '2025-08-15',
+    citation: 'Hyland — 2025-08-15',
+  },
+  {
+    id: 's3',
+    index: 3,
+    kind: 'transcript',
+    title: 'Embracer Q2 FY26 earnings call',
+    publication: 'Embracer Group',
+    date: '2025-08-14',
+    citation: 'CFO comments at 23:14',
+  },
+  {
+    id: 's4',
+    index: 4,
+    kind: 'social',
+    title: '@indiedev_ravi: "deal terms changed overnight"',
+    publication: 'X / Twitter',
+    date: '2025-09-02',
+    citation: 'Personal communication',
+  },
+];
 
 const SECTION_ORDER: ReadonlyArray<OutlineSection> = ['HOOK', 'BODY', 'CLOSE'];
 
@@ -890,8 +955,19 @@ export function DraftWorkspacePage(_props: Props) {
                 {totalOutlinePoints}/5–7
               </span>
             </button>
-            <button type="button" className="editorial-po-rail-tab" disabled>
-              Sources <span className="editorial-po-rail-tab-count">—</span>
+            <button
+              type="button"
+              className={`editorial-po-rail-tab${
+                activeRailTab === 'sources'
+                  ? ' editorial-po-rail-tab-active'
+                  : ''
+              }`}
+              onClick={() => setActiveRailTab('sources')}
+            >
+              Sources{' '}
+              <span className="editorial-po-rail-tab-count">
+                {FIXTURE_SOURCES.length}
+              </span>
             </button>
             <button
               type="button"
@@ -909,8 +985,8 @@ export function DraftWorkspacePage(_props: Props) {
             </button>
           </div>
 
-          {activeRailTab === 'outline' ? (
-            totalOutlinePoints === 0 ? (
+          {activeRailTab === 'outline' &&
+            (totalOutlinePoints === 0 ? (
               <p className="editorial-tt-empty">
                 No Points in the Outline yet. Visit{' '}
                 <a href="/editorial/points-outline">03 POINTS + OUTLINE</a> to
@@ -992,8 +1068,55 @@ export function DraftWorkspacePage(_props: Props) {
                   );
                 });
               })()
-            )
-          ) : (
+            ))}
+          {activeRailTab === 'sources' && (
+            <div className="editorial-po-draft-sources-list">
+              {FIXTURE_SOURCES.map((s) => (
+                <article key={s.id} className="editorial-po-draft-source-item">
+                  <header className="editorial-po-draft-source-header">
+                    <span className="editorial-po-draft-source-index">
+                      [{s.index}]
+                    </span>
+                    <span
+                      className={`editorial-po-draft-source-kind editorial-po-draft-source-kind-${s.kind}`}
+                    >
+                      {SOURCE_KIND_LABELS[s.kind]}
+                    </span>
+                    {s.date ? (
+                      <span className="editorial-po-draft-source-date">
+                        {s.date}
+                      </span>
+                    ) : null}
+                  </header>
+                  <h4 className="editorial-po-draft-source-title">{s.title}</h4>
+                  <p className="editorial-po-draft-source-citation">
+                    {s.publication ? (
+                      <span className="editorial-po-draft-source-publication">
+                        {s.publication}
+                      </span>
+                    ) : null}
+                    {s.publication ? ' · ' : null}
+                    {s.citation}
+                  </p>
+                  {s.url ? (
+                    <a
+                      className="editorial-po-draft-source-url"
+                      href={s.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      OPEN ↗
+                    </a>
+                  ) : null}
+                </article>
+              ))}
+              <p className="editorial-po-draft-source-note">
+                Fixture sources for v0p. Real source_blocks land with the
+                autoresearch wiring.
+              </p>
+            </div>
+          )}
+          {activeRailTab === 'versions' && (
             <div className="editorial-po-draft-versions-list">
               {namedVersions.length === 0 && autoVersions.length === 0 ? (
                 <p className="editorial-tt-empty">

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -6850,6 +6850,126 @@ a.editorial-phase-pill:hover {
   gap: 0.6rem;
 }
 
+/* Sources tab content */
+
+.editorial-po-draft-sources-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.editorial-po-draft-source-item {
+  background: #fff;
+  border: 1px solid #ddd6c8;
+  border-radius: 5px;
+  padding: 0.45rem 0.55rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.editorial-po-draft-source-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #6c6655;
+}
+
+.editorial-po-draft-source-index {
+  color: #b7372a;
+  font-weight: 600;
+}
+
+.editorial-po-draft-source-kind {
+  border: 1px solid #c9c0a8;
+  border-radius: 3px;
+  padding: 0 0.3rem;
+  letter-spacing: 0.06em;
+  font-size: 0.55rem;
+}
+
+.editorial-po-draft-source-kind-filing {
+  border-color: #2e7d62;
+  color: #2e7d62;
+}
+
+.editorial-po-draft-source-kind-article {
+  border-color: #5b6dad;
+  color: #5b6dad;
+}
+
+.editorial-po-draft-source-kind-transcript {
+  border-color: #8a6d2c;
+  color: #8a6d2c;
+}
+
+.editorial-po-draft-source-kind-page-ref {
+  border-color: #6c6655;
+  color: #6c6655;
+}
+
+.editorial-po-draft-source-kind-social {
+  border-color: #b7372a;
+  color: #b7372a;
+}
+
+.editorial-po-draft-source-date {
+  margin-left: auto;
+}
+
+.editorial-po-draft-source-title {
+  margin: 0.1rem 0 0;
+  font-size: 0.78rem;
+  font-weight: 500;
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  color: #1f1c14;
+  line-height: 1.3;
+}
+
+.editorial-po-draft-source-citation {
+  margin: 0;
+  font-size: 0.66rem;
+  font-family: 'IBM Plex Mono', monospace;
+  color: #6c6655;
+  letter-spacing: 0.02em;
+  line-height: 1.4;
+}
+
+.editorial-po-draft-source-publication {
+  color: #1f1c14;
+  font-weight: 500;
+}
+
+.editorial-po-draft-source-url {
+  align-self: flex-end;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #b7372a;
+  text-decoration: none;
+}
+
+.editorial-po-draft-source-url:hover {
+  text-decoration: underline;
+}
+
+.editorial-po-draft-source-note {
+  margin: 0.4rem 0 0;
+  padding-top: 0.45rem;
+  border-top: 1px dashed #c9c0a8;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #8a8268;
+  line-height: 1.4;
+}
+
 /* Versions tab content */
 
 .editorial-po-draft-versions-list {


### PR DESCRIPTION
## Summary

Wires the Sources rail tab per design/04_draft.md §6.1 — a draft-scoped view of the source_blocks the panel can cite. Sources tab pill bumps from \"—\" to the active count.

## What's new

Each source card shows:
- `[N]` index (numbered for inline citation matching)
- Kind chip (FILING / ARTICLE / TRANSCRIPT / PAGE / SOCIAL) — color-coded
- Title (serif) + publication · citation (mono)
- Optional `OPEN ↗` link out

## Fixture provenance

Sources match the Embracer hero example: 8-K filing, GamesIndustry.biz article, earnings call transcript, X/Twitter source. A trailing note in the rail (\"Fixture sources for v0p…\") makes the provenance honest so we don't accidentally treat the fixture as truth during the stop/go test.

## Deferred

- Real data lookup (\`clawrocket.source_blocks\` filtered by Outline ancestry) — lands with autoresearch wiring
- Click-to-cite into the editor — same dependency

## Test plan

- [ ] \`/editorial/draft\` — Sources tab pill shows \"4\" (was \"—\").
- [ ] Click Sources tab. Four source cards render with kind chips, titles, citations.
- [ ] Click \`OPEN ↗\` on the 8-K card → opens SEC EDGAR in a new tab.
- [ ] Switch back to Outline / Versions tabs — content swaps cleanly, no flicker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)