### PR TITLE
feat: Phase 04 DRAFT always-visible formatting toolbar (Substack pattern)

### DIFF
--- a/webapp/src/pages/DraftWorkspacePage.tsx
+++ b/webapp/src/pages/DraftWorkspacePage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
-  BubbleMenu,
   EditorContent,
   FloatingMenu,
   useEditor,
@@ -1815,20 +1814,12 @@ export function DraftWorkspacePage(_props: Props) {
 
         {/* CENTER — TIPTAP EDITOR */}
         <main className="editorial-po-draft-center">
-          <div className="editorial-po-draft-status-bar">{statusText}</div>
-          <div className="editorial-po-draft-editor">
+          <div className="editorial-po-draft-header">
+            <div className="editorial-po-draft-status-bar">{statusText}</div>
             {editor ? (
-              <BubbleMenu
-                editor={editor}
-                className="editorial-po-draft-bubble"
-                shouldShow={({ editor: e, from, to }) => {
-                  if (from === to) return false;
-                  if (e.isActive('codeBlock')) return false;
-                  return true;
-                }}
-              >
+              <div className="editorial-po-draft-format-toolbar">
                 <select
-                  className="editorial-po-draft-bubble-style"
+                  className="editorial-po-draft-toolbar-style"
                   value={getActiveStyle(editor)}
                   onChange={(e) => applyStyle(editor, e.target.value)}
                   aria-label="Text style"
@@ -1839,12 +1830,12 @@ export function DraftWorkspacePage(_props: Props) {
                   <option value="h3">Heading 3</option>
                   <option value="h4">Heading 4</option>
                 </select>
-                <span className="editorial-po-draft-bubble-divider" />
+                <span className="editorial-po-draft-toolbar-divider" />
                 <button
                   type="button"
-                  className={`editorial-po-draft-bubble-btn${
+                  className={`editorial-po-draft-toolbar-btn${
                     editor.isActive('bold')
-                      ? ' editorial-po-draft-bubble-btn-active'
+                      ? ' editorial-po-draft-toolbar-btn-active'
                       : ''
                   }`}
                   onClick={() => editor.chain().focus().toggleBold().run()}
@@ -1855,9 +1846,9 @@ export function DraftWorkspacePage(_props: Props) {
                 </button>
                 <button
                   type="button"
-                  className={`editorial-po-draft-bubble-btn${
+                  className={`editorial-po-draft-toolbar-btn${
                     editor.isActive('italic')
-                      ? ' editorial-po-draft-bubble-btn-active'
+                      ? ' editorial-po-draft-toolbar-btn-active'
                       : ''
                   }`}
                   onClick={() => editor.chain().focus().toggleItalic().run()}
@@ -1868,9 +1859,9 @@ export function DraftWorkspacePage(_props: Props) {
                 </button>
                 <button
                   type="button"
-                  className={`editorial-po-draft-bubble-btn${
+                  className={`editorial-po-draft-toolbar-btn${
                     editor.isActive('underline')
-                      ? ' editorial-po-draft-bubble-btn-active'
+                      ? ' editorial-po-draft-toolbar-btn-active'
                       : ''
                   }`}
                   onClick={() => editor.chain().focus().toggleUnderline().run()}
@@ -1881,9 +1872,9 @@ export function DraftWorkspacePage(_props: Props) {
                 </button>
                 <button
                   type="button"
-                  className={`editorial-po-draft-bubble-btn${
+                  className={`editorial-po-draft-toolbar-btn${
                     editor.isActive('strike')
-                      ? ' editorial-po-draft-bubble-btn-active'
+                      ? ' editorial-po-draft-toolbar-btn-active'
                       : ''
                   }`}
                   onClick={() => editor.chain().focus().toggleStrike().run()}
@@ -1894,9 +1885,9 @@ export function DraftWorkspacePage(_props: Props) {
                 </button>
                 <button
                   type="button"
-                  className={`editorial-po-draft-bubble-btn${
+                  className={`editorial-po-draft-toolbar-btn${
                     editor.isActive('code')
-                      ? ' editorial-po-draft-bubble-btn-active'
+                      ? ' editorial-po-draft-toolbar-btn-active'
                       : ''
                   }`}
                   onClick={() => editor.chain().focus().toggleCode().run()}
@@ -1907,22 +1898,22 @@ export function DraftWorkspacePage(_props: Props) {
                 </button>
                 <button
                   type="button"
-                  className={`editorial-po-draft-bubble-btn${
+                  className={`editorial-po-draft-toolbar-btn${
                     editor.isActive('highlight')
-                      ? ' editorial-po-draft-bubble-btn-active'
+                      ? ' editorial-po-draft-toolbar-btn-active'
                       : ''
                   }`}
                   onClick={() => editor.chain().focus().toggleHighlight().run()}
                   title="Highlight"
                   aria-label="Highlight"
                 >
-                  <span className="editorial-po-draft-bubble-hl">H</span>
+                  <span className="editorial-po-draft-toolbar-hl">H</span>
                 </button>
                 <button
                   type="button"
-                  className={`editorial-po-draft-bubble-btn${
+                  className={`editorial-po-draft-toolbar-btn${
                     editor.isActive('link')
-                      ? ' editorial-po-draft-bubble-btn-active'
+                      ? ' editorial-po-draft-toolbar-btn-active'
                       : ''
                   }`}
                   onClick={() => promptLink(editor)}
@@ -1931,12 +1922,12 @@ export function DraftWorkspacePage(_props: Props) {
                 >
                   🔗
                 </button>
-                <span className="editorial-po-draft-bubble-divider" />
+                <span className="editorial-po-draft-toolbar-divider" />
                 <button
                   type="button"
-                  className={`editorial-po-draft-bubble-btn${
+                  className={`editorial-po-draft-toolbar-btn${
                     editor.isActive('bulletList')
-                      ? ' editorial-po-draft-bubble-btn-active'
+                      ? ' editorial-po-draft-toolbar-btn-active'
                       : ''
                   }`}
                   onClick={() =>
@@ -1949,9 +1940,9 @@ export function DraftWorkspacePage(_props: Props) {
                 </button>
                 <button
                   type="button"
-                  className={`editorial-po-draft-bubble-btn${
+                  className={`editorial-po-draft-toolbar-btn${
                     editor.isActive('orderedList')
-                      ? ' editorial-po-draft-bubble-btn-active'
+                      ? ' editorial-po-draft-toolbar-btn-active'
                       : ''
                   }`}
                   onClick={() =>
@@ -1964,9 +1955,9 @@ export function DraftWorkspacePage(_props: Props) {
                 </button>
                 <button
                   type="button"
-                  className={`editorial-po-draft-bubble-btn${
+                  className={`editorial-po-draft-toolbar-btn${
                     editor.isActive('blockquote')
-                      ? ' editorial-po-draft-bubble-btn-active'
+                      ? ' editorial-po-draft-toolbar-btn-active'
                       : ''
                   }`}
                   onClick={() =>
@@ -1977,9 +1968,9 @@ export function DraftWorkspacePage(_props: Props) {
                 >
                   ❝
                 </button>
-                <span className="editorial-po-draft-bubble-divider" />
+                <span className="editorial-po-draft-toolbar-divider" />
                 <select
-                  className="editorial-po-draft-bubble-align"
+                  className="editorial-po-draft-toolbar-align"
                   value={getActiveAlign(editor)}
                   onChange={(e) =>
                     editor.chain().focus().setTextAlign(e.target.value).run()
@@ -1992,8 +1983,31 @@ export function DraftWorkspacePage(_props: Props) {
                   <option value="right">⇥ Right</option>
                   <option value="justify">≣ Justify</option>
                 </select>
-              </BubbleMenu>
+                <span className="editorial-po-draft-toolbar-divider" />
+                <button
+                  type="button"
+                  className="editorial-po-draft-toolbar-btn"
+                  onClick={() => editor.chain().focus().undo().run()}
+                  disabled={!editor.can().undo()}
+                  title="Undo (⌘Z)"
+                  aria-label="Undo"
+                >
+                  ↺
+                </button>
+                <button
+                  type="button"
+                  className="editorial-po-draft-toolbar-btn"
+                  onClick={() => editor.chain().focus().redo().run()}
+                  disabled={!editor.can().redo()}
+                  title="Redo (⌘⇧Z)"
+                  aria-label="Redo"
+                >
+                  ↻
+                </button>
+              </div>
             ) : null}
+          </div>
+          <div className="editorial-po-draft-editor">
             {editor ? (
               <FloatingMenu
                 editor={editor}

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -7065,15 +7065,19 @@ a.editorial-phase-pill:hover {
   background: #fbf8f2;
 }
 
-.editorial-po-draft-status-bar {
+.editorial-po-draft-header {
   position: sticky;
   top: 0;
-  z-index: 2;
-  background: rgba(251, 248, 242, 0.94);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
+  z-index: 5;
+  background: #fbf8f2;
   border-bottom: 1px solid #e2dccc;
-  padding: 0.45rem 1.6rem;
+  box-shadow: 0 2px 4px rgba(31, 28, 20, 0.04);
+}
+
+.editorial-po-draft-status-bar {
+  background: rgba(251, 248, 242, 0.94);
+  border-bottom: 1px solid #e8e1cc;
+  padding: 0.4rem 1.4rem;
   font-family: 'IBM Plex Mono', monospace;
   font-size: 0.62rem;
   letter-spacing: 0.06em;
@@ -7091,63 +7095,64 @@ a.editorial-phase-pill:hover {
   max-width: 720px;
 }
 
-/* Bubble toolbar (selection-driven formatting) */
+/* Always-visible formatting toolbar */
 
-.editorial-po-draft-bubble {
+.editorial-po-draft-format-toolbar {
   display: flex;
   align-items: center;
-  gap: 0.15rem;
-  background: #1f1c14;
-  color: #f7f3e8;
-  border-radius: 6px;
-  padding: 0.25rem 0.35rem;
-  box-shadow:
-    0 12px 30px rgba(0, 0, 0, 0.28),
-    0 2px 6px rgba(0, 0, 0, 0.15);
+  gap: 0.18rem;
+  padding: 0.4rem 1.4rem;
+  flex-wrap: wrap;
   font-family: 'IBM Plex Sans', system-ui, sans-serif;
-  font-size: 0.78rem;
-  z-index: 40;
+  background: #fbf8f2;
 }
 
-.editorial-po-draft-bubble-divider {
+.editorial-po-draft-toolbar-divider {
   width: 1px;
   height: 1.1rem;
-  background: rgba(247, 243, 232, 0.18);
-  margin: 0 0.1rem;
+  background: #d8cfb6;
+  margin: 0 0.2rem;
 }
 
-.editorial-po-draft-bubble-btn {
+.editorial-po-draft-toolbar-btn {
   background: none;
-  border: 0;
-  color: inherit;
-  padding: 0.25rem 0.45rem;
+  border: 1px solid transparent;
+  color: #1f1c14;
+  padding: 0.25rem 0.5rem;
   margin: 0;
   cursor: pointer;
   border-radius: 4px;
   font-size: 0.82rem;
   font-weight: 500;
-  min-width: 1.6rem;
+  min-width: 1.7rem;
   line-height: 1;
   font-family: inherit;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  transition:
+    background 80ms,
+    border-color 80ms,
+    color 80ms;
 }
 
-.editorial-po-draft-bubble-btn:hover {
-  background: rgba(247, 243, 232, 0.12);
+.editorial-po-draft-toolbar-btn:hover:not(:disabled) {
+  background: #efe9d8;
 }
 
-.editorial-po-draft-bubble-btn-active {
-  background: rgba(247, 243, 232, 0.2);
-  color: #fff;
+.editorial-po-draft-toolbar-btn-active,
+.editorial-po-draft-toolbar-btn-active:hover {
+  background: #fff8e7;
+  border-color: #b7372a;
+  color: #b7372a;
 }
 
-.editorial-po-draft-bubble-btn-active:hover {
-  background: rgba(247, 243, 232, 0.28);
+.editorial-po-draft-toolbar-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
 }
 
-.editorial-po-draft-bubble-hl {
+.editorial-po-draft-toolbar-hl {
   background: #f5d76e;
   color: #1f1c14;
   padding: 0 0.25rem;
@@ -7155,21 +7160,21 @@ a.editorial-phase-pill:hover {
   font-weight: 600;
 }
 
-.editorial-po-draft-bubble-style,
-.editorial-po-draft-bubble-align {
-  background: rgba(247, 243, 232, 0.1);
-  color: #f7f3e8;
-  border: 0;
+.editorial-po-draft-toolbar-style,
+.editorial-po-draft-toolbar-align {
+  background: #fff;
+  color: #1f1c14;
+  border: 1px solid #c9c0a8;
   border-radius: 4px;
-  padding: 0.28rem 0.4rem;
+  padding: 0.27rem 0.5rem;
   font-family: inherit;
-  font-size: 0.74rem;
+  font-size: 0.78rem;
   cursor: pointer;
   appearance: none;
   -webkit-appearance: none;
   background-image:
-    linear-gradient(45deg, transparent 50%, currentColor 50%),
-    linear-gradient(135deg, currentColor 50%, transparent 50%);
+    linear-gradient(45deg, transparent 50%, #5b5644 50%),
+    linear-gradient(135deg, #5b5644 50%, transparent 50%);
   background-position:
     calc(100% - 0.65rem) 50%,
     calc(100% - 0.4rem) 50%;
@@ -7177,18 +7182,12 @@ a.editorial-phase-pill:hover {
     0.25rem 0.25rem,
     0.25rem 0.25rem;
   background-repeat: no-repeat;
-  padding-right: 1.1rem;
+  padding-right: 1.4rem;
 }
 
-.editorial-po-draft-bubble-style:hover,
-.editorial-po-draft-bubble-align:hover {
-  background-color: rgba(247, 243, 232, 0.18);
-}
-
-.editorial-po-draft-bubble-style option,
-.editorial-po-draft-bubble-align option {
-  background: #1f1c14;
-  color: #f7f3e8;
+.editorial-po-draft-toolbar-style:hover,
+.editorial-po-draft-toolbar-align:hover {
+  border-color: #b7372a;
 }
 
 /* Floating menu (empty-line block insert) */


### PR DESCRIPTION
## Summary

Replaces the bubble menu (selection-driven, Notion pattern) with an always-visible formatting toolbar (Substack pattern) sitting in a sticky header above the editor. Matches the user-supplied Substack screenshots: toolbar visible at all times, not gated on selection.

## Why

The bubble menu was a UX-pattern mismatch with the design intent — users expect to see editing affordances without having to select text first.

## Layout

```
[Sticky header]
  Status bar — PARAGRAPH N OF M · POINT P · TYPE
  Format toolbar — Style ▼ | B I U S </> H 🔗 | • 1. ❝ | Align ▼ | ↺ ↻
[Editor prose]
```

Buttons go active when the corresponding mark / node applies to the current selection. Undo / redo buttons added (StarterKit History was already wired; UI just exposed now).

The FloatingMenu (empty-line `+ INSERT`) stays — complementary, not redundant. Together they cover format-on-existing + insert-on-empty.

## Net change

- Removed: `BubbleMenu` import + JSX + ~100 lines of bubble CSS
- Added: sticky header wrapper + always-visible toolbar JSX + light toolbar CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)