### PR TITLE
feat: Setup · Scoring System section — pipeline picker + scorers + caps

### DIFF
--- a/webapp/src/lib/editorial-fixtures.ts
+++ b/webapp/src/lib/editorial-fixtures.ts
@@ -223,3 +223,124 @@ export const FIXTURE_AGENT_PROFILES: ReadonlyArray<AgentProfile> = [
 export function getAgentProfileById(id: string): AgentProfile | null {
   return FIXTURE_AGENT_PROFILES.find((a) => a.id === id) ?? null;
 }
+
+// ─── Scoring pipeline library ───────────────────────────────────────────────
+// Each pipeline is a named bundle of scorers (with weights summing to ~1.0
+// across role:score scorers) + budget caps. At v0p the scorers and caps are
+// read-only — tunable inline editing lands when SetupState extends to carry
+// per-piece overrides.
+
+export type ScoringScorer = {
+  name: string;
+  weight: number;
+  description: string;
+  note?: string;
+};
+
+export type BudgetCap = {
+  label: string;
+  value: string;
+};
+
+export type ScoringPipeline = {
+  slug: string;
+  name: string;
+  description: string;
+  scorers: ScoringScorer[];
+  budgetCaps: BudgetCap[];
+};
+
+export const FIXTURE_PIPELINES: ReadonlyArray<ScoringPipeline> = [
+  {
+    slug: 'scoring_pipeline/gamemakers_default',
+    name: 'GameMakers default',
+    description:
+      'Rubric + SSR + voice drift; counter-audience disabled at Theme/Topic, auto-on at Polish.',
+    scorers: [
+      {
+        name: 'RUBRIC JUDGE',
+        weight: 0.4,
+        description:
+          'Opus · 6 axes · stance / claim / source / voice / risk / fit',
+      },
+      {
+        name: 'SSR PANEL',
+        weight: 0.4,
+        description: 'aggregated per-persona scores (audience size × scorers)',
+      },
+      {
+        name: 'VOICE DRIFT',
+        weight: 0.2,
+        description:
+          'rule-based · voice page rules · catches drift across sections',
+      },
+      {
+        name: 'COUNTER-AUDIENCE',
+        weight: 0.0,
+        description: 'adversarial pass against opposite cohort',
+        note: 'Drafts only · disabled at Theme/Topic · auto-on at Polish',
+      },
+    ],
+    budgetCaps: [
+      { label: 'PER TOPIC OPTIM.', value: '$5.00' },
+      { label: 'PER DRAFT OPTIM.', value: '$50.00' },
+      { label: 'PER POLISH ROUND', value: '$0.50' },
+      { label: 'HARD WALLCLOCK', value: '10 MIN' },
+    ],
+  },
+  {
+    slug: 'scoring_pipeline/autonovel_research',
+    name: 'AutoNovel research',
+    description: '5 personas · 4-agent panel · novelty-weighted scoring.',
+    scorers: [
+      {
+        name: 'NOVELTY',
+        weight: 0.3,
+        description: 'penalizes restated claims · rewards new framing',
+      },
+      {
+        name: 'RUBRIC JUDGE',
+        weight: 0.3,
+        description: 'Opus · 6 axes',
+      },
+      {
+        name: 'SSR PANEL',
+        weight: 0.3,
+        description: 'aggregated per-persona',
+      },
+      {
+        name: 'VOICE DRIFT',
+        weight: 0.1,
+        description: 'rule-based',
+      },
+    ],
+    budgetCaps: [
+      { label: 'PER TOPIC OPTIM.', value: '$8.00' },
+      { label: 'PER DRAFT OPTIM.', value: '$80.00' },
+      { label: 'PER POLISH ROUND', value: '$1.00' },
+      { label: 'HARD WALLCLOCK', value: '15 MIN' },
+    ],
+  },
+  {
+    slug: 'scoring_pipeline/memo_short',
+    name: 'Memo · short form',
+    description: '1 persona · 1 agent · rubric-only.',
+    scorers: [
+      {
+        name: 'RUBRIC JUDGE',
+        weight: 1.0,
+        description: 'Opus · single-axis fit',
+      },
+    ],
+    budgetCaps: [
+      { label: 'PER TOPIC OPTIM.', value: '$1.00' },
+      { label: 'PER DRAFT OPTIM.', value: '$10.00' },
+      { label: 'PER POLISH ROUND', value: '$0.10' },
+      { label: 'HARD WALLCLOCK', value: '3 MIN' },
+    ],
+  },
+];
+
+export function getPipelineBySlug(slug: string): ScoringPipeline | null {
+  return FIXTURE_PIPELINES.find((p) => p.slug === slug) ?? null;
+}

--- a/webapp/src/pages/EditorialSetupPage.tsx
+++ b/webapp/src/pages/EditorialSetupPage.tsx
@@ -4,10 +4,13 @@ import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
 import {
   FIXTURE_AGENT_PROFILES,
   FIXTURE_PERSONAS,
+  FIXTURE_PIPELINES,
   getAgentProfileById,
   getPersonaBySlug,
+  getPipelineBySlug,
   type AgentProfile,
   type Persona,
+  type ScoringPipeline,
 } from '../lib/editorial-fixtures';
 import {
   DELIVERABLE_LABELS,
@@ -206,13 +209,7 @@ export function EditorialSetupPage(_props: Props) {
             <LLMRoomSection setup={setup} update={update} nav={navProps} />
           )}
           {activeSection === 'scoring' && (
-            <StubSection
-              num="04"
-              title="What scoring system governs gates?"
-              copy="Pick a scoring pipeline. Tune scorer weights and budget caps inline."
-              note="Pipeline picker · weighted-scorer editor · budget caps — coming next slice."
-              nav={navProps}
-            />
+            <ScoringSection setup={setup} update={update} nav={navProps} />
           )}
         </main>
 
@@ -864,6 +861,113 @@ function LLMRoomSection({
           </ul>
         </div>
       ) : null}
+
+      <div className="editorial-section-footer">
+        <span className="editorial-section-footer-meta">
+          setup_version {setup.setup_version} · changes stale dependent scores
+        </span>
+      </div>
+    </section>
+  );
+}
+
+function ScoringSection({
+  setup,
+  update,
+  nav,
+}: {
+  setup: SetupState;
+  update: (patch: Partial<SetupState>) => void;
+  nav: SectionNavProps;
+}) {
+  const pipeline: ScoringPipeline =
+    getPipelineBySlug(setup.scoring_pipeline_slug) ?? FIXTURE_PIPELINES[0];
+
+  return (
+    <section className="editorial-section-workspace">
+      <SectionHeader
+        num="04"
+        title="What scoring system governs gates?"
+        copy="Pick a scoring pipeline. Each pipeline bundles weighted scorers and budget caps that govern Theme/Topic/Draft optimization. Inline tuning lands when SetupState extends with per-piece overrides."
+        nav={nav}
+      />
+
+      <div className="editorial-scoring-grid">
+        {/* Column 1 — PIPELINE */}
+        <div className="editorial-scoring-col">
+          <h3 className="editorial-personas-section-label">PIPELINE</h3>
+          <select
+            className="editorial-scoring-pipeline-select"
+            value={setup.scoring_pipeline_slug}
+            onChange={(e) => update({ scoring_pipeline_slug: e.target.value })}
+            aria-label="Scoring pipeline"
+          >
+            {FIXTURE_PIPELINES.map((p) => (
+              <option key={p.slug} value={p.slug}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+          <p className="editorial-scoring-pipeline-desc">
+            {pipeline.description}
+          </p>
+          <p className="editorial-scoring-pipeline-meta">
+            slug: <code>{pipeline.slug}</code>
+          </p>
+        </div>
+
+        {/* Column 2 — SCORERS */}
+        <div className="editorial-scoring-col">
+          <h3 className="editorial-personas-section-label">
+            SCORERS · WEIGHTS
+          </h3>
+          <ul className="editorial-scoring-scorers">
+            {pipeline.scorers.map((s) => (
+              <li key={s.name} className="editorial-scoring-scorer">
+                <div className="editorial-scoring-scorer-row">
+                  <span className="editorial-scoring-scorer-name">
+                    {s.name}
+                  </span>
+                  <div className="editorial-scoring-scorer-bar">
+                    <div
+                      className="editorial-scoring-scorer-fill"
+                      style={{ width: `${Math.round(s.weight * 100)}%` }}
+                    />
+                  </div>
+                  <span className="editorial-scoring-scorer-weight">
+                    ×{s.weight.toFixed(2)}
+                  </span>
+                </div>
+                <p className="editorial-scoring-scorer-desc">{s.description}</p>
+                {s.note ? (
+                  <p className="editorial-scoring-scorer-note">{s.note}</p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+          <p className="editorial-scoring-tuning-note">
+            Inline weight tuning is read-only at v0p. Per-piece scorer overrides
+            land when SetupState extends to carry them.
+          </p>
+        </div>
+
+        {/* Column 3 — BUDGET CAPS */}
+        <div className="editorial-scoring-col">
+          <h3 className="editorial-personas-section-label">BUDGET CAPS</h3>
+          <ul className="editorial-scoring-caps">
+            {pipeline.budgetCaps.map((cap) => (
+              <li key={cap.label} className="editorial-scoring-cap">
+                <span className="editorial-scoring-cap-label">{cap.label}</span>
+                <span className="editorial-scoring-cap-value">{cap.value}</span>
+              </li>
+            ))}
+          </ul>
+          <p className="editorial-scoring-tuning-note">
+            Hard caps for OPTIMIZATION_LOOP §5 cost guardrails. Inline editing
+            lands with SetupState overrides.
+          </p>
+        </div>
+      </div>
 
       <div className="editorial-section-footer">
         <span className="editorial-section-footer-meta">

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -5413,6 +5413,214 @@ a {
   background: #fbf8f2;
 }
 
+/* Setup · Scoring System section */
+
+.editorial-scoring-grid {
+  margin-top: 1.4rem;
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(0, 2fr) minmax(180px, 1fr);
+  gap: 1.1rem;
+}
+
+@media (max-width: 1080px) {
+  .editorial-scoring-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.editorial-scoring-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  background: #fff;
+  border: 1px solid #ddd6c8;
+  border-radius: 6px;
+  padding: 0.85rem 0.95rem;
+}
+
+.editorial-scoring-pipeline-select {
+  border: 1px solid #c9c0a8;
+  border-radius: 5px;
+  padding: 0.4rem 0.55rem;
+  font-family: 'IBM Plex Sans', system-ui, sans-serif;
+  font-size: 0.88rem;
+  background: #fbf8f2;
+  color: #1f1c14;
+}
+
+.editorial-scoring-pipeline-select:focus {
+  outline: none;
+  border-color: #b7372a;
+  box-shadow: 0 0 0 1px #b7372a;
+}
+
+.editorial-scoring-pipeline-desc {
+  margin: 0;
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-size: 0.84rem;
+  font-style: italic;
+  color: #4a4738;
+  line-height: 1.4;
+}
+
+.editorial-scoring-pipeline-meta {
+  margin: 0;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+  color: #8a8268;
+  text-transform: uppercase;
+}
+
+.editorial-scoring-pipeline-meta code {
+  background: #fbf8f2;
+  border: 1px solid #e2dccc;
+  border-radius: 3px;
+  padding: 0 0.35rem;
+  font-size: 0.7rem;
+  color: #5b5644;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.editorial-scoring-scorers {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.editorial-scoring-scorer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px dashed #efe9d8;
+}
+
+.editorial-scoring-scorer:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.editorial-scoring-scorer-row {
+  display: grid;
+  grid-template-columns: minmax(120px, max-content) 1fr auto;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.editorial-scoring-scorer-name {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #1f1c14;
+  font-weight: 600;
+}
+
+.editorial-scoring-scorer-bar {
+  position: relative;
+  height: 0.4rem;
+  background: #efe9d8;
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.editorial-scoring-scorer-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  background: #b7372a;
+  border-radius: 2px;
+  transition: width 200ms ease;
+}
+
+.editorial-scoring-scorer-weight {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  color: #1f1c14;
+  font-weight: 600;
+  white-space: nowrap;
+  min-width: 3rem;
+  text-align: right;
+}
+
+.editorial-scoring-scorer-desc {
+  margin: 0;
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-size: 0.78rem;
+  font-style: italic;
+  color: #5b5644;
+  line-height: 1.45;
+  padding-left: 0.05rem;
+}
+
+.editorial-scoring-scorer-note {
+  margin: 0;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #8a6d2c;
+  background: #fff8e7;
+  border: 1px solid #f5d76e;
+  border-radius: 3px;
+  padding: 0.18rem 0.4rem;
+  align-self: flex-start;
+}
+
+.editorial-scoring-tuning-note {
+  margin: 0.5rem 0 0;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #8a8268;
+  line-height: 1.4;
+}
+
+.editorial-scoring-caps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.editorial-scoring-cap {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px dashed #efe9d8;
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+.editorial-scoring-cap:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.editorial-scoring-cap-label {
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+}
+
+.editorial-scoring-cap-value {
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: #1f1c14;
+  letter-spacing: 0.02em;
+}
+
 .editorial-setup-preview {
   border-left: 1px solid #ddd6c8;
   padding: 1.1rem 1rem;


### PR DESCRIPTION
## Summary

Closes **Option A — Setup completion**. Replaces the Scoring stub with the real section per `docs/design/01_setup.md` §9 Section 04. Three-column layout: PIPELINE · SCORERS · BUDGET CAPS.

## Fixture pipelines

| Slug | Name | Scorers (weights) | Topic cap |
|---|---|---|---|
| `gamemakers_default` | GameMakers default | rubric ×0.40 + SSR ×0.40 + voice drift ×0.20 + counter ×0.00 | $5.00 |
| `autonovel_research` | AutoNovel research | novelty ×0.30 + rubric ×0.30 + SSR ×0.30 + voice drift ×0.10 | $8.00 |
| `memo_short` | Memo · short form | rubric ×1.00 | $1.00 |

## UI surfaces

| Column | Content |
|---|---|
| **PIPELINE** | dropdown switching active pipeline + italic description + slug pill |
| **SCORERS · WEIGHTS** | per-scorer rows with name + horizontal weight bar + `×weight` number + italic description; amber inline note for COUNTER-AUDIENCE \"drafts only · disabled at Theme/Topic · auto-on at Polish\" |
| **BUDGET CAPS** | label · value pairs (per-topic, per-draft, per-polish, hard wallclock) |

## v0p caveats

Inline weight tuning is read-only — `SetupState` only carries `scoring_pipeline_slug`, no per-piece scorer overrides yet. Both columns surface a \"tuning is read-only\" footnote so the user understands what's coming. Per-piece overrides land when the contract extends.

## End of Option A

Setup is now feature-complete across all four sections:
- Deliverable (Section 01) — already shipped
- Audience (Section 02) — PR #283
- LLM Room (Section 03) — PR #284
- Scoring System (Section 04) — this PR

## Test plan

- [ ] `/editorial/setup` → click Scoring tab. Three columns render side-by-side.
- [ ] Switch pipeline dropdown to AutoNovel research. Scorers + caps swap, weight bars re-fill.
- [ ] Switch to Memo · short form. Single rubric scorer with full bar fill.
- [ ] COUNTER-AUDIENCE in GameMakers default shows the amber note.
- [ ] Reload — selected pipeline persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)