### PR TITLE
feat: Phase 04 DRAFT + OPTIMIZE popover UI shell

### DIFF
--- a/webapp/src/pages/DraftWorkspacePage.tsx
+++ b/webapp/src/pages/DraftWorkspacePage.tsx
@@ -11,22 +11,26 @@ import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
 import { serializeDocToMarkdown, type JSONNode } from '../lib/markdown-export';
 
 // ───────────────────────────────────────────────────────────────────────────
-// Phase 04 DRAFT — Sources tab cut.
-// Wires the Sources rail tab per design/04_draft.md §6.1: a draft-scoped
-// view of the source_blocks the panel can cite. Fixture-only at v0p; real
-// `clawrocket.source_blocks filtered by Outline ancestry` lookup lands when
-// the autoresearch pipeline plugs in.
+// Phase 04 DRAFT — + OPTIMIZE popover UI shell.
+// Wires the popover per design/04_draft.md §5: scope-aware description,
+// 4-stage list (AUTORESEARCH / AUTONOVEL / PANEL PASS / PROPOSE 2–3), mock
+// cost preview, CUSTOMIZE / RUN footer. RUN is visible-but-disabled at v0p
+// because no LLM provider is wired into Draft yet — the popover establishes
+// the UX surface and keyboard shortcut (⌘O) so the run flow can drop in
+// later without re-litigating the visual design.
 //
 // Earlier cuts in this page:
 //   • PR #269: three-column shell + Tiptap editor + outline rail + word count
 //   • PR #270: cursor-aware status bar + scope chip + outline jump-to-segment
 //   • PR #271: Versions tab + ⌘S manual save + 60s autosave snapshots
 //   • PR #272: ↑ COPY MD export (Tiptap-JSON → markdown serializer)
+//   • PR #273: Sources tab — fixture-only cite tracker
 //
 // Still deferred (per design/04_draft.md):
 // - Panel chat scoped to active segment (right rail)
 // - Quick-action chips wired to handlers (FULL DRAFT / POLISH / etc.)
-// - + OPTIMIZE popover with cost preview + customize panel + run
+// - + OPTIMIZE actually runs an optimization round (LLM wiring)
+// - CUSTOMIZE: per-stage provider/threshold/anchor-bundle config
 // - Voice-lock banner, mechanical scorer, suggestion overlay
 // - Markdown round-trip + source-map (0p-b1 spike: Tiptap → MD → Tiptap)
 // - Compressed-diff snapshot storage (currently full JSON per snapshot)
@@ -632,6 +636,91 @@ function activeStatusText(
   return `${base} · POINT ${activePoint + 1} · ${typeLabel}`;
 }
 
+// ─── + OPTIMIZE popover content ─────────────────────────────────────────────
+
+type OptimizeStageId = 'autoresearch' | 'autonovel' | 'panel_pass' | 'propose';
+
+type OptimizeStage = {
+  id: OptimizeStageId;
+  label: string;
+  description: string;
+  active: boolean;
+};
+
+type OptimizeCostEstimate = {
+  tokens: string;
+  wall: string;
+  dollars: string;
+};
+
+function optimizeScopeLabel(cursor: CursorState): string {
+  if (cursor.hasSelection) return 'SELECTION';
+  if (cursor.activeParaIndex >= 0) {
+    return `PARAGRAPH ${cursor.activeParaIndex + 1}`;
+  }
+  return 'WHOLE DRAFT';
+}
+
+function optimizeDescription(cursor: CursorState): string {
+  if (cursor.hasSelection) {
+    return 'Optimize selection: 2–3 alternative phrasings of the highlighted text, panel-rate, return top.';
+  }
+  if (cursor.activeParaIndex >= 0) {
+    return `Targeted optimize on ¶${cursor.activeParaIndex + 1}: 2–3 alternative phrasings, panel-rate, return top.`;
+  }
+  return 'Multi-pass: research supporting + counter angles, propose 2–3 alternatives, panel-rate, return top.';
+}
+
+// Stage activity per design §5.3:
+//   AUTORESEARCH — skipped when scope is paragraph or short selection
+//   AUTONOVEL    — always active
+//   PANEL PASS   — always active for whole-draft / point; skippable for
+//                  paragraph / selection
+//   PROPOSE 2–3  — always active
+function getOptimizeStages(cursor: CursorState): OptimizeStage[] {
+  const isWholeDraft = !cursor.hasSelection && cursor.activeParaIndex < 0;
+  return [
+    {
+      id: 'autoresearch',
+      label: 'AUTORESEARCH',
+      description: 'gather supporting + counter sources',
+      active: isWholeDraft,
+    },
+    {
+      id: 'autonovel',
+      label: 'AUTONOVEL',
+      description: 'draft 2–3 alternative versions',
+      active: true,
+    },
+    {
+      id: 'panel_pass',
+      label: 'PANEL PASS',
+      description: 'score with full panel + SSR',
+      active: isWholeDraft,
+    },
+    {
+      id: 'propose',
+      label: 'PROPOSE 2–3',
+      description: 'pick top by aggregate; show side-by-side',
+      active: true,
+    },
+  ];
+}
+
+// Mock cost preview by scope. Real estimate uses scoring-pipeline metadata
+// + per-stage multipliers from the optimization_cost_calibration ledger
+// (design §10.1). Numbers below are rough order-of-magnitude defaults so the
+// popover doesn't render blank.
+function optimizeCostEstimate(cursor: CursorState): OptimizeCostEstimate {
+  if (cursor.hasSelection) {
+    return { tokens: '≈2K TOKENS', wall: '2S WALL', dollars: '≈$0.01' };
+  }
+  if (cursor.activeParaIndex >= 0) {
+    return { tokens: '≈3K TOKENS', wall: '3S WALL', dollars: '≈$0.01' };
+  }
+  return { tokens: '≈28K TOKENS', wall: '12S WALL', dollars: '≈$0.08' };
+}
+
 const WORD_TARGET_MIN = 1200;
 const WORD_TARGET_MAX = 1400;
 
