### PR TITLE
feat: Setup · Audience section — persona library + selected list

### DIFF
--- a/webapp/src/lib/editorial-fixtures.ts
+++ b/webapp/src/lib/editorial-fixtures.ts
@@ -1,0 +1,132 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Editorial Room — fixture data (personas, agent profiles, scoring pipelines).
+//
+// At v0p these are static tables that mirror what the rocketorchestra
+// `personas`, agent-profile, and scoring-pipeline libraries will return when
+// wired up. The shapes match the design intent in:
+//   - docs/design/01_setup.md §5–9
+//   - docs/EDITORIAL_ROOM_CONTRACT.md §2
+//
+// When the real backend lands, these consts get replaced with API loads;
+// consumers (EditorialSetupPage, panel chat, scoring tables) keep the same
+// shape.
+// ───────────────────────────────────────────────────────────────────────────
+
+export type PersonaColor =
+  | 'green'
+  | 'red'
+  | 'blue'
+  | 'gold'
+  | 'purple'
+  | 'teal';
+
+export type Persona = {
+  slug: string;
+  name: string;
+  monogram: string;
+  color: PersonaColor;
+  occupation: string;
+  cohortTag: string;
+  location: string;
+  voiceQuote: string;
+  lastEditDays: number;
+  suggested?: 'yellow' | 'red';
+};
+
+// Persona library matching the GameMakers working example. A / R / M
+// colors carry through into Draft panel chat avatars.
+export const FIXTURE_PERSONAS: ReadonlyArray<Persona> = [
+  {
+    slug: 'persona/ankit-sharma',
+    name: 'Ankit Sharma',
+    monogram: 'A',
+    color: 'green',
+    occupation: 'indie dev · solo',
+    cohortTag: 'indie_dev_economics',
+    location: 'Bangalore',
+    voiceQuote: "If you can't show me the MG schedule, I won't sign.",
+    lastEditDays: 3,
+  },
+  {
+    slug: 'persona/ravi-mehra',
+    name: 'Ravi Mehra',
+    monogram: 'R',
+    color: 'red',
+    occupation: 'studio lead · 14 ppl',
+    cohortTag: 'studio_operator',
+    location: 'Mumbai',
+    voiceQuote: 'Cash flow first. The rest is theology.',
+    lastEditDays: 3,
+  },
+  {
+    slug: 'persona/mei-tanaka',
+    name: 'Mei Tanaka',
+    monogram: 'M',
+    color: 'blue',
+    occupation: 'publisher BD',
+    cohortTag: 'publisher_bd',
+    location: 'Tokyo',
+    voiceQuote: "If you can't define recoupment, you don't have a deal.",
+    lastEditDays: 3,
+    suggested: 'yellow',
+  },
+  {
+    slug: 'persona/sarah-chen',
+    name: 'Sarah Chen',
+    monogram: 'S',
+    color: 'gold',
+    occupation: 'solo journalist · ex-PCG',
+    cohortTag: 'trade_press',
+    location: 'San Francisco',
+    voiceQuote: "I don't quote unless you name a source.",
+    lastEditDays: 3,
+  },
+  {
+    slug: 'persona/diego-rivera',
+    name: 'Diego Rivera',
+    monogram: 'D',
+    color: 'purple',
+    occupation: 'QA lead · 4-yr ten.',
+    cohortTag: 'studio_ops',
+    location: 'Mexico City',
+    voiceQuote: 'I want to know what shipped vs what was promised.',
+    lastEditDays: 3,
+  },
+  {
+    slug: 'persona/yuki-watanabe',
+    name: 'Yuki Watanabe',
+    monogram: 'Y',
+    color: 'teal',
+    occupation: 'platform program lead',
+    cohortTag: 'platform_relations',
+    location: 'Tokyo',
+    voiceQuote: "We don't comment, but we read everything.",
+    lastEditDays: 5,
+  },
+  {
+    slug: 'persona/priya-iyer',
+    name: 'Priya Iyer',
+    monogram: 'P',
+    color: 'red',
+    occupation: 'investor · seed/A',
+    cohortTag: 'venture_lp',
+    location: 'Singapore',
+    voiceQuote: 'Tell me which deals would close today.',
+    lastEditDays: 5,
+  },
+  {
+    slug: 'persona/jonas-petersen',
+    name: 'Jonas Petersen',
+    monogram: 'J',
+    color: 'blue',
+    occupation: 'co-op studio rep',
+    cohortTag: 'cooperative_studios',
+    location: 'Copenhagen',
+    voiceQuote: 'Bands of 5–10 are the only sustainable shape.',
+    lastEditDays: 5,
+  },
+];
+
+export function getPersonaBySlug(slug: string): Persona | null {
+  return FIXTURE_PERSONAS.find((p) => p.slug === slug) ?? null;
+}

