### PR TITLE
feat: Setup · LLM Room section — agent profile picker

### DIFF
--- a/webapp/src/lib/editorial-fixtures.ts
+++ b/webapp/src/lib/editorial-fixtures.ts
@@ -130,3 +130,96 @@ export const FIXTURE_PERSONAS: ReadonlyArray<Persona> = [
 export function getPersonaBySlug(slug: string): Persona | null {
   return FIXTURE_PERSONAS.find((p) => p.slug === slug) ?? null;
 }
+
+// ─── LLM Room agent profile library ─────────────────────────────────────────
+// Agent profiles are the AI critics on the panel — not anonymous chips per
+// design §11 anti-pattern. Each is named, has a surface model + provider,
+// a stance, and a per-turn cost so the user always sees what they're paying
+// for and how the agent will critique.
+
+export type AgentProfile = {
+  id: string;
+  name: string;
+  role: string;
+  monogram: string;
+  color: PersonaColor;
+  model: string;
+  provider: string;
+  stance: string;
+  costPerTurnUsd: number;
+  suggested?: boolean;
+};
+
+export const FIXTURE_AGENT_PROFILES: ReadonlyArray<AgentProfile> = [
+  {
+    id: 'agent/argus',
+    name: 'Argus',
+    role: 'argument critic',
+    monogram: 'A',
+    color: 'green',
+    model: 'CLAUDE-OPUS-4',
+    provider: 'ANTHROPIC',
+    stance: 'hostile to weak claims · steelmans counters',
+    costPerTurnUsd: 0.04,
+  },
+  {
+    id: 'agent/marisol',
+    name: 'Marisol',
+    role: 'narrative shaper',
+    monogram: 'M',
+    color: 'blue',
+    model: 'GPT-5',
+    provider: 'OPENAI',
+    stance: 'tightens prose · won’t soften claims',
+    costPerTurnUsd: 0.03,
+  },
+  {
+    id: 'agent/kenji',
+    name: 'Kenji',
+    role: 'source auditor',
+    monogram: 'K',
+    color: 'red',
+    model: 'GEMINI-2-PRO',
+    provider: 'GOOGLE',
+    stance: 'verifies citations · flags missing primary sources',
+    costPerTurnUsd: 0.02,
+  },
+  {
+    id: 'agent/voice-critic',
+    name: 'Voice Critic',
+    role: 'voice consistency',
+    monogram: 'V',
+    color: 'gold',
+    model: 'CLAUDE-OPUS-4',
+    provider: 'ANTHROPIC',
+    stance: 'enforces voice page rules · catches drift',
+    costPerTurnUsd: 0.04,
+    suggested: true,
+  },
+  {
+    id: 'agent/ada',
+    name: 'Ada',
+    role: 'structure scout',
+    monogram: 'D',
+    color: 'purple',
+    model: 'CLAUDE-SONNET-4',
+    provider: 'ANTHROPIC',
+    stance: 'evaluates section flow + length',
+    costPerTurnUsd: 0.02,
+  },
+  {
+    id: 'agent/counter',
+    name: 'Counter',
+    role: 'adversarial reader',
+    monogram: 'C',
+    color: 'teal',
+    model: 'GPT-5',
+    provider: 'OPENAI',
+    stance: 'argues the opposite case · finds blind spots',
+    costPerTurnUsd: 0.04,
+  },
+];
+
+export function getAgentProfileById(id: string): AgentProfile | null {
+  return FIXTURE_AGENT_PROFILES.find((a) => a.id === id) ?? null;
+}

--- a/webapp/src/pages/EditorialSetupPage.tsx
+++ b/webapp/src/pages/EditorialSetupPage.tsx
@@ -2,8 +2,11 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
 import {
+  FIXTURE_AGENT_PROFILES,
   FIXTURE_PERSONAS,
+  getAgentProfileById,
   getPersonaBySlug,
+  type AgentProfile,
   type Persona,
 } from '../lib/editorial-fixtures';
 import {
@@ -200,13 +203,7 @@ export function EditorialSetupPage(_props: Props) {
             <AudienceSection setup={setup} update={update} nav={navProps} />
           )}
           {activeSection === 'llm-room' && (
-            <StubSection
-              num="03"
-              title="Who is in the LLM Room?"
-              copy="Pick agent profiles that critique, propose, and score during the run."
-              note="Agent library + per-agent stance/cost — coming next slice."
-              nav={navProps}
-            />
+            <LLMRoomSection setup={setup} update={update} nav={navProps} />
           )}
           {activeSection === 'scoring' && (
             <StubSection
@@ -676,6 +673,195 @@ function AudienceSection({
               ADD SUGGESTED
             </button>
           </div>
+        </div>
+      ) : null}
+
+      <div className="editorial-section-footer">
+        <span className="editorial-section-footer-meta">
+          setup_version {setup.setup_version} · changes stale dependent scores
+        </span>
+      </div>
+    </section>
+  );
+}
+
+function LLMRoomSection({
+  setup,
+  update,
+  nav,
+}: {
+  setup: SetupState;
+  update: (patch: Partial<SetupState>) => void;
+  nav: SectionNavProps;
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const selected = useMemo<AgentProfile[]>(
+    () =>
+      setup.llm_room_agent_profile_ids
+        .map((id) => getAgentProfileById(id))
+        .filter((a): a is AgentProfile => a !== null),
+    [setup.llm_room_agent_profile_ids],
+  );
+
+  const available = useMemo<AgentProfile[]>(
+    () =>
+      FIXTURE_AGENT_PROFILES.filter(
+        (a) => !setup.llm_room_agent_profile_ids.includes(a.id),
+      ),
+    [setup.llm_room_agent_profile_ids],
+  );
+
+  const totalCostPerTurn = useMemo(
+    () => selected.reduce((sum, a) => sum + a.costPerTurnUsd, 0),
+    [selected],
+  );
+
+  const addAgent = (id: string): void => {
+    if (setup.llm_room_agent_profile_ids.includes(id)) return;
+    update({
+      llm_room_agent_profile_ids: [...setup.llm_room_agent_profile_ids, id],
+    });
+  };
+
+  const removeAgent = (id: string): void => {
+    update({
+      llm_room_agent_profile_ids: setup.llm_room_agent_profile_ids.filter(
+        (i) => i !== id,
+      ),
+    });
+  };
+
+  return (
+    <section className="editorial-section-workspace">
+      <SectionHeader
+        num="03"
+        title="Who is in the LLM Room?"
+        copy="Pick agent profiles that critique, propose, and score during the run. Each one is a named voice with a surface model, a stance, and a per-turn cost — never an anonymous chip."
+        nav={nav}
+      />
+
+      <div className="editorial-agents-selected">
+        <h3 className="editorial-personas-section-label">
+          ACTIVE · {selected.length}
+        </h3>
+        {selected.length === 0 ? (
+          <p className="editorial-personas-empty">
+            No agents in the room yet — pick at least two so a panel turn can
+            run.
+          </p>
+        ) : (
+          <ul className="editorial-agents-list">
+            {selected.map((a) => (
+              <li key={a.id} className="editorial-agent-row">
+                <span
+                  className={`editorial-persona-avatar editorial-persona-avatar-${a.color}`}
+                  aria-hidden="true"
+                >
+                  {a.monogram}
+                </span>
+                <div className="editorial-agent-row-text">
+                  <div className="editorial-agent-headline">
+                    <span className="editorial-persona-name">{a.name}</span>
+                    <span className="editorial-agent-role">{a.role}</span>
+                  </div>
+                  <p className="editorial-agent-stance">{a.stance}</p>
+                </div>
+                <span className="editorial-agent-model">
+                  {a.model} · {a.provider}
+                </span>
+                <span className="editorial-agent-cost">
+                  ~${a.costPerTurnUsd.toFixed(2)}/TURN
+                </span>
+                <button
+                  type="button"
+                  className="editorial-chip-button"
+                  onClick={() => removeAgent(a.id)}
+                >
+                  REMOVE
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="editorial-agents-footer">
+        <span className="editorial-agents-footer-meta">
+          {selected.length} ACTIVE · ALL PROFILES FROM AGENT-PROFILE LIBRARY ·
+          EST. ~${totalCostPerTurn.toFixed(2)} PER PANEL TURN
+        </span>
+        <div className="editorial-agents-footer-actions">
+          <button
+            type="button"
+            className="editorial-chip-button editorial-chip-button-primary"
+            onClick={() => setPickerOpen((open) => !open)}
+            disabled={available.length === 0}
+          >
+            {pickerOpen ? '✕ CLOSE PICKER' : '+ ADD AGENT'}
+          </button>
+          <button type="button" className="editorial-chip-button" disabled>
+            BROWSE LIBRARY
+          </button>
+        </div>
+      </div>
+
+      {pickerOpen && available.length > 0 ? (
+        <div className="editorial-agents-picker">
+          <h3 className="editorial-personas-section-label">
+            AGENT LIBRARY · {available.length} AVAILABLE
+          </h3>
+          <ul className="editorial-agents-picker-grid">
+            {available.map((a) => (
+              <li
+                key={a.id}
+                className={`editorial-agent-card${
+                  a.suggested ? ' editorial-agent-card-suggested' : ''
+                }`}
+              >
+                {a.suggested ? (
+                  <span className="editorial-persona-suggested editorial-persona-suggested-yellow">
+                    ● SUGGESTED
+                  </span>
+                ) : null}
+                <div className="editorial-agent-card-body">
+                  <div className="editorial-agent-card-headline">
+                    <span
+                      className={`editorial-persona-avatar editorial-persona-avatar-${a.color}`}
+                      aria-hidden="true"
+                    >
+                      {a.monogram}
+                    </span>
+                    <div>
+                      <h4 className="editorial-persona-name">{a.name}</h4>
+                      <span className="editorial-agent-role">{a.role}</span>
+                    </div>
+                  </div>
+                  <span className="editorial-agent-model">
+                    {a.model} · {a.provider}
+                  </span>
+                  <p className="editorial-agent-stance">{a.stance}</p>
+                </div>
+                <footer className="editorial-agent-card-footer">
+                  <span className="editorial-agent-cost">
+                    ~${a.costPerTurnUsd.toFixed(2)}/TURN
+                  </span>
+                  <button
+                    type="button"
+                    className={`editorial-chip-button${
+                      a.suggested ? ' editorial-chip-button-primary' : ''
+                    }`}
+                    onClick={() => {
+                      addAgent(a.id);
+                      if (available.length === 1) setPickerOpen(false);
+                    }}
+                  >
+                    + ADD
+                  </button>
+                </footer>
+              </li>
+            ))}
+          </ul>
         </div>
       ) : null}
 

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -5238,6 +5238,181 @@ a {
   gap: 0.4rem;
 }
 
+/* Setup · LLM Room section */
+
+.editorial-agents-selected {
+  margin-top: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.editorial-agents-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.editorial-agent-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.7rem;
+  background: #fff;
+  border: 1px solid #ddd6c8;
+  border-radius: 6px;
+  padding: 0.55rem 0.75rem;
+}
+
+.editorial-agent-row-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.editorial-agent-headline {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.editorial-agent-role {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+}
+
+.editorial-agent-stance {
+  margin: 0;
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-style: italic;
+  font-size: 0.82rem;
+  color: #4a4738;
+  line-height: 1.4;
+}
+
+.editorial-agent-model {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  color: #5b5644;
+  border: 1px solid #c9c0a8;
+  border-radius: 3px;
+  padding: 0.12rem 0.45rem;
+  white-space: nowrap;
+  text-transform: uppercase;
+}
+
+.editorial-agent-cost {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6c6655;
+  white-space: nowrap;
+}
+
+.editorial-agents-footer {
+  margin-top: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+}
+
+.editorial-agents-footer-meta {
+  flex: 1;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #6c6655;
+  min-width: 0;
+}
+
+.editorial-agents-footer-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.editorial-agents-picker {
+  margin-top: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.editorial-agents-picker-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+@media (max-width: 880px) {
+  .editorial-agents-picker-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .editorial-agent-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-rows: auto auto auto;
+    row-gap: 0.4rem;
+  }
+}
+
+.editorial-agent-card {
+  position: relative;
+  background: #fff;
+  border: 1px solid #ddd6c8;
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.editorial-agent-card-suggested {
+  border-color: #b7372a;
+  box-shadow: 0 0 0 1px rgba(183, 55, 42, 0.1);
+}
+
+.editorial-agent-card-body {
+  padding: 0.8rem 0.85rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.editorial-agent-card-headline {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.editorial-agent-card-headline > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.05rem;
+}
+
+.editorial-agent-card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.85rem;
+  border-top: 1px solid #efe9d8;
+  background: #fbf8f2;
+}
+
 .editorial-setup-preview {
   border-left: 1px solid #ddd6c8;
   padding: 1.1rem 1rem;


### PR DESCRIPTION
## Summary

Replaces the LLM Room stub with the real section per `docs/design/01_setup.md` §9 Section 03. Per the design anti-pattern, agents are **named** with a surface model + provider + stance + per-turn cost — never anonymous chips.

## Fixture agent profiles

| Name | Role | Model · Provider | Cost/turn |
|---|---|---|---|
| Argus | argument critic | Claude Opus 4 · Anthropic | $0.04 |
| Marisol | narrative shaper | GPT-5 · OpenAI | $0.03 |
| Kenji | source auditor | Gemini 2 Pro · Google | $0.02 |
| Voice Critic | voice consistency | Claude Opus 4 · Anthropic | $0.04 (suggested) |
| Ada | structure scout | Claude Sonnet 4 · Anthropic | $0.02 |
| Counter | adversarial reader | GPT-5 · OpenAI | $0.04 |

## Surfaces

- **`ACTIVE · N`** row list: avatar + name + role + italic stance + model chip + cost chip + `REMOVE`
- **Footer:** `N ACTIVE · ALL PROFILES FROM AGENT-PROFILE LIBRARY · EST. ~$X.XX PER PANEL TURN` — total cost recomputes live as agents are added/removed
- **`+ ADD AGENT`** toggles a 2-column picker grid; suggested agents render with the same yellow `● SUGGESTED` treatment as personas
- **`BROWSE LIBRARY`** chip placeholder for richer browsing UI

## Persistence

Writes to `llm_room_agent_profile_ids[]` via the existing `update()` flow. `setup_version` bumps; dependent scores stale per the contract.

## Test plan

- [ ] Setup → click LLM Room tab. Empty state appears.
- [ ] Click `+ ADD AGENT`. Picker grid opens with 6 agents; Voice Critic has the SUGGESTED badge.
- [ ] Click + ADD on Argus → moves to active list. Footer shows `1 ACTIVE · ALL PROFILES… · EST. ~$0.04`.
- [ ] Add Marisol + Kenji. Footer reads `3 ACTIVE · … · ~$0.09`.
- [ ] Click REMOVE on a row. Returns to picker. Cost recomputes.
- [ ] Reload — selections persist (localStorage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)