@@ -657,8 +746,10 @@ export function DraftWorkspacePage(_props: Props) {
   const [exportState, setExportState] = useState<'idle' | 'copied' | 'error'>(
     'idle',
   );
+  const [optimizeOpen, setOptimizeOpen] = useState<boolean>(false);
   const saveTimerRef = useRef<number | null>(null);
   const exportResetTimerRef = useRef<number | null>(null);
+  const optimizeAnchorRef = useRef<HTMLDivElement | null>(null);
   // Bumped on every editor onUpdate. Compared against `lastSnapshotVersionRef`
   // by the auto-snapshot interval to skip no-op snapshots.
   const editorVersionRef = useRef<number>(0);
@@ -765,6 +856,43 @@ export function DraftWorkspacePage(_props: Props) {
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [editor]);
+
+  // ⌘O / Ctrl+O toggles the + OPTIMIZE popover. Esc closes it. Cmd+O is the
+  // browser default for "open file" — we preventDefault to claim the key.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape' && optimizeOpen) {
+        e.preventDefault();
+        setOptimizeOpen(false);
+        return;
+      }
+      if (
+        (e.key === 'o' || e.key === 'O') &&
+        (e.metaKey || e.ctrlKey) &&
+        !e.shiftKey &&
+        !e.altKey
+      ) {
+        e.preventDefault();
+        setOptimizeOpen((open) => !open);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [optimizeOpen]);
+
+  // Click outside the popover closes it. Anchor-relative; we ignore clicks
+  // inside the anchor wrapper (which contains both the button and popover).
+  useEffect(() => {
+    if (!optimizeOpen) return;
+    const handler = (e: MouseEvent): void => {
+      const anchor = optimizeAnchorRef.current;
+      if (!anchor) return;
+      if (e.target instanceof Node && anchor.contains(e.target)) return;
+      setOptimizeOpen(false);
+    };
+    window.addEventListener('mousedown', handler);
+    return () => window.removeEventListener('mousedown', handler);
+  }, [optimizeOpen]);
 
   const orderedOutline = useMemo<OutlineEntry[]>(
     () => [
@@ -927,13 +1055,111 @@ export function DraftWorkspacePage(_props: Props) {
           ? MISSING ⌘M
         </button>
         <span className="editorial-po-draft-toolbar-sep">┃</span>
-        <button
-          type="button"
-          className="editorial-chip-button editorial-chip-button-primary"
-          disabled
+        <div
+          ref={optimizeAnchorRef}
+          className="editorial-po-draft-optimize-anchor"
         >
-          + OPTIMIZE ⌘O
-        </button>
+          <button
+            type="button"
+            className="editorial-chip-button editorial-chip-button-primary"
+            onClick={() => setOptimizeOpen((open) => !open)}
+            aria-haspopup="dialog"
+            aria-expanded={optimizeOpen}
+            disabled={!editor}
+          >
+            + OPTIMIZE ⌘O
+          </button>
+          {optimizeOpen ? (
+            <div
+              className="editorial-po-draft-optimize-popover"
+              role="dialog"
+              aria-label="Optimize draft"
+            >
+              <header className="editorial-po-draft-optimize-header">
+                <span className="editorial-po-draft-optimize-title">
+                  OPTIMIZE
+                </span>
+                <span className="editorial-po-draft-optimize-scope">
+                  · scope: {optimizeScopeLabel(cursor)}
+                </span>
+                <button
+                  type="button"
+                  className="editorial-po-draft-optimize-close"
+                  onClick={() => setOptimizeOpen(false)}
+                  aria-label="Close popover"
+                >
+                  ✕
+                </button>
+              </header>
+              <p className="editorial-po-draft-optimize-description">
+                {optimizeDescription(cursor)}
+              </p>
+              <section className="editorial-po-draft-optimize-stages">
+                <h4 className="editorial-po-draft-optimize-section-title">
+                  STAGES
+                </h4>
+                <ul className="editorial-po-draft-optimize-stage-list">
+                  {getOptimizeStages(cursor).map((stage) => (
+                    <li
+                      key={stage.id}
+                      className={`editorial-po-draft-optimize-stage${
+                        stage.active
+                          ? ''
+                          : ' editorial-po-draft-optimize-stage-inactive'
+                      }`}
+                    >
+                      <span
+                        className="editorial-po-draft-optimize-stage-mark"
+                        aria-hidden="true"
+                      >
+                        {stage.active ? '✓' : '◌'}
+                      </span>
+                      <span className="editorial-po-draft-optimize-stage-label">
+                        {stage.label}
+                      </span>
+                      <span className="editorial-po-draft-optimize-stage-desc">
+                        {stage.description}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+              <section className="editorial-po-draft-optimize-cost">
+                <h4 className="editorial-po-draft-optimize-section-title">
+                  COST PREVIEW
+                </h4>
+                <p className="editorial-po-draft-optimize-cost-line">
+                  {(() => {
+                    const c = optimizeCostEstimate(cursor);
+                    return `${c.tokens} · ${c.wall} · ${c.dollars}`;
+                  })()}
+                </p>
+                <p className="editorial-po-draft-optimize-cost-note">
+                  Estimates only — real numbers replace these once the
+                  scoring-pipeline metadata is wired up.
+                </p>
+              </section>
+              <footer className="editorial-po-draft-optimize-footer">
+                <button
+                  type="button"
+                  className="editorial-po-draft-optimize-customize"
+                  disabled
+                  title="Per-stage provider/threshold config — coming soon"
+                >
+                  CUSTOMIZE
+                </button>
+                <button
+                  type="button"
+                  className="editorial-po-draft-optimize-run"
+                  disabled
+                  title="LLM provider not yet wired into Draft at v0p"
+                >
+                  RUN ⌥↵
+                </button>
+              </footer>
+            </div>
+          ) : null}
+        </div>
         <span className="editorial-po-draft-scope">SCOPE: {scopeText}</span>
       </div>
 

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -6608,6 +6608,219 @@ a.editorial-phase-pill:hover {
   padding: 0 0.2rem;
 }
 
+/* + OPTIMIZE popover */
+
+.editorial-po-draft-optimize-anchor {
+  position: relative;
+  display: inline-flex;
+}
+
+.editorial-po-draft-optimize-popover {
+  position: absolute;
+  top: calc(100% + 0.45rem);
+  right: 0;
+  z-index: 30;
+  width: 380px;
+  background: #fff;
+  border: 1px solid #c9c0a8;
+  border-radius: 6px;
+  box-shadow:
+    0 12px 30px rgba(31, 28, 20, 0.18),
+    0 2px 6px rgba(31, 28, 20, 0.06);
+  display: flex;
+  flex-direction: column;
+  font-family: 'IBM Plex Mono', monospace;
+  color: #1f1c14;
+  overflow: hidden;
+  animation: editorial-po-draft-optimize-pop 120ms ease-out;
+}
+
+@keyframes editorial-po-draft-optimize-pop {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.editorial-po-draft-optimize-header {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px solid #e2dccc;
+  background: #f7f3e8;
+}
+
+.editorial-po-draft-optimize-title {
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: #1f1c14;
+}
+
+.editorial-po-draft-optimize-scope {
+  font-size: 0.66rem;
+  letter-spacing: 0.05em;
+  color: #6c6655;
+  text-transform: uppercase;
+}
+
+.editorial-po-draft-optimize-close {
+  margin-left: auto;
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: #6c6655;
+  line-height: 1;
+}
+
+.editorial-po-draft-optimize-close:hover {
+  color: #b7372a;
+}
+
+.editorial-po-draft-optimize-description {
+  margin: 0;
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid #e2dccc;
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: #1f1c14;
+}
+
+.editorial-po-draft-optimize-stages,
+.editorial-po-draft-optimize-cost {
+  padding: 0.55rem 0.75rem 0.6rem;
+  border-bottom: 1px solid #e2dccc;
+}
+
+.editorial-po-draft-optimize-section-title {
+  margin: 0 0 0.4rem;
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #6c6655;
+  font-weight: 500;
+}
+
+.editorial-po-draft-optimize-stage-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.editorial-po-draft-optimize-stage {
+  display: grid;
+  grid-template-columns: 1rem 6.5rem 1fr;
+  align-items: baseline;
+  gap: 0.4rem;
+  font-size: 0.7rem;
+  color: #1f1c14;
+}
+
+.editorial-po-draft-optimize-stage-inactive {
+  color: #8a8268;
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+}
+
+.editorial-po-draft-optimize-stage-mark {
+  font-size: 0.85rem;
+  color: #2e7d62;
+  text-align: center;
+}
+
+.editorial-po-draft-optimize-stage-inactive
+  .editorial-po-draft-optimize-stage-mark {
+  color: #c9c0a8;
+}
+
+.editorial-po-draft-optimize-stage-label {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.editorial-po-draft-optimize-stage-desc {
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-style: italic;
+  color: #5b5644;
+  font-size: 0.74rem;
+}
+
+.editorial-po-draft-optimize-stage-inactive
+  .editorial-po-draft-optimize-stage-desc {
+  color: #8a8268;
+}
+
+.editorial-po-draft-optimize-cost-line {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  font-weight: 500;
+  color: #1f1c14;
+}
+
+.editorial-po-draft-optimize-cost-note {
+  margin: 0.35rem 0 0;
+  font-size: 0.6rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #8a8268;
+  line-height: 1.4;
+}
+
+.editorial-po-draft-optimize-footer {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.75rem;
+  background: #fbf8f2;
+}
+
+.editorial-po-draft-optimize-customize {
+  background: none;
+  border: 1px solid #c9c0a8;
+  border-radius: 3px;
+  padding: 0.25rem 0.7rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #5b5644;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.editorial-po-draft-optimize-run {
+  margin-left: auto;
+  background: #b7372a;
+  border: 1px solid #b7372a;
+  border-radius: 3px;
+  padding: 0.3rem 0.9rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #fff;
+  font-weight: 500;
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.editorial-po-draft-optimize-run:not(:disabled):hover {
+  background: #9c2d22;
+  border-color: #9c2d22;
+}
+
 .editorial-po-draft-scope {
   margin-left: auto;
   font-family: 'IBM Plex Mono', monospace;


### PR DESCRIPTION
## Summary

Wires the + OPTIMIZE popover per design/04_draft.md §5. The popover is fully visual at v0p — the RUN button stays disabled until an LLM provider is wired into Draft. This establishes the UX surface and keyboard shortcut so the run flow can drop in later without re-litigating the visual design.

## Behavior

- Click `+ OPTIMIZE` button → popover toggles
- `⌘O` / `Ctrl+O` → popover toggles (preventDefault on browser's "open file")
- `Esc` → close
- Click outside the anchor wrapper → close

## Scope-aware content

| Scope | Description | Active stages | Cost |
|---|---|---|---|
| `WHOLE DRAFT` | Multi-pass; research + autonovel + panel + propose | all 4 ✓ | ≈28K · 12S · ≈$0.08 |
| `PARAGRAPH N` | Targeted optimize on ¶N | autonovel + propose only | ≈3K · 3S · ≈$0.01 |
| `SELECTION` | Optimize selection: 2–3 phrasings | autonovel + propose only | ≈2K · 2S · ≈$0.01 |

Skipped stages render with `◌` mark + strikethrough per spec §5.3.

## v0p disabled actions (with tooltip context)

- `CUSTOMIZE` — \"Per-stage provider/threshold config — coming soon\"
- `RUN ⌥↵` — \"LLM provider not yet wired into Draft at v0p\"

## Test plan

- [ ] Click `+ OPTIMIZE`. Popover opens anchored under the button.
- [ ] Press `⌘O` (or Ctrl+O on non-Mac). Popover toggles. No browser \"open file\" dialog.
- [ ] Press `Esc`. Popover closes.
- [ ] Click outside the popover. Popover closes.
- [ ] Click in the editor body. Status bar updates. Re-open popover; description + stages + cost adapt to PARAGRAPH N scope.
- [ ] Drag-select across paragraphs. Re-open popover; description shows SELECTION variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)