### PR TITLE
feat: hide ↓ PASTE MD when destination's natural input is rich text

### DIFF
--- a/webapp/src/lib/editorial-setup.ts
+++ b/webapp/src/lib/editorial-setup.ts
@@ -79,6 +79,10 @@ export type ToolbarCapabilities = {
   exportFormat: 'markdown' | 'html';
   exportButtonLabel: string;
   exportSuccessLabel: string;
+  // Whether to surface the `↓ PASTE MD` button. False for destinations
+  // where the natural paste-in source is rich text (Google Doc), since
+  // Tiptap handles HTML paste directly into the editor body.
+  showPasteMarkdown: boolean;
 };
 
 export const DESTINATION_CAPABILITIES: Record<
@@ -92,6 +96,7 @@ export const DESTINATION_CAPABILITIES: Record<
     exportFormat: 'markdown',
     exportButtonLabel: '↑ COPY MD',
     exportSuccessLabel: 'COPIED MD ✓',
+    showPasteMarkdown: true,
   },
   google_doc: {
     underline: true,
@@ -100,6 +105,7 @@ export const DESTINATION_CAPABILITIES: Record<
     exportFormat: 'html',
     exportButtonLabel: '↑ COPY RICH',
     exportSuccessLabel: 'COPIED RICH ✓',
+    showPasteMarkdown: false,
   },
   plain_md: {
     underline: false,
@@ -108,6 +114,7 @@ export const DESTINATION_CAPABILITIES: Record<
     exportFormat: 'markdown',
     exportButtonLabel: '↑ COPY MD',
     exportSuccessLabel: 'COPIED MD ✓',
+    showPasteMarkdown: true,
   },
   youtube_script: {
     underline: false,
@@ -116,6 +123,7 @@ export const DESTINATION_CAPABILITIES: Record<
     exportFormat: 'markdown',
     exportButtonLabel: '↑ COPY MD',
     exportSuccessLabel: 'COPIED MD ✓',
+    showPasteMarkdown: true,
   },
   other: {
     underline: true,
@@ -124,6 +132,7 @@ export const DESTINATION_CAPABILITIES: Record<
     exportFormat: 'markdown',
     exportButtonLabel: '↑ COPY MD',
     exportSuccessLabel: 'COPIED MD ✓',
+    showPasteMarkdown: true,
   },
 };
 

--- a/webapp/src/pages/DraftWorkspacePage.tsx
+++ b/webapp/src/pages/DraftWorkspacePage.tsx
@@ -1466,24 +1466,28 @@ export function DraftWorkspacePage(_props: Props) {
           {exportState === 'error' && 'COPY FAILED'}
           {exportState === 'idle' && capabilities.exportButtonLabel}
         </button>
-        <button
-          type="button"
-          className={`editorial-po-draft-import${
-            importState === 'pasted' ? ' editorial-po-draft-import-pasted' : ''
-          }${
-            importState === 'error' ? ' editorial-po-draft-import-error' : ''
-          }`}
-          onClick={() => {
-            void handleImportMarkdown();
-          }}
-          disabled={!editor}
-          aria-live="polite"
-          title="Replace the draft with markdown from your clipboard (a pre-paste snapshot is captured to Versions)"
-        >
-          {importState === 'pasted' && 'PASTED ✓'}
-          {importState === 'error' && 'PASTE FAILED'}
-          {importState === 'idle' && '↓ PASTE MD'}
-        </button>
+        {capabilities.showPasteMarkdown ? (
+          <button
+            type="button"
+            className={`editorial-po-draft-import${
+              importState === 'pasted'
+                ? ' editorial-po-draft-import-pasted'
+                : ''
+            }${
+              importState === 'error' ? ' editorial-po-draft-import-error' : ''
+            }`}
+            onClick={() => {
+              void handleImportMarkdown();
+            }}
+            disabled={!editor}
+            aria-live="polite"
+            title="Replace the draft with markdown from your clipboard (a pre-paste snapshot is captured to Versions)"
+          >
+            {importState === 'pasted' && 'PASTED ✓'}
+            {importState === 'error' && 'PASTE FAILED'}
+            {importState === 'idle' && '↓ PASTE MD'}
+          </button>
+        ) : null}
         <Link
           to="/editorial/points-outline"
           className="editorial-po-draft-back"


### PR DESCRIPTION
## Summary

Adds `showPasteMarkdown: boolean` to `ToolbarCapabilities`. The PASTE MD button only renders when the destination's typical paste-in source is markdown.

| Destination | PASTE MD button |
|---|---|
| Substack · Markdown export | ✅ shown |
| Plain Markdown | ✅ shown |
| Google Doc | ❌ hidden |
| YouTube Script | ✅ shown |
| Other | ✅ shown |

For Google Doc, Tiptap handles HTML paste natively into the editor body when the user does Cmd+V on rich-text content — the button would just be clutter for that workflow.

Canonical-JSON guarantee unchanged: pasted content still lands as proper Tiptap nodes, just via a different paste path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)