### PR TITLE
feat: deliverable-aware Draft toolbar — Setup persists, Draft adapts

### DIFF
--- a/webapp/src/lib/editorial-setup.ts
+++ b/webapp/src/lib/editorial-setup.ts
@@ -1,0 +1,181 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Editorial Room — shared SetupState persistence + destination capabilities.
+//
+// Setup is the source of truth for `deliverable_type`, `destination`, voice,
+// and length target. Other phases (Draft, Polish, Ship) read from here so
+// the editing surface adapts to what the destination actually supports
+// without duplicating input controls.
+//
+// Persistence is localStorage at v0p; replaced by the rocketorchestra
+// `setup` page lookup once that's wired.
+// ───────────────────────────────────────────────────────────────────────────
+
+export type DeliverableType =
+  | 'longform_post'
+  | 'podcast_script'
+  | 'book_chapter'
+  | 'social_post'
+  | 'memo';
+
+export type Destination =
+  | 'substack_md'
+  | 'google_doc'
+  | 'plain_md'
+  | 'youtube_script'
+  | 'other';
+
+export type SetupState = {
+  schema_version: '0';
+  setup_version: number;
+  deliverable_type: DeliverableType;
+  voice_page_slug: string;
+  length_target: { min_words: number; max_words: number } | null;
+  destination: Destination;
+  audience_persona_slugs: string[];
+  llm_room_agent_profile_ids: string[];
+  scoring_pipeline_slug: string;
+  updated_at: string;
+  updated_by_user_id: string;
+};
+
+const SETUP_STATE_KEY = 'editorial-room.setup.state-v0';
+
+export const DELIVERABLE_LABELS: Record<DeliverableType, string> = {
+  longform_post: 'Longform Post',
+  podcast_script: 'Podcast Script',
+  book_chapter: 'Book Chapter',
+  social_post: 'Social Post',
+  memo: 'Memo',
+};
+
+export const DESTINATION_LABELS: Record<Destination, string> = {
+  substack_md: 'Substack · Markdown export',
+  google_doc: 'Google Doc',
+  plain_md: 'Plain Markdown',
+  youtube_script: 'YouTube Script',
+  other: 'Other',
+};
+
+// Compact label for the Draft eyebrow row.
+export const DESTINATION_SHORT: Record<Destination, string> = {
+  substack_md: 'SUBSTACK',
+  google_doc: 'GOOGLE DOC',
+  plain_md: 'PLAIN MD',
+  youtube_script: 'YOUTUBE',
+  other: 'OTHER',
+};
+
+// Per-destination toolbar capabilities. Marks/attrs that won't survive the
+// destination's export are hidden from the toolbar — the canonical Tiptap
+// JSON still carries them if previously applied, but the user isn't
+// encouraged to add new ones for this destination.
+//
+// Bold / italic / strike / code / link / lists / blockquote / headings are
+// always on (universal markdown subset).
+export type ToolbarCapabilities = {
+  underline: boolean;
+  highlight: boolean;
+  align: boolean;
+  exportFormat: 'markdown' | 'html';
+  exportButtonLabel: string;
+  exportSuccessLabel: string;
+};
+
+export const DESTINATION_CAPABILITIES: Record<
+  Destination,
+  ToolbarCapabilities
+> = {
+  substack_md: {
+    underline: false,
+    highlight: false,
+    align: false,
+    exportFormat: 'markdown',
+    exportButtonLabel: '↑ COPY MD',
+    exportSuccessLabel: 'COPIED MD ✓',
+  },
+  google_doc: {
+    underline: true,
+    highlight: true,
+    align: true,
+    exportFormat: 'html',
+    exportButtonLabel: '↑ COPY RICH',
+    exportSuccessLabel: 'COPIED RICH ✓',
+  },
+  plain_md: {
+    underline: false,
+    highlight: false,
+    align: false,
+    exportFormat: 'markdown',
+    exportButtonLabel: '↑ COPY MD',
+    exportSuccessLabel: 'COPIED MD ✓',
+  },
+  youtube_script: {
+    underline: false,
+    highlight: false,
+    align: false,
+    exportFormat: 'markdown',
+    exportButtonLabel: '↑ COPY MD',
+    exportSuccessLabel: 'COPIED MD ✓',
+  },
+  other: {
+    underline: true,
+    highlight: true,
+    align: true,
+    exportFormat: 'markdown',
+    exportButtonLabel: '↑ COPY MD',
+    exportSuccessLabel: 'COPIED MD ✓',
+  },
+};
+
+export function defaultSetupState(): SetupState {
+  return {
+    schema_version: '0',
+    setup_version: 1,
+    deliverable_type: 'longform_post',
+    voice_page_slug: 'voice/gamemakers-2026',
+    length_target: { min_words: 2000, max_words: 2500 },
+    destination: 'substack_md',
+    audience_persona_slugs: [],
+    llm_room_agent_profile_ids: [],
+    scoring_pipeline_slug: 'scoring_pipeline/gamemakers_default',
+    updated_at: new Date().toISOString(),
+    updated_by_user_id: 'user_local_joseph',
+  };
+}
+
+function isValidSetupState(v: unknown): v is SetupState {
+  if (!v || typeof v !== 'object') return false;
+  const obj = v as Record<string, unknown>;
+  if (obj.schema_version !== '0') return false;
+  if (typeof obj.setup_version !== 'number') return false;
+  if (typeof obj.deliverable_type !== 'string') return false;
+  if (typeof obj.destination !== 'string') return false;
+  return true;
+}
+
+export function loadSetupState(): SetupState {
+  if (typeof window === 'undefined') return defaultSetupState();
+  try {
+    const raw = window.localStorage.getItem(SETUP_STATE_KEY);
+    if (!raw) return defaultSetupState();
+    const parsed = JSON.parse(raw);
+    if (!isValidSetupState(parsed)) return defaultSetupState();
+    // Merge with default to backfill any new fields we add later.
+    return { ...defaultSetupState(), ...parsed };
+  } catch {
+    return defaultSetupState();
+  }
+}
+
+export function saveSetupState(state: SetupState): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(SETUP_STATE_KEY, JSON.stringify(state));
+  } catch {
+    // localStorage quota errors silently dropped at v0p
+  }
+}
+
+export function loadDestination(): Destination {
+  return loadSetupState().destination;
+}

