### PR TITLE
feat: 0p-b1 Markdown round-trip parser + ↓ PASTE MD button

### DIFF
--- a/webapp/src/lib/markdown-import.test.ts
+++ b/webapp/src/lib/markdown-import.test.ts
@@ -1,0 +1,433 @@
+import { describe, expect, it } from 'vitest';
+
+import { serializeDocToMarkdown, type JSONNode } from './markdown-export';
+import { parseInline, parseMarkdownToDoc } from './markdown-import';
+
+describe('parseMarkdownToDoc — block coverage', () => {
+  it('returns an empty doc for empty input', () => {
+    expect(parseMarkdownToDoc('')).toEqual({ type: 'doc', content: [] });
+  });
+
+  it('parses a heading with the right level', () => {
+    expect(parseMarkdownToDoc('## Hello')).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 2 },
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      ],
+    });
+  });
+
+  it('parses paragraphs separated by blank lines', () => {
+    const out = parseMarkdownToDoc('First paragraph.\n\nSecond paragraph.');
+    expect(out.content).toEqual([
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'First paragraph.' }],
+      },
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Second paragraph.' }],
+      },
+    ]);
+  });
+
+  it('parses a horizontal rule', () => {
+    const out = parseMarkdownToDoc('above\n\n---\n\nbelow');
+    expect(out.content).toEqual([
+      { type: 'paragraph', content: [{ type: 'text', text: 'above' }] },
+      { type: 'horizontalRule' },
+      { type: 'paragraph', content: [{ type: 'text', text: 'below' }] },
+    ]);
+  });
+
+  it('parses a bullet list', () => {
+    const out = parseMarkdownToDoc('- one\n- two\n- three');
+    expect(out.content?.[0].type).toBe('bulletList');
+    expect(out.content?.[0].content).toHaveLength(3);
+  });
+
+  it('parses an ordered list and preserves the start index', () => {
+    const out = parseMarkdownToDoc('3. three\n4. four');
+    expect(out.content?.[0]).toEqual({
+      type: 'orderedList',
+      attrs: { start: 3 },
+      content: [
+        {
+          type: 'listItem',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'three' }],
+            },
+          ],
+        },
+        {
+          type: 'listItem',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'four' }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('parses a blockquote with multiple lines', () => {
+    const out = parseMarkdownToDoc('> First.\n>\n> Second.');
+    const quote = out.content?.[0];
+    expect(quote?.type).toBe('blockquote');
+    expect(quote?.content).toHaveLength(2);
+    expect(quote?.content?.[0].type).toBe('paragraph');
+  });
+
+  it('parses a fenced code block with language', () => {
+    const out = parseMarkdownToDoc('```ts\nconst x = 1;\n```');
+    expect(out.content?.[0]).toEqual({
+      type: 'codeBlock',
+      attrs: { language: 'ts' },
+      content: [{ type: 'text', text: 'const x = 1;' }],
+    });
+  });
+
+  it('parses a fenced code block without language', () => {
+    const out = parseMarkdownToDoc('```\nplain\n```');
+    expect(out.content?.[0]).toEqual({
+      type: 'codeBlock',
+      attrs: { language: null },
+      content: [{ type: 'text', text: 'plain' }],
+    });
+  });
+});
+
+describe('parseInline — mark coverage', () => {
+  it('returns a plain text node for unmarked content', () => {
+    expect(parseInline('hello world')).toEqual([
+      { type: 'text', text: 'hello world' },
+    ]);
+  });
+
+  it('parses a single bold span', () => {
+    expect(parseInline('say **hi** there')).toEqual([
+      { type: 'text', text: 'say ' },
+      { type: 'text', text: 'hi', marks: [{ type: 'bold' }] },
+      { type: 'text', text: ' there' },
+    ]);
+  });
+
+  it('parses a single italic span', () => {
+    expect(parseInline('be *brave*')).toEqual([
+      { type: 'text', text: 'be ' },
+      { type: 'text', text: 'brave', marks: [{ type: 'italic' }] },
+    ]);
+  });
+
+  it('parses an inline code span', () => {
+    expect(parseInline('use `editor`')).toEqual([
+      { type: 'text', text: 'use ' },
+      { type: 'text', text: 'editor', marks: [{ type: 'code' }] },
+    ]);
+  });
+
+  it('parses a strike span', () => {
+    expect(parseInline('not ~~old~~ new')).toEqual([
+      { type: 'text', text: 'not ' },
+      { type: 'text', text: 'old', marks: [{ type: 'strike' }] },
+      { type: 'text', text: ' new' },
+    ]);
+  });
+
+  it('parses a link', () => {
+    expect(parseInline('see [docs](https://example.com)')).toEqual([
+      { type: 'text', text: 'see ' },
+      {
+        type: 'text',
+        text: 'docs',
+        marks: [{ type: 'link', attrs: { href: 'https://example.com' } }],
+      },
+    ]);
+  });
+
+  it('does not split mark inside inline code', () => {
+    expect(parseInline('`**not bold**`')).toEqual([
+      { type: 'text', text: '**not bold**', marks: [{ type: 'code' }] },
+    ]);
+  });
+});
+
+describe('round-trip — Tiptap → MD → Tiptap', () => {
+  function rt(doc: JSONNode): JSONNode {
+    const md = serializeDocToMarkdown(doc);
+    return parseMarkdownToDoc(md);
+  }
+
+  it('round-trips a single paragraph', () => {
+    const doc: JSONNode = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Just one paragraph.' }],
+        },
+      ],
+    };
+    expect(rt(doc)).toEqual(doc);
+  });
+
+  it('round-trips multiple paragraphs', () => {
+    const doc: JSONNode = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'First.' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Second.' }] },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Third.' }] },
+      ],
+    };
+    expect(rt(doc)).toEqual(doc);
+  });
+
+  it('round-trips headings + paragraphs', () => {
+    const doc: JSONNode = {
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 1 },
+          content: [{ type: 'text', text: 'Title' }],
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Body line.' }],
+        },
+        {
+          type: 'heading',
+          attrs: { level: 2 },
+          content: [{ type: 'text', text: 'Section' }],
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'More body.' }],
+        },
+      ],
+    };
+    expect(rt(doc)).toEqual(doc);
+  });
+
+  it('round-trips a bullet list', () => {
+    const doc: JSONNode = {
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'one' }],
+                },
+              ],
+            },
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'two' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(rt(doc)).toEqual(doc);
+  });
+
+  it('round-trips an ordered list with custom start', () => {
+    const doc: JSONNode = {
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          attrs: { start: 5 },
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'five' }],
+                },
+              ],
+            },
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'six' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(rt(doc)).toEqual(doc);
+  });
+
+  it('round-trips a code block', () => {
+    const doc: JSONNode = {
+      type: 'doc',
+      content: [
+        {
+          type: 'codeBlock',
+          attrs: { language: 'ts' },
+          content: [{ type: 'text', text: 'const x = 1;\nconst y = 2;' }],
+        },
+      ],
+    };
+    expect(rt(doc)).toEqual(doc);
+  });
+
+  it('round-trips a horizontal rule', () => {
+    const doc: JSONNode = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'above' }] },
+        { type: 'horizontalRule' },
+        { type: 'paragraph', content: [{ type: 'text', text: 'below' }] },
+      ],
+    };
+    expect(rt(doc)).toEqual(doc);
+  });
+
+  it('round-trips single inline marks (bold, italic, code, strike)', () => {
+    const doc: JSONNode = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'plain ' },
+            { type: 'text', text: 'bold', marks: [{ type: 'bold' }] },
+            { type: 'text', text: ' more ' },
+            { type: 'text', text: 'italic', marks: [{ type: 'italic' }] },
+            { type: 'text', text: ' more ' },
+            { type: 'text', text: 'code', marks: [{ type: 'code' }] },
+            { type: 'text', text: ' more ' },
+            { type: 'text', text: 'strike', marks: [{ type: 'strike' }] },
+          ],
+        },
+      ],
+    };
+    expect(rt(doc)).toEqual(doc);
+  });
+
+  it('round-trips a link', () => {
+    const doc: JSONNode = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'see ' },
+            {
+              type: 'text',
+              text: 'docs',
+              marks: [{ type: 'link', attrs: { href: 'https://example.com' } }],
+            },
+          ],
+        },
+      ],
+    };
+    expect(rt(doc)).toEqual(doc);
+  });
+
+  it('round-trips the kickoff Embracer-style mixed document', () => {
+    const doc: JSONNode = {
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 1 },
+          content: [{ type: 'text', text: 'Embracer reclassification' }],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'When Embracer wrote down 2.1B last quarter, indie studios noticed.',
+            },
+          ],
+        },
+        {
+          type: 'heading',
+          attrs: { level: 2 },
+          content: [{ type: 'text', text: 'Three structural shifts' }],
+        },
+        {
+          type: 'orderedList',
+          attrs: { start: 1 },
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'MG reclassification' }],
+                },
+              ],
+            },
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'Cohort split' }],
+                },
+              ],
+            },
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'Recoupment creep' }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'blockquote',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'The reclassification IS the story.',
+                },
+              ],
+            },
+          ],
+        },
+        { type: 'horizontalRule' },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Closing thought.' }],
+        },
+      ],
+    };
+    expect(rt(doc)).toEqual(doc);
+  });
+});

