### PR TITLE
feat: Phase 04 DRAFT floating + INSERT menu on empty lines

### DIFF
--- a/webapp/src/pages/DraftWorkspacePage.tsx
+++ b/webapp/src/pages/DraftWorkspacePage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import {
   BubbleMenu,
   EditorContent,
+  FloatingMenu,
   useEditor,
   type Content,
   type Editor,
@@ -1992,6 +1993,110 @@ export function DraftWorkspacePage(_props: Props) {
                   <option value="justify">≣ Justify</option>
                 </select>
               </BubbleMenu>
+            ) : null}
+            {editor ? (
+              <FloatingMenu
+                editor={editor}
+                className="editorial-po-draft-floating"
+                shouldShow={({ editor: e, state }) => {
+                  const { $from } = state.selection;
+                  const isEmptyParagraph =
+                    $from.parent.type.name === 'paragraph' &&
+                    $from.parent.content.size === 0;
+                  if (!isEmptyParagraph) return false;
+                  if (e.isActive('codeBlock')) return false;
+                  if (e.isActive('blockquote')) return false;
+                  return true;
+                }}
+              >
+                <span className="editorial-po-draft-floating-label">
+                  + INSERT
+                </span>
+                <button
+                  type="button"
+                  className="editorial-po-draft-floating-btn"
+                  onClick={() =>
+                    editor.chain().focus().toggleHeading({ level: 1 }).run()
+                  }
+                  title="Heading 1"
+                >
+                  H1
+                </button>
+                <button
+                  type="button"
+                  className="editorial-po-draft-floating-btn"
+                  onClick={() =>
+                    editor.chain().focus().toggleHeading({ level: 2 }).run()
+                  }
+                  title="Heading 2"
+                >
+                  H2
+                </button>
+                <button
+                  type="button"
+                  className="editorial-po-draft-floating-btn"
+                  onClick={() =>
+                    editor.chain().focus().toggleHeading({ level: 3 }).run()
+                  }
+                  title="Heading 3"
+                >
+                  H3
+                </button>
+                <span className="editorial-po-draft-floating-divider" />
+                <button
+                  type="button"
+                  className="editorial-po-draft-floating-btn"
+                  onClick={() =>
+                    editor.chain().focus().toggleBulletList().run()
+                  }
+                  title="Bullet list"
+                  aria-label="Bullet list"
+                >
+                  •
+                </button>
+                <button
+                  type="button"
+                  className="editorial-po-draft-floating-btn"
+                  onClick={() =>
+                    editor.chain().focus().toggleOrderedList().run()
+                  }
+                  title="Numbered list"
+                  aria-label="Numbered list"
+                >
+                  1.
+                </button>
+                <button
+                  type="button"
+                  className="editorial-po-draft-floating-btn"
+                  onClick={() =>
+                    editor.chain().focus().toggleBlockquote().run()
+                  }
+                  title="Blockquote"
+                  aria-label="Blockquote"
+                >
+                  ❝
+                </button>
+                <button
+                  type="button"
+                  className="editorial-po-draft-floating-btn"
+                  onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+                  title="Code block"
+                  aria-label="Code block"
+                >
+                  &lt;/&gt;
+                </button>
+                <button
+                  type="button"
+                  className="editorial-po-draft-floating-btn"
+                  onClick={() =>
+                    editor.chain().focus().setHorizontalRule().run()
+                  }
+                  title="Divider"
+                  aria-label="Divider"
+                >
+                  ―
+                </button>
+              </FloatingMenu>
             ) : null}
             <EditorContent editor={editor} />
           </div>

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -7191,6 +7191,58 @@ a.editorial-phase-pill:hover {
   color: #f7f3e8;
 }
 
+/* Floating menu (empty-line block insert) */
+
+.editorial-po-draft-floating {
+  display: flex;
+  align-items: center;
+  gap: 0.15rem;
+  background: #fbf8f2;
+  border: 1px solid #c9c0a8;
+  border-radius: 5px;
+  padding: 0.2rem 0.35rem;
+  box-shadow: 0 4px 12px rgba(31, 28, 20, 0.08);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.66rem;
+  color: #5b5644;
+  z-index: 35;
+}
+
+.editorial-po-draft-floating-label {
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #8a8268;
+  padding-right: 0.2rem;
+}
+
+.editorial-po-draft-floating-divider {
+  width: 1px;
+  height: 0.95rem;
+  background: #d8cfb6;
+  margin: 0 0.05rem;
+}
+
+.editorial-po-draft-floating-btn {
+  background: none;
+  border: 0;
+  color: #5b5644;
+  padding: 0.2rem 0.4rem;
+  margin: 0;
+  cursor: pointer;
+  border-radius: 3px;
+  font-size: 0.7rem;
+  font-weight: 500;
+  font-family: inherit;
+  letter-spacing: 0.04em;
+  min-width: 1.4rem;
+  line-height: 1;
+}
+
+.editorial-po-draft-floating-btn:hover {
+  background: #fff8e7;
+  color: #b7372a;
+}
+
 /* Tiptap link styling inside the editor */
 
 .editorial-po-draft-editor .ProseMirror a {


### PR DESCRIPTION
## Summary

Second half of the rich-text surface (after the bubble toolbar): a floating `+ INSERT` menu that appears next to empty paragraphs. Notion / Substack pattern — keeps the always-visible toolbar minimal while making block insertion one click away.

## Buttons

| Group | Buttons |
|---|---|
| Headings | `H1` `H2` `H3` |
| Lists | `•` `1.` |
| Blocks | `❝` `</>` `―` |

`+ INSERT` label on the left clarifies the menu's purpose at a glance.

## shouldShow guard

Fires only on a truly empty paragraph (size === 0) that's not nested inside a code block or blockquote. Avoids cluttering the editor when the user is mid-write.

## How it composes with the bubble toolbar

| Surface | Trigger | Use case |
|---|---|---|
| Bubble toolbar | Selection has range | Format selected text |
| Floating menu | Empty paragraph + cursor | Insert a new block |

Together they cover the editing capabilities flagged as missing vs. Substack.

## Test plan

- [ ] In `/editorial/draft`, click into an empty paragraph (or press Enter to create one). Floating `+ INSERT H1 H2 H3 | • 1. ❝ </> ―` menu appears next to the cursor.
- [ ] Each button transforms / inserts the corresponding block.
- [ ] Type a character in the empty paragraph → the floating menu vanishes.
- [ ] In a code block / blockquote, the floating menu does NOT appear.
- [ ] Bubble menu (text selection) and floating menu (empty line) don't both show at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)