--- a/webapp/src/pages/EditorialSetupPage.tsx
+++ b/webapp/src/pages/EditorialSetupPage.tsx
@@ -2,9 +2,13 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
 import {
+  FIXTURE_PERSONAS,
+  getPersonaBySlug,
+  type Persona,
+} from '../lib/editorial-fixtures';
+import {
   DELIVERABLE_LABELS,
   DESTINATION_LABELS,
-  defaultSetupState,
   loadSetupState,
   saveSetupState,
   type DeliverableType,
@@ -193,13 +197,7 @@ export function EditorialSetupPage(_props: Props) {
             <DeliverableSection setup={setup} update={update} nav={navProps} />
           )}
           {activeSection === 'audience' && (
-            <StubSection
-              num="02"
-              title="Who is this for?"
-              copy="Add personas from your library. Each one becomes a scoring perspective at every layer."
-              note="Persona library picker, suggestions, weight editing — coming next slice."
-              nav={navProps}
-            />
+            <AudienceSection setup={setup} update={update} nav={navProps} />
           )}
           {activeSection === 'llm-room' && (
             <StubSection
@@ -442,6 +440,244 @@ function DeliverableSection({
           </button>
         </fieldset>
       </div>
+
+      <div className="editorial-section-footer">
+        <span className="editorial-section-footer-meta">
+          setup_version {setup.setup_version} · changes stale dependent scores
+        </span>
+      </div>
+    </section>
+  );
+}
+
+function matchesPersonaSearch(p: Persona, query: string): boolean {
+  const q = query.toLowerCase().trim();
+  if (q === '') return true;
+  return (
+    p.name.toLowerCase().includes(q) ||
+    p.occupation.toLowerCase().includes(q) ||
+    p.cohortTag.toLowerCase().includes(q) ||
+    p.location.toLowerCase().includes(q)
+  );
+}
+
+function AudienceSection({
+  setup,
+  update,
+  nav,
+}: {
+  setup: SetupState;
+  update: (patch: Partial<SetupState>) => void;
+  nav: SectionNavProps;
+}) {
+  const [search, setSearch] = useState('');
+
+  const selected = useMemo<Persona[]>(
+    () =>
+      setup.audience_persona_slugs
+        .map((slug) => getPersonaBySlug(slug))
+        .filter((p): p is Persona => p !== null),
+    [setup.audience_persona_slugs],
+  );
+
+  const available = useMemo<Persona[]>(
+    () =>
+      FIXTURE_PERSONAS.filter(
+        (p) =>
+          !setup.audience_persona_slugs.includes(p.slug) &&
+          matchesPersonaSearch(p, search),
+      ),
+    [setup.audience_persona_slugs, search],
+  );
+
+  const suggested = useMemo<Persona | null>(
+    () =>
+      available.find(
+        (p) => p.suggested === 'yellow' || p.suggested === 'red',
+      ) ?? null,
+    [available],
+  );
+
+  const addPersona = (slug: string): void => {
+    if (setup.audience_persona_slugs.includes(slug)) return;
+    update({
+      audience_persona_slugs: [...setup.audience_persona_slugs, slug],
+    });
+  };
+
+  const removePersona = (slug: string): void => {
+    update({
+      audience_persona_slugs: setup.audience_persona_slugs.filter(
+        (s) => s !== slug,
+      ),
+    });
+  };
+
+  return (
+    <section className="editorial-section-workspace">
+      <SectionHeader
+        num="02"
+        title="Who is this for?"
+        copy="Add personas from your library. Each one becomes a scoring perspective at every layer."
+        nav={nav}
+      />
+
+      <div className="editorial-personas-selected">
+        <h3 className="editorial-personas-section-label">
+          SELECTED · {selected.length}
+        </h3>
+        {selected.length === 0 ? (
+          <p className="editorial-personas-empty">
+            No personas added yet — pick from the library below.
+          </p>
+        ) : (
+          <ul className="editorial-personas-selected-list">
+            {selected.map((p) => (
+              <li key={p.slug} className="editorial-persona-row">
+                <span
+                  className={`editorial-persona-avatar editorial-persona-avatar-${p.color}`}
+                  aria-hidden="true"
+                >
+                  {p.monogram}
+                </span>
+                <div className="editorial-persona-row-text">
+                  <div className="editorial-persona-row-headline">
+                    <span className="editorial-persona-name">{p.name}</span>
+                    <span className="editorial-persona-cohort">
+                      {p.cohortTag}
+                    </span>
+                  </div>
+                  <span className="editorial-persona-subtitle">
+                    {p.occupation} · {p.location}
+                  </span>
+                </div>
+                <span className="editorial-persona-weight">PRIMARY</span>
+                <div className="editorial-persona-row-actions">
+                  <button
+                    type="button"
+                    className="editorial-chip-button"
+                    disabled
+                    title="Per-persona weight editing coming next slice"
+                  >
+                    EDIT WEIGHT
+                  </button>
+                  <button
+                    type="button"
+                    className="editorial-chip-button"
+                    onClick={() => removePersona(p.slug)}
+                  >
+                    REMOVE
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="editorial-personas-library">
+        <header className="editorial-personas-library-header">
+          <h3 className="editorial-personas-section-label">
+            ADD FROM PERSONA LIBRARY
+          </h3>
+          <p className="editorial-personas-library-blurb">
+            {FIXTURE_PERSONAS.length} personas in library · suggested by
+            deliverable + theme tag
+          </p>
+          <input
+            type="search"
+            className="editorial-personas-search"
+            placeholder="search personas…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            aria-label="Search persona library"
+          />
+        </header>
+
+        {available.length === 0 ? (
+          <p className="editorial-personas-empty">
+            {search.trim() === ''
+              ? 'All personas already added.'
+              : `No personas match "${search}".`}
+          </p>
+        ) : (
+          <ul className="editorial-personas-library-grid">
+            {available.map((p) => (
+              <li
+                key={p.slug}
+                className={`editorial-persona-card${
+                  p.suggested ? ' editorial-persona-card-suggested' : ''
+                }`}
+              >
+                {p.suggested ? (
+                  <span
+                    className={`editorial-persona-suggested editorial-persona-suggested-${p.suggested}`}
+                  >
+                    ● SUGGESTED
+                  </span>
+                ) : null}
+                <div className="editorial-persona-card-body">
+                  <span
+                    className={`editorial-persona-avatar editorial-persona-avatar-${p.color}`}
+                    aria-hidden="true"
+                  >
+                    {p.monogram}
+                  </span>
+                  <h4 className="editorial-persona-name">{p.name}</h4>
+                  <p className="editorial-persona-subtitle">
+                    {p.occupation} · {p.location}
+                  </p>
+                  <span className="editorial-persona-cohort">
+                    {p.cohortTag}
+                  </span>
+                  <p className="editorial-persona-quote">“{p.voiceQuote}”</p>
+                </div>
+                <footer className="editorial-persona-card-footer">
+                  <span className="editorial-persona-lastedit">
+                    LAST EDIT · {p.lastEditDays}D
+                  </span>
+                  <button
+                    type="button"
+                    className={`editorial-chip-button${
+                      p.suggested ? ' editorial-chip-button-primary' : ''
+                    }`}
+                    onClick={() => addPersona(p.slug)}
+                  >
+                    + ADD
+                  </button>
+                </footer>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {suggested ? (
+        <div className="editorial-personas-suggestion">
+          <p className="editorial-personas-suggestion-text">
+            <strong>{suggested.name}</strong> is suggested — your deliverable
+            tags include <code>publishing_economics</code> and your library has
+            a <code>{suggested.cohortTag}</code> persona.
+          </p>
+          <div className="editorial-personas-suggestion-actions">
+            <button
+              type="button"
+              className="editorial-chip-button"
+              disabled
+              title="Persona authoring lands when rocketorchestra wires up"
+            >
+              + NEW PERSONA
+            </button>
+            <button
+              type="button"
+              className="editorial-chip-button editorial-chip-button-primary"
+              onClick={() => addPersona(suggested.slug)}
+            >
+              ADD SUGGESTED
+            </button>
+          </div>
+        </div>
+      ) : null}
 
       <div className="editorial-section-footer">
         <span className="editorial-section-footer-meta">

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -4903,6 +4903,341 @@ a {
   color: #7a2419;
 }
 
+/* Setup · Audience section */
+
+.editorial-personas-selected {
+  margin-top: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.editorial-personas-section-label {
+  margin: 0;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #6c6655;
+  font-weight: 500;
+}
+
+.editorial-personas-empty {
+  margin: 0;
+  padding: 0.7rem 0.9rem;
+  background: #fbf8f2;
+  border: 1px dashed #c9c0a8;
+  border-radius: 5px;
+  font-size: 0.84rem;
+  color: #6c6655;
+  font-style: italic;
+}
+
+.editorial-personas-selected-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.editorial-persona-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: #fff;
+  border: 1px solid #ddd6c8;
+  border-radius: 6px;
+  padding: 0.6rem 0.75rem;
+}
+
+.editorial-persona-avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'IBM Plex Sans', system-ui, sans-serif;
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: #fff;
+  background: #1f1c14;
+  flex-shrink: 0;
+}
+
+.editorial-persona-avatar-green {
+  background: #2e7d62;
+}
+
+.editorial-persona-avatar-red {
+  background: #b7372a;
+}
+
+.editorial-persona-avatar-blue {
+  background: #5b6dad;
+}
+
+.editorial-persona-avatar-gold {
+  background: #c98a2c;
+}
+
+.editorial-persona-avatar-purple {
+  background: #6e4a8a;
+}
+
+.editorial-persona-avatar-teal {
+  background: #2c8a8a;
+}
+
+.editorial-persona-row-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.editorial-persona-row-headline {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.editorial-persona-name {
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-weight: 600;
+  font-size: 0.96rem;
+  color: #1f1c14;
+}
+
+.editorial-persona-cohort {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+  color: #5b5644;
+  border: 1px solid #c9c0a8;
+  border-radius: 3px;
+  padding: 0.05rem 0.4rem;
+  white-space: nowrap;
+}
+
+.editorial-persona-subtitle {
+  font-size: 0.78rem;
+  color: #6c6655;
+  font-family: 'IBM Plex Sans', system-ui, sans-serif;
+}
+
+.editorial-persona-weight {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #b7372a;
+  border: 1px solid #b7372a;
+  border-radius: 3px;
+  padding: 0.1rem 0.45rem;
+  font-weight: 500;
+}
+
+.editorial-persona-row-actions {
+  display: flex;
+  gap: 0.35rem;
+}
+
+/* Library grid */
+
+.editorial-personas-library {
+  margin-top: 1.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.editorial-personas-library-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.editorial-personas-library-blurb {
+  margin: 0;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.04em;
+  color: #6c6655;
+  text-transform: uppercase;
+}
+
+.editorial-personas-search {
+  border: 1px solid #c9c0a8;
+  border-radius: 5px;
+  padding: 0.4rem 0.6rem;
+  font-family: 'IBM Plex Sans', system-ui, sans-serif;
+  font-size: 0.85rem;
+  background: #fff;
+  color: #1f1c14;
+  max-width: 360px;
+}
+
+.editorial-personas-search:focus {
+  outline: none;
+  border-color: #b7372a;
+  box-shadow: 0 0 0 1px #b7372a;
+}
+
+.editorial-personas-library-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+@media (max-width: 1180px) {
+  .editorial-personas-library-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .editorial-personas-library-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.editorial-persona-card {
+  position: relative;
+  background: #fff;
+  border: 1px solid #ddd6c8;
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transition:
+    border-color 100ms,
+    box-shadow 100ms;
+}
+
+.editorial-persona-card:hover {
+  border-color: #c9c0a8;
+}
+
+.editorial-persona-card-suggested {
+  border-color: #b7372a;
+  box-shadow: 0 0 0 1px rgba(183, 55, 42, 0.1);
+}
+
+.editorial-persona-suggested {
+  position: absolute;
+  top: 0.4rem;
+  left: 0.4rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.55rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+}
+
+.editorial-persona-suggested-yellow {
+  color: #8a6d2c;
+  background: #fff5d8;
+}
+
+.editorial-persona-suggested-red {
+  color: #b7372a;
+  background: #fff0eb;
+}
+
+.editorial-persona-card-body {
+  padding: 0.8rem 0.75rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  flex: 1;
+}
+
+.editorial-persona-card-body .editorial-persona-avatar {
+  align-self: flex-start;
+  margin-bottom: 0.3rem;
+}
+
+.editorial-persona-card-body .editorial-persona-name {
+  font-size: 0.92rem;
+}
+
+.editorial-persona-card-body .editorial-persona-cohort {
+  align-self: flex-start;
+}
+
+.editorial-persona-quote {
+  margin: 0.3rem 0 0;
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-style: italic;
+  font-size: 0.82rem;
+  color: #4a4738;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.editorial-persona-card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  border-top: 1px solid #efe9d8;
+  background: #fbf8f2;
+}
+
+.editorial-persona-lastedit {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.04em;
+  color: #8a8268;
+  text-transform: uppercase;
+}
+
+.editorial-personas-suggestion {
+  margin-top: 1rem;
+  padding: 0.7rem 0.85rem;
+  background: #fff8e7;
+  border: 1px solid #c98a2c;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.editorial-personas-suggestion-text {
+  margin: 0;
+  font-size: 0.84rem;
+  color: #4a4738;
+  flex: 1;
+  min-width: 0;
+}
+
+.editorial-personas-suggestion-text code {
+  background: #fff;
+  border: 1px solid #e2dccc;
+  border-radius: 3px;
+  padding: 0 0.3rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.78rem;
+}
+
+.editorial-personas-suggestion-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
 .editorial-setup-preview {
   border-left: 1px solid #ddd6c8;
   padding: 1.1rem 1rem;


### PR DESCRIPTION
## Summary

Replaces the Audience stub with the real section per `docs/design/01_setup.md` §5. Fixture-only at v0p; the data shape mirrors what rocketorchestra's persona library will return when wired.

## What's new

### `webapp/src/lib/editorial-fixtures.ts` (new)
8 personas built around the GameMakers working example. A / R / M monogram colors carry through to Draft panel chat avatars so the cast is consistent across phases.

### Audience section surfaces

- **`SELECTED · N`** list of persona rows: avatar + name + cohort chip + occupation/location subtitle + `PRIMARY` weight chip + `EDIT WEIGHT` / `REMOVE` actions
- **`ADD FROM PERSONA LIBRARY`** — 3-column grid of persona cards with avatar / name / occupation / cohort / italic voice quote / `LAST EDIT · 3D` / `+ ADD` button
- **Suggested-persona signal** — yellow/red `● SUGGESTED` badge top-left, accent border, accent `+ ADD` button. Mei is suggested in the fixture.
- **Footer suggestion bar** — explanation + `+ NEW PERSONA` (disabled) + `ADD SUGGESTED` actions

Search filters across name / occupation / cohortTag / location.

## Persistence

Adding/removing personas writes to `audience_persona_slugs[]` via the existing `update()` flow, which bumps `setup_version` and stales dependent scores. localStorage persists across reloads.

## Deferred

- Per-persona weight editing (PRIMARY / SECONDARY / COUNTER toggle)
- `+ NEW PERSONA` authoring (depends on rocketorchestra persona page)
- `FILTERS` drawer (basic search ships; advanced filters next slice)

## Test plan

- [ ] `/editorial/setup` → click Audience tab in left rail
- [ ] SELECTED · 0 with empty-state copy
- [ ] Mei card has `● SUGGESTED` yellow badge + accent + ADD
- [ ] Click + ADD on Ankit → moves to selected list, removed from library, count bumps
- [ ] Click ADD SUGGESTED → Mei joins selected list
- [ ] Search "studio" → only studio_operator / studio_ops / cooperative_studios cards remain
- [ ] REMOVE on a selected persona → returns to library
- [ ] Reload page → selections persist (localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)