### PR TITLE
feat: Phase 04 DRAFT sub-meta polish — eyebrow + SSR + GATES + ← BACK

### DIFF
--- a/webapp/src/pages/DraftWorkspacePage.tsx
+++ b/webapp/src/pages/DraftWorkspacePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
 import {
   useEditor,
   EditorContent,
@@ -11,13 +12,19 @@ import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
 import { serializeDocToMarkdown, type JSONNode } from '../lib/markdown-export';
 
 // ───────────────────────────────────────────────────────────────────────────
-// Phase 04 DRAFT — + OPTIMIZE popover UI shell.
-// Wires the popover per design/04_draft.md §5: scope-aware description,
-// 4-stage list (AUTORESEARCH / AUTONOVEL / PANEL PASS / PROPOSE 2–3), mock
-// cost preview, CUSTOMIZE / RUN footer. RUN is visible-but-disabled at v0p
-// because no LLM provider is wired into Draft yet — the popover establishes
-// the UX surface and keyboard shortcut (⌘O) so the run flow can drop in
-// later without re-litigating the visual design.
+// Phase 04 DRAFT — sub-meta bar polish.
+// Adds the eyebrow row (`UNDER OUTLINE: <title> · N POINTS`), SSR aggregate +
+// GATES indicator on the main meta row, and a `← BACK` chip linking back to
+// the Points + Outline workspace per design/04_draft.md §3.
+//
+// Outline title is hardcoded to the Embracer fixture for v0p; once the
+// Outline workspace stores a topic title in localStorage, plumb it through
+// here.
+//
+// SSR aggregate is computed as the mean of outline-point scores (no real
+// scoring pipeline at v0p). GATES indicator is heuristic at v0p: ✓ when the
+// SSR mean ≥ 6.0 and no point dips below 5.0; ⚠ otherwise. Real gate logic
+// replaces this once gate thresholds land in Setup.
 //
 // Earlier cuts in this page:
 //   • PR #269: three-column shell + Tiptap editor + outline rail + word count
@@ -25,6 +32,7 @@ import { serializeDocToMarkdown, type JSONNode } from '../lib/markdown-export';
 //   • PR #271: Versions tab + ⌘S manual save + 60s autosave snapshots
 //   • PR #272: ↑ COPY MD export (Tiptap-JSON → markdown serializer)
 //   • PR #273: Sources tab — fixture-only cite tracker
+//   • PR #274: + OPTIMIZE popover UI shell (RUN disabled at v0p)
 //
 // Still deferred (per design/04_draft.md):
 // - Panel chat scoped to active segment (right rail)
@@ -36,6 +44,7 @@ import { serializeDocToMarkdown, type JSONNode } from '../lib/markdown-export';
 // - Compressed-diff snapshot storage (currently full JSON per snapshot)
 // - Real Sources data: currently fixture-only; cite-on-click into editor
 //   + per-segment source filter deferred to autoresearch wiring
+// - Real outline title + real GATES thresholds from Setup
 //
 // NOTE on the Outline-rail data source: the Points workspace owns its
 // state in its own localStorage envelope. To avoid threading a shared
@@ -721,6 +730,30 @@ function optimizeCostEstimate(cursor: CursorState): OptimizeCostEstimate {
   return { tokens: '≈28K TOKENS', wall: '12S WALL', dollars: '≈$0.08' };
 }
 
+// Fixture outline title for the Embracer working example. Will be replaced
+// with `outline.compiled_truth.title` from the Points + Outline workspace
+// once that field is plumbed through localStorage.
+const FIXTURE_OUTLINE_TITLE =
+  "How Embracer's $2.1B writedown changed indie publishing terms";
+
+type GateStatus = 'pass' | 'warn' | 'unknown';
+
+function computeSsrAggregate(orderedOutline: OutlineEntry[]): number | null {
+  if (orderedOutline.length === 0) return null;
+  const sum = orderedOutline.reduce((acc, p) => acc + p.score, 0);
+  return sum / orderedOutline.length;
+}
+
+function computeGateStatus(
+  orderedOutline: OutlineEntry[],
+  ssr: number | null,
+): GateStatus {
+  if (ssr === null) return 'unknown';
+  if (ssr < 6.0) return 'warn';
+  if (orderedOutline.some((p) => p.score < 5.0)) return 'warn';
+  return 'pass';
+}
+
 const WORD_TARGET_MIN = 1200;
 const WORD_TARGET_MAX = 1400;
 
@@ -914,6 +947,14 @@ export function DraftWorkspacePage(_props: Props) {
   );
 
   const totalOutlinePoints = orderedOutline.length;
+  const ssrAggregate = useMemo(
+    () => computeSsrAggregate(orderedOutline),
+    [orderedOutline],
+  );
+  const gateStatus = useMemo(
+    () => computeGateStatus(orderedOutline, ssrAggregate),
+    [orderedOutline, ssrAggregate],
+  );
   const scopeText = scopeChipText(cursor);
   const statusText = activeStatusText(cursor, orderedOutline, activePoint);
 
@@ -1007,10 +1048,52 @@ export function DraftWorkspacePage(_props: Props) {
     <div className="editorial-room">
       <EditorialPhaseStrip activePhase="draft" />
 
+      <div className="editorial-po-draft-meta editorial-po-draft-meta-eyebrow">
+        <span className="editorial-po-draft-meta-eyebrow-label">
+          UNDER OUTLINE:
+        </span>
+        <Link
+          to="/editorial/points-outline"
+          className="editorial-po-draft-meta-title"
+        >
+          {FIXTURE_OUTLINE_TITLE}
+        </Link>
+        <span className="editorial-po-meta-sep">·</span>
+        <span>
+          {totalOutlinePoints} {totalOutlinePoints === 1 ? 'POINT' : 'POINTS'}
+        </span>
+      </div>
+
       <div className="editorial-po-draft-meta">
         <span className={`editorial-po-draft-words ${wordTargetStatus}`}>
           {wordCount.toLocaleString()} / {WORD_TARGET_MIN.toLocaleString()}–
           {WORD_TARGET_MAX.toLocaleString()} WORDS
+        </span>
+        <span className="editorial-po-meta-sep">·</span>
+        <span
+          className={`editorial-po-draft-ssr${
+            ssrAggregate === null ? ' editorial-po-draft-ssr-empty' : ''
+          }`}
+          title="Mean of outline-point scores (no scoring pipeline at v0p)"
+        >
+          {ssrAggregate === null ? '—.— SSR' : `${ssrAggregate.toFixed(1)} SSR`}
+        </span>
+        <span className="editorial-po-meta-sep">·</span>
+        <span
+          className={`editorial-po-draft-gates editorial-po-draft-gates-${gateStatus}`}
+          title={
+            gateStatus === 'pass'
+              ? 'Heuristic gate: all outline scores ≥ 5.0 and SSR mean ≥ 6.0 (v0p heuristic)'
+              : gateStatus === 'warn'
+                ? 'Heuristic gate: SSR mean below 6.0 or a point below 5.0 (v0p heuristic)'
+                : 'No outline points yet — gate status unknown'
+          }
+        >
+          {gateStatus === 'pass'
+            ? '✓ GATES'
+            : gateStatus === 'warn'
+              ? '⚠ GATES'
+              : '— GATES'}
         </span>
         <span className="editorial-po-meta-sep">·</span>
         <span className="editorial-po-draft-autosave">
@@ -1036,6 +1119,13 @@ export function DraftWorkspacePage(_props: Props) {
           {exportState === 'error' && 'COPY FAILED'}
           {exportState === 'idle' && '↑ COPY MD'}
         </button>
+        <Link
+          to="/editorial/points-outline"
+          className="editorial-po-draft-back"
+          title="Back to Points + Outline"
+        >
+          ← BACK
+        </Link>
       </div>
 
       <div className="editorial-po-draft-toolbar">

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -6549,6 +6549,83 @@ a.editorial-phase-pill:hover {
   color: #6c6655;
 }
 
+.editorial-po-draft-meta-eyebrow {
+  border-bottom: none;
+  padding-bottom: 0;
+  font-size: 0.6rem;
+  color: #6c6655;
+}
+
+.editorial-po-draft-meta-eyebrow-label {
+  color: #8a8268;
+  letter-spacing: 0.08em;
+}
+
+.editorial-po-draft-meta-title {
+  color: #1f1c14;
+  text-decoration: none;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-size: 0.78rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 60ch;
+}
+
+.editorial-po-draft-meta-title:hover {
+  color: #b7372a;
+  text-decoration: underline;
+}
+
+.editorial-po-draft-ssr,
+.editorial-po-draft-gates {
+  font-weight: 500;
+}
+
+.editorial-po-draft-ssr-empty {
+  color: #8a8268;
+  font-weight: 400;
+}
+
+.editorial-po-draft-gates-pass {
+  color: #2e7d62;
+}
+
+.editorial-po-draft-gates-warn {
+  color: #c98a2c;
+}
+
+.editorial-po-draft-gates-unknown {
+  color: #8a8268;
+  font-weight: 400;
+}
+
+.editorial-po-draft-back {
+  background: none;
+  border: 1px solid #c9c0a8;
+  border-radius: 3px;
+  padding: 0.2rem 0.6rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #5b5644;
+  text-decoration: none;
+  transition:
+    background 100ms,
+    color 100ms,
+    border-color 100ms;
+}
+
+.editorial-po-draft-back:hover {
+  background: #fff8e7;
+  border-color: #b7372a;
+  color: #b7372a;
+}
+
 .editorial-po-draft-export {
   margin-left: auto;
   background: none;
@@ -6836,7 +6913,7 @@ a.editorial-phase-pill:hover {
 .editorial-po-draft-grid {
   display: grid;
   grid-template-columns: 220px minmax(0, 1fr) 280px;
-  height: calc(100vh - 170px);
+  height: calc(100vh - 200px);
   background: #fbf8f2;
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary

Sub-meta bar to spec parity with design/04_draft.md §3.

## What's new

- **Eyebrow row** — `UNDER OUTLINE: <title> · N POINTS` with the title clickable back to Points + Outline
- **SSR aggregate** — mean of outline-point scores, `N.N SSR`
- **GATES indicator** — three states with tooltips explaining the v0p heuristic:
  | State | Trigger | Color |
  |---|---|---|
  | `✓ GATES` | SSR ≥ 6.0 AND every point ≥ 5.0 | green |
  | `⚠ GATES` | SSR < 6.0 OR any point < 5.0 | amber |
  | `— GATES` | no outline points | muted |
- **← BACK chip** — right-aligned, routes back to Points + Outline

## v0p caveats (documented in code + tooltips)

- Outline title is hardcoded to the Embracer fixture; will load from `outline.compiled_truth.title` once that's plumbed
- GATES is heuristic; real thresholds replace the math when Setup wires gates

## Test plan

- [ ] Eyebrow row shows under the phase strip with the working title and `5 POINTS`
- [ ] Click the title or `← BACK` chip → routes to `/editorial/points-outline`
- [ ] Main meta row reads: `1,XXX / 1,200–1,400 WORDS · 7.X SSR · ✓ GATES · LAST AUTOSAVE … · COPY MD · BACK`
- [ ] In Points workspace, drop a Point's score below 5.0 → reload Draft → GATES flips to `⚠`
- [ ] Tooltip on each indicator explains the v0p computation

🤖 Generated with [Claude Code](https://claude.com/claude-code)