--- a/webapp/src/pages/DraftWorkspacePage.tsx
+++ b/webapp/src/pages/DraftWorkspacePage.tsx
@@ -14,6 +14,12 @@ import TextAlign from '@tiptap/extension-text-align';
 import Highlight from '@tiptap/extension-highlight';
 
 import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
+import {
+  DESTINATION_CAPABILITIES,
+  DESTINATION_SHORT,
+  loadDestination,
+  type Destination,
+} from '../lib/editorial-setup';
 import { serializeDocToMarkdown, type JSONNode } from '../lib/markdown-export';
 import { parseMarkdownToDoc } from '../lib/markdown-import';
 
@@ -985,6 +991,7 @@ export function DraftWorkspacePage(_props: Props) {
     'idle',
   );
   const [optimizeOpen, setOptimizeOpen] = useState<boolean>(false);
+  const [destination, setDestination] = useState<Destination>(loadDestination);
   const saveTimerRef = useRef<number | null>(null);
   const exportResetTimerRef = useRef<number | null>(null);
   const importResetTimerRef = useRef<number | null>(null);
@@ -1165,6 +1172,20 @@ export function DraftWorkspacePage(_props: Props) {
     return () => window.removeEventListener('mousedown', handler);
   }, [optimizeOpen]);
 