--- a/webapp/src/lib/markdown-import.ts
+++ b/webapp/src/lib/markdown-import.ts
@@ -1,0 +1,349 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Markdown → Tiptap-JSON parser (StarterKit subset).
+//
+// Companion to `markdown-export.ts`. The Editorial Room Phase 04 DRAFT
+// flow runs Tiptap → MD on export; this module covers the inverse so we
+// can prove round-trip viability for the 0p-b1 spike (kickoff item 5).
+//
+// Block coverage:
+//   doc, paragraph, heading (#–######), blockquote (`> `),
+//   codeBlock (fenced ```), bulletList (`-`/`*`/`+`), orderedList (`N.`),
+//   horizontalRule (`---`)
+//
+// Inline coverage (best-effort, single-pass):
+//   bold `**text**`, italic `*text*`, strike `~~text~~`,
+//   code `\`text\``, link `[text](url)`
+//
+// Caveats — the parser is intentionally small and prioritizes block
+// fidelity for the spike. Known rough edges:
+//   - Nested combined marks like `***bold-italic***` survive the parse but
+//     may not produce the exact same JSON as the original Tiptap doc.
+//   - Nested lists are not parsed (each list item is treated as a
+//     single paragraph).
+//   - Tables are not in StarterKit, so out of scope.
+// Document round-trip results live in markdown-export.test.ts.
+// ───────────────────────────────────────────────────────────────────────────
+
+import type { JSONMark, JSONNode } from './markdown-export';
+
+const HEADING_RE = /^(#{1,6})\s+(.*)$/;
+const HR_RE = /^(?:-{3,}|\*{3,}|_{3,})$/;
+const FENCE_RE = /^```\s*([a-zA-Z0-9_+-]*)\s*$/;
+const BLOCKQUOTE_RE = /^>\s?(.*)$/;
+const BULLET_RE = /^[-*+]\s+(.*)$/;
+const ORDERED_RE = /^(\d+)\.\s+(.*)$/;
+const LINK_RE = /^\[([^\]]+)\]\(([^)\s]+)\)/;
+
+function isBlockStart(line: string): boolean {
+  return (
+    HEADING_RE.test(line) ||
+    HR_RE.test(line.trim()) ||
+    FENCE_RE.test(line) ||
+    BLOCKQUOTE_RE.test(line) ||
+    BULLET_RE.test(line) ||
+    ORDERED_RE.test(line)
+  );
+}
+
+function pushText(out: JSONNode[], text: string, marks?: JSONMark[]): void {
+  if (text === '') return;
+  if (!marks || marks.length === 0) {
+    const last = out[out.length - 1];
+    if (last && last.type === 'text' && !last.marks) {
+      last.text = (last.text ?? '') + text;
+      return;
+    }
+    out.push({ type: 'text', text });
+    return;
+  }
+  out.push({ type: 'text', text, marks });
+}
+
+function withAddedMark(node: JSONNode, mark: JSONMark): JSONNode {
+  if (node.type !== 'text') return node;
+  const existing = node.marks ?? [];
+  // Don't duplicate the same mark twice.
+  if (existing.some((m) => m.type === mark.type)) return node;
+  return { ...node, marks: [...existing, mark] };
+}
+
+export function parseInline(text: string): JSONNode[] {
+  const out: JSONNode[] = [];
+  let pos = 0;
+  while (pos < text.length) {
+    const char = text[pos];
+
+    // Inline code — never recurse into mark parsing inside a code span.
+    if (char === '`') {
+      const end = text.indexOf('`', pos + 1);
+      if (end !== -1) {
+        out.push({
+          type: 'text',
+          text: text.slice(pos + 1, end),
+          marks: [{ type: 'code' }],
+        });
+        pos = end + 1;
+        continue;
+      }
+    }
+
+    // Strike — `~~text~~`.
+    if (char === '~' && text[pos + 1] === '~') {
+      const end = text.indexOf('~~', pos + 2);
+      if (end !== -1) {
+        const inner = parseInline(text.slice(pos + 2, end));
+        for (const node of inner) {
+          out.push(withAddedMark(node, { type: 'strike' }));
+        }
+        pos = end + 2;
+        continue;
+      }
+    }
+
+    // Bold — `**text**`. Match before italic so `**` doesn't get eaten by
+    // the italic path.
+    if (char === '*' && text[pos + 1] === '*') {
+      const end = text.indexOf('**', pos + 2);
+      if (end !== -1 && end > pos + 2) {
+        const inner = parseInline(text.slice(pos + 2, end));
+        for (const node of inner) {
+          out.push(withAddedMark(node, { type: 'bold' }));
+        }
+        pos = end + 2;
+        continue;
+      }
+    }
+
+    // Italic — `*text*`. Skip if next char is `*` (would be bold) or
+    // previous char is `*` (mid-bold-token).
+    if (char === '*') {
+      let scan = pos + 1;
+      while (scan < text.length && text[scan] !== '*') scan++;
+      if (scan < text.length && scan > pos + 1) {
+        const inner = parseInline(text.slice(pos + 1, scan));
+        for (const node of inner) {
+          out.push(withAddedMark(node, { type: 'italic' }));
+        }
+        pos = scan + 1;
+        continue;
+      }
+    }
+
+    // Link — `[text](url)`.
+    if (char === '[') {
+      const slice = text.slice(pos);
+      const m = LINK_RE.exec(slice);
+      if (m) {
+        out.push({
+          type: 'text',
+          text: m[1],
+          marks: [{ type: 'link', attrs: { href: m[2] } }],
+        });
+        pos += m[0].length;
+        continue;
+      }
+    }
+
+    // Hard break — `  \n` collapsed to `<br>` not currently supported in
+    // single-line inline parse (the line-break is consumed by the block
+    // parser already). Plain text fallback.
+
+    // Default: accumulate until next special character.
+    const SPECIAL = '`*~[';
+    let plainEnd = pos + 1;
+    while (plainEnd < text.length && !SPECIAL.includes(text[plainEnd])) {
+      plainEnd++;
+    }
+    pushText(out, text.slice(pos, plainEnd));
+    pos = plainEnd;
+  }
+  return out;
+}
+
+function takeListBlock(
+  lines: string[],
+  startIdx: number,
+  ordered: boolean,
+): { node: JSONNode; nextIdx: number } {
+  const items: JSONNode[] = [];
+  let i = startIdx;
+  let firstStart = 1;
+  while (i < lines.length) {
+    const m = ordered ? ORDERED_RE.exec(lines[i]) : BULLET_RE.exec(lines[i]);
+    if (!m) break;
+    if (ordered && items.length === 0) {
+      firstStart = parseInt(m[1], 10);
+    }
+    const itemText = ordered ? m[2] : m[1];
+    items.push({
+      type: 'listItem',
+      content: [
+        {
+          type: 'paragraph',
+          content: parseInline(itemText),
+        },
+      ],
+    });
+    i++;
+  }
+  const node: JSONNode = ordered
+    ? {
+        type: 'orderedList',
+        attrs: { start: firstStart },
+        content: items,
+      }
+    : {
+        type: 'bulletList',
+        content: items,
+      };
+  return { node, nextIdx: i };
+}
+
+function takeBlockquote(
+  lines: string[],
+  startIdx: number,
+): { node: JSONNode; nextIdx: number } {
+  const quoteLines: string[] = [];
+  let i = startIdx;
+  while (i < lines.length) {
+    const m = BLOCKQUOTE_RE.exec(lines[i]);
+    if (m) {
+      quoteLines.push(m[1]);
+      i++;
+      continue;
+    }
+    if (lines[i].trim() === '' && i + 1 < lines.length) {
+      const next = BLOCKQUOTE_RE.exec(lines[i + 1]);
+      if (next) {
+        quoteLines.push('');
+        i++;
+        continue;
+      }
+    }
+    break;
+  }
+  const inner = parseMarkdownToDoc(quoteLines.join('\n'));
+  return {
+    node: { type: 'blockquote', content: inner.content ?? [] },
+    nextIdx: i,
+  };
+}
+
+function takeCodeBlock(
+  lines: string[],
+  startIdx: number,
+): { node: JSONNode; nextIdx: number } {
+  const fence = FENCE_RE.exec(lines[startIdx]);
+  const language = fence ? fence[1] : '';
+  const codeLines: string[] = [];
+  let i = startIdx + 1;
+  while (i < lines.length && !/^```\s*$/.test(lines[i])) {
+    codeLines.push(lines[i]);
+    i++;
+  }
+  // Skip closing fence if present.
+  if (i < lines.length) i++;
+  const text = codeLines.join('\n');
+  const content: JSONNode[] = text === '' ? [] : [{ type: 'text', text }];
+  return {
+    node: {
+      type: 'codeBlock',
+      attrs: language ? { language } : { language: null },
+      content,
+    },
+    nextIdx: i,
+  };
+}
+
+function takeParagraph(
+  lines: string[],
+  startIdx: number,
+): { node: JSONNode; nextIdx: number } {
+  const paraLines: string[] = [lines[startIdx]];
+  let i = startIdx + 1;
+  while (
+    i < lines.length &&
+    lines[i].trim() !== '' &&
+    !isBlockStart(lines[i])
+  ) {
+    paraLines.push(lines[i]);
+    i++;
+  }
+  return {
+    node: {
+      type: 'paragraph',
+      content: parseInline(paraLines.join(' ')),
+    },
+    nextIdx: i,
+  };
+}
+
+export function parseMarkdownToDoc(md: string): JSONNode {
+  const lines = md.split('\n');
+  // Strip trailing-only empty lines so we don't generate empty trailing
+  // paragraphs but keep internal blank lines intact for block grouping.
+  while (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+
+  const blocks: JSONNode[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.trim() === '') {
+      i++;
+      continue;
+    }
+
+    const headingMatch = HEADING_RE.exec(line);
+    if (headingMatch) {
+      blocks.push({
+        type: 'heading',
+        attrs: { level: headingMatch[1].length },
+        content: parseInline(headingMatch[2]),
+      });
+      i++;
+      continue;
+    }
+
+    if (HR_RE.test(line.trim())) {
+      blocks.push({ type: 'horizontalRule' });
+      i++;
+      continue;
+    }
+
+    if (FENCE_RE.test(line)) {
+      const { node, nextIdx } = takeCodeBlock(lines, i);
+      blocks.push(node);
+      i = nextIdx;
+      continue;
+    }
+
+    if (BLOCKQUOTE_RE.test(line)) {
+      const { node, nextIdx } = takeBlockquote(lines, i);
+      blocks.push(node);
+      i = nextIdx;
+      continue;
+    }
+
+    if (BULLET_RE.test(line)) {
+      const { node, nextIdx } = takeListBlock(lines, i, false);
+      blocks.push(node);
+      i = nextIdx;
+      continue;
+    }
+
+    if (ORDERED_RE.test(line)) {
+      const { node, nextIdx } = takeListBlock(lines, i, true);
+      blocks.push(node);
+      i = nextIdx;
+      continue;
+    }
+
+    const { node, nextIdx } = takeParagraph(lines, i);
+    blocks.push(node);
+    i = nextIdx;
+  }
+
+  return { type: 'doc', content: blocks };
+}

--- a/webapp/src/pages/DraftWorkspacePage.tsx
+++ b/webapp/src/pages/DraftWorkspacePage.tsx
@@ -10,6 +10,7 @@ import StarterKit from '@tiptap/starter-kit';
 
 import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
 import { serializeDocToMarkdown, type JSONNode } from '../lib/markdown-export';
+import { parseMarkdownToDoc } from '../lib/markdown-import';
 
 // ───────────────────────────────────────────────────────────────────────────
 // Phase 04 DRAFT — Panel chat right rail (mock turns).
@@ -906,9 +907,13 @@ export function DraftWorkspacePage(_props: Props) {
   const [exportState, setExportState] = useState<'idle' | 'copied' | 'error'>(
     'idle',
   );
+  const [importState, setImportState] = useState<'idle' | 'pasted' | 'error'>(
+    'idle',
+  );
   const [optimizeOpen, setOptimizeOpen] = useState<boolean>(false);
   const saveTimerRef = useRef<number | null>(null);
   const exportResetTimerRef = useRef<number | null>(null);
+  const importResetTimerRef = useRef<number | null>(null);
   const optimizeAnchorRef = useRef<HTMLDivElement | null>(null);
   // Bumped on every editor onUpdate. Compared against `lastSnapshotVersionRef`
   // by the auto-snapshot interval to skip no-op snapshots.
@@ -948,6 +953,9 @@ export function DraftWorkspacePage(_props: Props) {
       }
       if (exportResetTimerRef.current !== null) {
         window.clearTimeout(exportResetTimerRef.current);
+      }
+      if (importResetTimerRef.current !== null) {
+        window.clearTimeout(importResetTimerRef.current);
       }
     };
   }, []);
@@ -1149,6 +1157,46 @@ export function DraftWorkspacePage(_props: Props) {
     }
   };
 
+  const handleImportMarkdown = async (): Promise<void> => {
+    if (!editor) return;
+    const finish = (state: 'pasted' | 'error'): void => {
+      setImportState(state);
+      if (importResetTimerRef.current !== null) {
+        window.clearTimeout(importResetTimerRef.current);
+      }
+      importResetTimerRef.current = window.setTimeout(() => {
+        setImportState('idle');
+        importResetTimerRef.current = null;
+      }, 1500);
+    };
+    try {
+      if (
+        typeof navigator === 'undefined' ||
+        !navigator.clipboard ||
+        typeof navigator.clipboard.readText !== 'function'
+      ) {
+        finish('error');
+        return;
+      }
+      const md = await navigator.clipboard.readText();
+      if (!md.trim()) {
+        finish('error');
+        return;
+      }
+      // Capture pre-import snapshot so the user can recover via Versions.
+      const preImport = createVersionEntry(editor, 'named', 'manual_save');
+      setVersions((prev) => pruneAutoVersions([...prev, preImport]));
+      const parsed = parseMarkdownToDoc(md);
+      editor.commands.setContent(parsed as Content);
+      saveDraftContent(parsed);
+      setLastSavedAt(new Date());
+      lastSnapshotVersionRef.current = editorVersionRef.current;
+      finish('pasted');
+    } catch {
+      finish('error');
+    }
+  };
+
   const handleRestoreVersion = (version: VersionEntry): void => {
     if (!editor) return;
     // Per design/04_draft.md §10.4: capture pre-restore state as a named
@@ -1250,6 +1298,24 @@ export function DraftWorkspacePage(_props: Props) {
           {exportState === 'copied' && 'COPIED ✓'}
           {exportState === 'error' && 'COPY FAILED'}
           {exportState === 'idle' && '↑ COPY MD'}
+        </button>
+        <button
+          type="button"
+          className={`editorial-po-draft-import${
+            importState === 'pasted' ? ' editorial-po-draft-import-pasted' : ''
+          }${
+            importState === 'error' ? ' editorial-po-draft-import-error' : ''
+          }`}
+          onClick={() => {
+            void handleImportMarkdown();
+          }}
+          disabled={!editor}
+          aria-live="polite"
+          title="Replace the draft with markdown from your clipboard (a pre-paste snapshot is captured to Versions)"
+        >
+          {importState === 'pasted' && 'PASTED ✓'}
+          {importState === 'error' && 'PASTE FAILED'}
+          {importState === 'idle' && '↓ PASTE MD'}
         </button>
         <Link
           to="/editorial/points-outline"

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -6669,6 +6669,48 @@ a.editorial-phase-pill:hover {
   color: #b7372a;
 }
 
+.editorial-po-draft-import {
+  background: none;
+  border: 1px solid #c9c0a8;
+  border-radius: 3px;
+  padding: 0.2rem 0.6rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #5b5644;
+  cursor: pointer;
+  transition:
+    background 100ms,
+    color 100ms,
+    border-color 100ms;
+}
+
+.editorial-po-draft-import:hover:not(:disabled) {
+  background: #fff8e7;
+  border-color: #b7372a;
+  color: #b7372a;
+}
+
+.editorial-po-draft-import:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.editorial-po-draft-import-pasted,
+.editorial-po-draft-import-pasted:hover {
+  background: #ddf0e1;
+  border-color: #2e7d62;
+  color: #2e7d62;
+}
+
+.editorial-po-draft-import-error,
+.editorial-po-draft-import-error:hover {
+  background: #fbe5e1;
+  border-color: #b7372a;
+  color: #b7372a;
+}
+
 .editorial-po-draft-toolbar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Closes the kickoff **0p-b1 source-map feasibility spike** — proves Tiptap → Markdown → Tiptap round-trips for the StarterKit subset.

## What's new

### `webapp/src/lib/markdown-import.ts`

A small block-level parser with simple inline mark handling. Companion to the existing `markdown-export.ts`.

**Block coverage:** paragraph, heading (#–######), blockquote (`> `), codeBlock (fenced \`\`\`), bulletList (`-`/`*`/`+`), orderedList (`N.`), horizontalRule (`---`).

**Inline marks:** bold (`**`), italic (`*`), strike (`~~`), code (\`), link `[text](url)`.

### Tests (26 new)

- 9 block-coverage unit tests
- 7 inline-mark unit tests
- 10 round-trip tests, including a mixed Embracer-style document with heading + paragraph + ordered list + blockquote + hr — all preserved through Tiptap → MD → Tiptap.

### UI: `↓ PASTE MD` button in the sub-meta bar

Sits next to `↑ COPY MD`. Reads markdown from clipboard, captures a pre-paste named snapshot (so user can recover via Versions if they paste over a draft they care about), then replaces the editor body with the parsed doc. States: `idle` / `PASTED ✓` / `PASTE FAILED`.

## Caveats (documented in code)

- Combined nested marks (`***bold-italic***`) survive but may not match the original JSON exactly
- Nested lists are not parsed (each item is one paragraph)
- Tables out of scope (not in StarterKit)

## Spike conclusion

Round-trip is feasible for the surface we ship. The 26 tests serve as the regression net. Sufficient to back the eventual source-map work.

## Test plan

- [ ] `npm --prefix webapp run test -- markdown` → 42 tests pass
- [ ] In `/editorial/draft`, copy any markdown to clipboard
- [ ] Click `↓ PASTE MD`. Editor body replaces with the pasted markdown rendered into Tiptap nodes. Pre-paste state captured under Versions tab as a manual_save snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)