+  // Refresh destination when window regains focus or another tab updates
+  // Setup. Cheap, and keeps the toolbar in sync without polling.
+  useEffect(() => {
+    const refresh = (): void => setDestination(loadDestination());
+    window.addEventListener('focus', refresh);
+    window.addEventListener('storage', refresh);
+    return () => {
+      window.removeEventListener('focus', refresh);
+      window.removeEventListener('storage', refresh);
+    };
+  }, []);
+
+  const capabilities = DESTINATION_CAPABILITIES[destination];
+
   const orderedOutline = useMemo<OutlineEntry[]>(
     () => [
       ...outlineGroups.HOOK,
@@ -1223,8 +1244,6 @@ export function DraftWorkspacePage(_props: Props) {
 
   const handleExportMarkdown = async (): Promise<void> => {
     if (!editor) return;
-    const json = editor.getJSON() as JSONNode;
-    const md = serializeDocToMarkdown(json);
     const finish = (state: 'copied' | 'error'): void => {
       setExportState(state);
       if (exportResetTimerRef.current !== null) {
@@ -1236,6 +1255,43 @@ export function DraftWorkspacePage(_props: Props) {
       }, 1500);
     };
     try {
+      if (capabilities.exportFormat === 'html') {
+        // Rich-text export for Google Doc — copy as text/html so paste
+        // targets that understand HTML (Google Docs, Notion, etc.) preserve
+        // marks/alignment/etc. Plain text fallback alongside.
+        const html = editor.getHTML();
+        const plain = editor.state.doc.textContent;
+        if (
+          typeof navigator !== 'undefined' &&
+          navigator.clipboard &&
+          typeof ClipboardItem !== 'undefined' &&
+          typeof navigator.clipboard.write === 'function'
+        ) {
+          const item = new ClipboardItem({
+            'text/html': new Blob([html], { type: 'text/html' }),
+            'text/plain': new Blob([plain], { type: 'text/plain' }),
+          });
+          await navigator.clipboard.write([item]);
+          finish('copied');
+          return;
+        }
+        // Fallback: copy raw HTML as plain text.
+        if (
+          typeof navigator !== 'undefined' &&
+          navigator.clipboard &&
+          typeof navigator.clipboard.writeText === 'function'
+        ) {
+          await navigator.clipboard.writeText(html);
+          finish('copied');
+          return;
+        }
+        finish('error');
+        return;
+      }
+
+      // Markdown export for Substack / Plain Markdown / etc.
+      const json = editor.getJSON() as JSONNode;
+      const md = serializeDocToMarkdown(json);
       if (
         typeof navigator !== 'undefined' &&
         navigator.clipboard &&
@@ -1345,6 +1401,14 @@ export function DraftWorkspacePage(_props: Props) {
         <span>
           {totalOutlinePoints} {totalOutlinePoints === 1 ? 'POINT' : 'POINTS'}
         </span>
+        <span className="editorial-po-meta-sep">·</span>
+        <Link
+          to="/editorial/setup"
+          className="editorial-po-draft-destination"
+          title={`Destination: ${DESTINATION_CAPABILITIES[destination].exportButtonLabel.replace('↑ ', '')} export — change in Setup`}
+        >
+          → {DESTINATION_SHORT[destination]}
+        </Link>
       </div>
 
       <div className="editorial-po-draft-meta">
@@ -1398,9 +1462,9 @@ export function DraftWorkspacePage(_props: Props) {
           aria-live="polite"
           title="Copy the draft as Substack-ready markdown"
         >
-          {exportState === 'copied' && 'COPIED ✓'}
+          {exportState === 'copied' && capabilities.exportSuccessLabel}
           {exportState === 'error' && 'COPY FAILED'}
-          {exportState === 'idle' && '↑ COPY MD'}
+          {exportState === 'idle' && capabilities.exportButtonLabel}
         </button>
         <button
           type="button"
@@ -1857,19 +1921,23 @@ export function DraftWorkspacePage(_props: Props) {
                 >
                   <em>I</em>
                 </button>
-                <button
-                  type="button"
-                  className={`editorial-po-draft-toolbar-btn${
-                    editor.isActive('underline')
-                      ? ' editorial-po-draft-toolbar-btn-active'
-                      : ''
-                  }`}
-                  onClick={() => editor.chain().focus().toggleUnderline().run()}
-                  title="Underline (⌘U)"
-                  aria-label="Underline"
-                >
-                  <u>U</u>
-                </button>
+                {capabilities.underline ? (
+                  <button
+                    type="button"
+                    className={`editorial-po-draft-toolbar-btn${
+                      editor.isActive('underline')
+                        ? ' editorial-po-draft-toolbar-btn-active'
+                        : ''
+                    }`}
+                    onClick={() =>
+                      editor.chain().focus().toggleUnderline().run()
+                    }
+                    title="Underline (⌘U)"
+                    aria-label="Underline"
+                  >
+                    <u>U</u>
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   className={`editorial-po-draft-toolbar-btn${
@@ -1896,19 +1964,23 @@ export function DraftWorkspacePage(_props: Props) {
                 >
                   &lt;/&gt;
                 </button>
-                <button
-                  type="button"
-                  className={`editorial-po-draft-toolbar-btn${
-                    editor.isActive('highlight')
-                      ? ' editorial-po-draft-toolbar-btn-active'
-                      : ''
-                  }`}
-                  onClick={() => editor.chain().focus().toggleHighlight().run()}
-                  title="Highlight"
-                  aria-label="Highlight"
-                >
-                  <span className="editorial-po-draft-toolbar-hl">H</span>
-                </button>
+                {capabilities.highlight ? (
+                  <button
+                    type="button"
+                    className={`editorial-po-draft-toolbar-btn${
+                      editor.isActive('highlight')
+                        ? ' editorial-po-draft-toolbar-btn-active'
+                        : ''
+                    }`}
+                    onClick={() =>
+                      editor.chain().focus().toggleHighlight().run()
+                    }
+                    title="Highlight"
+                    aria-label="Highlight"
+                  >
+                    <span className="editorial-po-draft-toolbar-hl">H</span>
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   className={`editorial-po-draft-toolbar-btn${
@@ -1968,21 +2040,29 @@ export function DraftWorkspacePage(_props: Props) {
                 >
                   ❝
                 </button>
-                <span className="editorial-po-draft-toolbar-divider" />
-                <select
-                  className="editorial-po-draft-toolbar-align"
-                  value={getActiveAlign(editor)}
-                  onChange={(e) =>
-                    editor.chain().focus().setTextAlign(e.target.value).run()
-                  }
-                  aria-label="Text alignment"
-                  title="Text alignment"
-                >
-                  <option value="left">⇤ Left</option>
-                  <option value="center">≡ Center</option>
-                  <option value="right">⇥ Right</option>
-                  <option value="justify">≣ Justify</option>
-                </select>
+                {capabilities.align ? (
+                  <>
+                    <span className="editorial-po-draft-toolbar-divider" />
+                    <select
+                      className="editorial-po-draft-toolbar-align"
+                      value={getActiveAlign(editor)}
+                      onChange={(e) =>
+                        editor
+                          .chain()
+                          .focus()
+                          .setTextAlign(e.target.value)
+                          .run()
+                      }
+                      aria-label="Text alignment"
+                      title="Text alignment"
+                    >
+                      <option value="left">⇤ Left</option>
+                      <option value="center">≡ Center</option>
+                      <option value="right">⇥ Right</option>
+                      <option value="justify">≣ Justify</option>
+                    </select>
+                  </>
+                ) : null}
                 <span className="editorial-po-draft-toolbar-divider" />
                 <button
                   type="button"

--- a/webapp/src/pages/EditorialSetupPage.tsx
+++ b/webapp/src/pages/EditorialSetupPage.tsx
@@ -1,37 +1,21 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
+import {
+  DELIVERABLE_LABELS,
+  DESTINATION_LABELS,
+  defaultSetupState,
+  loadSetupState,
+  saveSetupState,
+  type DeliverableType,
+  type Destination,
+  type SetupState,
+} from '../lib/editorial-setup';
 
 // SetupState mirrors docs/contracts/editorial-room/v0/setup_state.schema.json
-// (also in EDITORIAL_ROOM_CONTRACT.md §2.1). Held in component state for the
-// 0p-a vertical slice; no persistence yet.
-type DeliverableType =
-  | 'longform_post'
-  | 'podcast_script'
-  | 'book_chapter'
-  | 'social_post'
-  | 'memo';
-
-type Destination =
-  | 'substack_md'
-  | 'google_doc'
-  | 'plain_md'
-  | 'youtube_script'
-  | 'other';
-
-type SetupState = {
-  schema_version: '0';
-  setup_version: number;
-  deliverable_type: DeliverableType;
-  voice_page_slug: string;
-  length_target: { min_words: number; max_words: number } | null;
-  destination: Destination;
-  audience_persona_slugs: string[];
-  llm_room_agent_profile_ids: string[];
-  scoring_pipeline_slug: string;
-  updated_at: string;
-  updated_by_user_id: string;
-};
+// (also in EDITORIAL_ROOM_CONTRACT.md §2.1). Persisted to localStorage via
+// `lib/editorial-setup.ts` so other phases (Draft, Polish, Ship) can read
+// destination + deliverable_type and adapt their surfaces.
 
 type SectionId = 'deliverable' | 'audience' | 'llm-room' | 'scoring';
 
@@ -41,22 +25,6 @@ const SECTIONS: ReadonlyArray<{ id: SectionId; num: string; name: string }> = [
   { id: 'llm-room', num: '03', name: 'LLM Room' },
   { id: 'scoring', num: '04', name: 'Scoring System' },
 ];
-
-const DELIVERABLE_LABELS: Record<DeliverableType, string> = {
-  longform_post: 'Longform Post',
-  podcast_script: 'Podcast Script',
-  book_chapter: 'Book Chapter',
-  social_post: 'Social Post',
-  memo: 'Memo',
-};
-
-const DESTINATION_LABELS: Record<Destination, string> = {
-  substack_md: 'Substack · Markdown export',
-  google_doc: 'Google Doc',
-  plain_md: 'Plain Markdown',
-  youtube_script: 'YouTube Script',
-  other: 'Other',
-};
 
 // Voice library shown in the Deliverable section's voice picker. In production
 // this list comes from rocketorchestra's voice page library; for 0p we
@@ -73,22 +41,6 @@ const AVAILABLE_VOICES: ReadonlyArray<{ slug: string; label: string }> = [
   },
   { slug: 'voice/memo-tight-2026', label: 'Memo · Tight (2026)' },
 ];
-
-function defaultSetupState(): SetupState {
-  return {
-    schema_version: '0',
-    setup_version: 1,
-    deliverable_type: 'longform_post',
-    voice_page_slug: 'voice/gamemakers-2026',
-    length_target: { min_words: 2000, max_words: 2500 },
-    destination: 'substack_md',
-    audience_persona_slugs: [],
-    llm_room_agent_profile_ids: [],
-    scoring_pipeline_slug: 'scoring_pipeline/gamemakers_default',
-    updated_at: new Date().toISOString(),
-    updated_by_user_id: 'user_local_joseph',
-  };
-}
 
 function sectionStatus(
   id: SectionId,
@@ -113,9 +65,15 @@ type Props = {
 };
 
 export function EditorialSetupPage(_props: Props) {
-  const [setup, setSetup] = useState<SetupState>(defaultSetupState);
+  const [setup, setSetup] = useState<SetupState>(loadSetupState);
   const [activeSection, setActiveSection] = useState<SectionId>('deliverable');
   const [pieceTitle, setPieceTitle] = useState('Untitled Piece — new');
+
+  // Persist on every change so other phases (Draft, Polish, Ship) see the
+  // current SetupState immediately.
+  useEffect(() => {
+    saveSetupState(setup);
+  }, [setup]);
 
   const update = (patch: Partial<SetupState>) =>
     setSetup((s) => ({

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -6580,6 +6580,23 @@ a.editorial-phase-pill:hover {
   text-decoration: underline;
 }
 
+.editorial-po-draft-destination {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+  text-decoration: none;
+  border: 1px solid #c9c0a8;
+  border-radius: 3px;
+  padding: 0.12rem 0.4rem;
+}
+
+.editorial-po-draft-destination:hover {
+  color: #b7372a;
+  border-color: #b7372a;
+}
+
 .editorial-po-draft-ssr,
 .editorial-po-draft-gates {
   font-weight: 500;


### PR DESCRIPTION
## Summary

Setup is now the source of truth for `destination`. Draft reads it and adapts the toolbar capabilities + export format — **no duplicate input control**, just an indicator chip in the eyebrow row that links back to Setup if the user wants to change it.

## What's new

### `webapp/src/lib/editorial-setup.ts` (new)
- Owns `SetupState` / `Destination` / `DeliverableType` types (moved out of `EditorialSetupPage` so Draft / Polish / Ship can import without coupling)
- `loadSetupState` / `saveSetupState` — localStorage at key `editorial-room.setup.state-v0`
- `DESTINATION_CAPABILITIES` matrix:

| Destination | Underline | Highlight | Align | Export |
|---|---|---|---|---|
| Substack (MD) | ❌ | ❌ | ❌ | markdown |
| Google Doc | ✅ | ✅ | ✅ | html |
| Plain Markdown | ❌ | ❌ | ❌ | markdown |

### `EditorialSetupPage`
- Init from localStorage instead of in-memory default
- `useEffect` persists every `SetupState` change

### `DraftWorkspacePage`
- Reads destination on mount + on window `focus` + on `storage` events (cross-tab Setup changes propagate without polling)
- Toolbar buttons for Underline / Highlight / Alignment **hide** when the destination's export drops them
- COPY button label adapts: `↑ COPY MD` for markdown destinations, `↑ COPY RICH` for Google Doc
- For Google Doc, copy uses `ClipboardItem` with both `text/html` (full Tiptap HTML preserving alignment, marks, etc.) and `text/plain` fallback — paste into Google Docs preserves formatting
- Eyebrow row appends `→ SUBSTACK` / `→ GOOGLE DOC` / etc. chip, clickable back to Setup

## Canonical JSON unchanged

Destination only affects toolbar visibility + export shape, not the substrate. Versions ledger preserves underline / highlight / alignment regardless of which destination is active.

## Test plan

- [ ] Setup → change Destination from "Substack · Markdown export" to "Google Doc". Navigate to Draft.
- [ ] Eyebrow chip flips: `→ SUBSTACK` becomes `→ GOOGLE DOC`.
- [ ] Toolbar shows U / H / Align controls (hidden for Substack).
- [ ] COPY button reads `↑ COPY RICH`. Click → paste into Google Docs reproduces bold/italic/underline/alignment.
- [ ] Switch back to Substack → those controls disappear, COPY reverts to `↑ COPY MD`.
- [ ] Reload `/editorial/setup` — selected destination persists.
- [ ] Open Draft in another tab; change destination in first tab; second tab refreshes destination on focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)