### PR TITLE
feat: Anthropic OAuth subscription auth — foundation

### DIFF
--- a/src/clawrocket/agents/execution-planner.test.ts
+++ b/src/clawrocket/agents/execution-planner.test.ts
@@ -27,7 +27,7 @@ function seedAnthropicSecret(apiKey = 'sk-ant-test'): void {
        ON CONFLICT(provider_id) DO UPDATE SET ciphertext = excluded.ciphertext,
          updated_at = excluded.updated_at, updated_by = excluded.updated_by`,
     )
-    .run(encryptProviderSecret({ apiKey }), now, 'owner-1');
+    .run(encryptProviderSecret({ kind: 'api_key', apiKey }), now, 'owner-1');
 }
 
 function upsertProviderVerification(

--- a/src/clawrocket/agents/execution-planner.ts
+++ b/src/clawrocket/agents/execution-planner.ts
@@ -167,7 +167,9 @@ export function getAnthropicApiKeyFromDb(): string | null {
   }
 
   try {
-    return decryptProviderSecret(row.ciphertext).apiKey.trim();
+    const payload = decryptProviderSecret(row.ciphertext);
+    if (payload.kind !== 'api_key') return null;
+    return payload.apiKey.trim();
   } catch {
     return null;
   }

--- a/src/clawrocket/agents/execution-preview.test.ts
+++ b/src/clawrocket/agents/execution-preview.test.ts
@@ -23,7 +23,7 @@ function seedAnthropicSecret(apiKey = 'sk-ant-test'): void {
        ON CONFLICT(provider_id) DO UPDATE SET ciphertext = excluded.ciphertext,
          updated_at = excluded.updated_at, updated_by = excluded.updated_by`,
     )
-    .run(encryptProviderSecret({ apiKey }), now, 'owner-1');
+    .run(encryptProviderSecret({ kind: 'api_key', apiKey }), now, 'owner-1');
 }
 
 function seedProviderVerification(providerId: string): void {

--- a/src/clawrocket/agents/execution-resolver.ts
+++ b/src/clawrocket/agents/execution-resolver.ts
@@ -179,8 +179,22 @@ function resolveSecret(
 
   if (secretRecord) {
     try {
-      return decryptProviderSecret(secretRecord.ciphertext);
-    } catch {
+      const payload = decryptProviderSecret(secretRecord.ciphertext);
+      // Talk runtime uses x-api-key auth (direct HTTP). OAuth subscription
+      // tokens are not compatible — they require Bearer auth + the Claude
+      // Code identity headers, which Editorial Room handles separately.
+      // Surface a specific error so callers can fall back / instruct the
+      // user to switch to API-key auth for Talks.
+      if (payload.kind !== 'api_key') {
+        throw new ExecutionResolverError(
+          `Provider ${agent.provider_id} is configured with ${payload.kind} auth — ` +
+            `Talk runtime requires an API key. Connect an API key for direct HTTP execution.`,
+          'SECRET_DECRYPTION_FAILED',
+        );
+      }
+      return { apiKey: payload.apiKey };
+    } catch (err) {
+      if (err instanceof ExecutionResolverError) throw err;
       throw new ExecutionResolverError(
         `Failed to decrypt provider secret for ${agent.provider_id}`,
         'SECRET_DECRYPTION_FAILED',

--- a/src/clawrocket/agents/main-browser-contract.test.ts
+++ b/src/clawrocket/agents/main-browser-contract.test.ts
@@ -23,7 +23,7 @@ function seedAnthropicSecret(apiKey = 'sk-ant-test'): void {
        ON CONFLICT(provider_id) DO UPDATE SET ciphertext = excluded.ciphertext,
          updated_at = excluded.updated_at, updated_by = excluded.updated_by`,
     )
-    .run(encryptProviderSecret({ apiKey }), now, 'owner-1');
+    .run(encryptProviderSecret({ kind: 'api_key', apiKey }), now, 'owner-1');
 }
 
 function upsertProviderVerification(

--- a/src/clawrocket/agents/main-channel.test.ts
+++ b/src/clawrocket/agents/main-channel.test.ts
@@ -63,7 +63,7 @@ function seedAnthropicSecret(apiKey = 'sk-ant-test'): void {
        ON CONFLICT(provider_id) DO UPDATE SET ciphertext = excluded.ciphertext,
          updated_at = excluded.updated_at, updated_by = excluded.updated_by`,
     )
-    .run(encryptProviderSecret({ apiKey }), now, USER_A);
+    .run(encryptProviderSecret({ kind: 'api_key', apiKey }), now, USER_A);
 }
 
 function upsertProviderVerification(

--- a/src/clawrocket/llm/anthropic-oauth.test.ts
+++ b/src/clawrocket/llm/anthropic-oauth.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  ANTHROPIC_CLAUDE_CODE_SYSTEM_PREFIX,
+  ANTHROPIC_OAUTH_AUTHORIZE_URL,
+  ANTHROPIC_OAUTH_BETAS,
+  ANTHROPIC_OAUTH_CLIENT_ID,
+  ANTHROPIC_OAUTH_REDIRECT_URI,
+  ANTHROPIC_OAUTH_SCOPES,
+  ANTHROPIC_OAUTH_TOKEN_URLS,
+  ANTHROPIC_VERSION_HEADER,
+  buildAnthropicHeaders,
+  buildAnthropicSystemPrompt,
+  buildAuthorizeUrl,
+  createPkcePair,
+  exchangeAuthorizationCode,
+  isOAuthTokenExpiring,
+  refreshOAuthToken,
+} from './anthropic-oauth.js';
+
+describe('createPkcePair', () => {
+  it('returns a verifier and challenge of expected length', () => {
+    const pair = createPkcePair();
+    expect(pair.verifier).toHaveLength(64);
+    expect(pair.challenge.length).toBeGreaterThan(40);
+    // url-safe base64 — no `+`, `/`, or `=`
+    expect(pair.verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(pair.challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it('produces unique pairs per call', () => {
+    const a = createPkcePair();
+    const b = createPkcePair();
+    expect(a.verifier).not.toBe(b.verifier);
+    expect(a.challenge).not.toBe(b.challenge);
+  });
+});
+
+describe('buildAuthorizeUrl', () => {
+  it('builds an authorize URL with all required OAuth params', () => {
+    const url = new URL(
+      buildAuthorizeUrl({
+        codeChallenge: 'test-challenge',
+        state: 'state-abc',
+      }),
+    );
+
+    expect(url.origin + url.pathname).toBe(ANTHROPIC_OAUTH_AUTHORIZE_URL);
+    expect(url.searchParams.get('code')).toBe('true');
+    expect(url.searchParams.get('client_id')).toBe(ANTHROPIC_OAUTH_CLIENT_ID);
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      ANTHROPIC_OAUTH_REDIRECT_URI,
+    );
+    expect(url.searchParams.get('scope')).toBe(
+      ANTHROPIC_OAUTH_SCOPES.join(' '),
+    );
+    expect(url.searchParams.get('code_challenge')).toBe('test-challenge');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(url.searchParams.get('state')).toBe('state-abc');
+  });
+
+  it('honours an explicit redirectUri', () => {
+    const url = new URL(
+      buildAuthorizeUrl({
+        codeChallenge: 'c',
+        state: 's',
+        redirectUri: 'https://localhost:3210/oauth/callback',
+      }),
+    );
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      'https://localhost:3210/oauth/callback',
+    );
+  });
+});
+
+describe('buildAnthropicHeaders', () => {
+  it('returns x-api-key auth for api_key credentials', () => {
+    const headers = buildAnthropicHeaders({
+      credentialKind: 'api_key',
+      token: 'sk-ant-123',
+    });
+    expect(headers['anthropic-version']).toBe(ANTHROPIC_VERSION_HEADER);
+    expect(headers['x-api-key']).toBe('sk-ant-123');
+    expect(headers.Authorization).toBeUndefined();
+    expect(headers['anthropic-beta']).toBeTruthy();
+  });
+
+  it('returns Bearer + Claude Code identity headers for oauth_subscription', () => {
+    const headers = buildAnthropicHeaders({
+      credentialKind: 'oauth_subscription',
+      token: 'access-xyz',
+    });
+    expect(headers.Authorization).toBe('Bearer access-xyz');
+    expect(headers['anthropic-beta']).toBe(ANTHROPIC_OAUTH_BETAS.join(','));
+    expect(headers['user-agent']).toContain('claude-cli/');
+    expect(headers['user-agent']).toContain('(external, cli)');
+    expect(headers['x-app']).toBe('cli');
+    expect(headers['x-api-key']).toBeUndefined();
+  });
+
+  it('uses provided claudeCodeVersion in user-agent', () => {
+    const headers = buildAnthropicHeaders({
+      credentialKind: 'oauth_subscription',
+      token: 't',
+      claudeCodeVersion: '9.9.9',
+    });
+    expect(headers['user-agent']).toBe('claude-cli/9.9.9 (external, cli)');
+  });
+});
+
+describe('buildAnthropicSystemPrompt', () => {
+  it('returns the plain string for api_key credentials', () => {
+    expect(
+      buildAnthropicSystemPrompt({
+        credentialKind: 'api_key',
+        systemPrompt: 'You are a writer.',
+      }),
+    ).toBe('You are a writer.');
+  });
+
+  it('prepends the Claude Code identity block for oauth_subscription', () => {
+    const result = buildAnthropicSystemPrompt({
+      credentialKind: 'oauth_subscription',
+      systemPrompt: 'You are a writer.',
+    });
+    expect(Array.isArray(result)).toBe(true);
+    if (!Array.isArray(result)) throw new Error('expected array');
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      type: 'text',
+      text: ANTHROPIC_CLAUDE_CODE_SYSTEM_PREFIX,
+    });
+    expect(result[1]).toEqual({ type: 'text', text: 'You are a writer.' });
+  });
+
+  it('returns identity-only block when systemPrompt is empty (oauth)', () => {
+    const result = buildAnthropicSystemPrompt({
+      credentialKind: 'oauth_subscription',
+      systemPrompt: '',
+    });
+    expect(Array.isArray(result)).toBe(true);
+    if (!Array.isArray(result)) throw new Error('expected array');
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe(ANTHROPIC_CLAUDE_CODE_SYSTEM_PREFIX);
+  });
+});
+
+describe('isOAuthTokenExpiring', () => {
+  it('treats null/undefined as expiring', () => {
+    expect(isOAuthTokenExpiring(null)).toBe(true);
+    expect(isOAuthTokenExpiring(undefined)).toBe(true);
+  });
+
+  it('treats a malformed date as expiring', () => {
+    expect(isOAuthTokenExpiring('not-a-date')).toBe(true);
+  });
+
+  it('reports past timestamps as expiring', () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    expect(isOAuthTokenExpiring(past)).toBe(true);
+  });
+
+  it('reports timestamps within the skew window as expiring', () => {
+    const soon = new Date(Date.now() + 30_000).toISOString();
+    expect(isOAuthTokenExpiring(soon, 60_000)).toBe(true);
+  });
+
+  it('reports timestamps beyond the skew window as not expiring', () => {
+    const later = new Date(Date.now() + 120_000).toISOString();
+    expect(isOAuthTokenExpiring(later, 60_000)).toBe(false);
+  });
+});
+
+describe('exchangeAuthorizationCode', () => {
+  it('returns parsed tokens on first-endpoint success', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: 'a-1',
+          refresh_token: 'r-1',
+          expires_in: 3600,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const tokens = await exchangeAuthorizationCode({
+      code: 'abc',
+      codeVerifier: 'verifier',
+      state: 'state',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(tokens.accessToken).toBe('a-1');
+    expect(tokens.refreshToken).toBe('r-1');
+    // ~1 hour out
+    const ms = Date.parse(tokens.expiresAt) - Date.now();
+    expect(ms).toBeGreaterThan(3500_000);
+    expect(ms).toBeLessThan(3700_000);
+    // Hit the first token URL only.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe(ANTHROPIC_OAUTH_TOKEN_URLS[0]);
+  });
+
+  it('falls through to the second endpoint when first returns non-OK', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('boom', { status: 502 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'a-2',
+            refresh_token: 'r-2',
+            expires_in: 1800,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+
+    const tokens = await exchangeAuthorizationCode({
+      code: 'abc',
+      codeVerifier: 'verifier',
+      state: 'state',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(tokens.accessToken).toBe('a-2');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws when both endpoints reject', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(new Response('nope', { status: 400 }));
+
+    await expect(
+      exchangeAuthorizationCode({
+        code: 'c',
+        codeVerifier: 'v',
+        state: 's',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/code exchange failed/);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('refreshOAuthToken', () => {
+  it('returns refreshed tokens on success', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: 'a-new',
+          refresh_token: 'r-new',
+          expires_in: 7200,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const tokens = await refreshOAuthToken({
+      refreshToken: 'r-old',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(tokens.accessToken).toBe('a-new');
+    expect(tokens.refreshToken).toBe('r-new');
+  });
+
+  it('keeps the prior refresh token when the response omits it', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: 'a-new',
+          expires_in: 3600,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const tokens = await refreshOAuthToken({
+      refreshToken: 'r-old',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(tokens.accessToken).toBe('a-new');
+    expect(tokens.refreshToken).toBe('r-old');
+  });
+});

--- a/src/clawrocket/llm/anthropic-oauth.ts
+++ b/src/clawrocket/llm/anthropic-oauth.ts
@@ -1,0 +1,345 @@
+/**
+ * anthropic-oauth.ts
+ *
+ * Anthropic Claude.ai subscription OAuth flow — port of rocketboard's
+ * `src/features/ai/anthropic-auth.shared.ts` + `_shared/anthropic-auth.ts`,
+ * adapted for clawrocket's runtime (no Supabase, no Deno-specific APIs).
+ *
+ * Pattern is shared with Claude Code, Hermes, pi-ai, OpenCode — Anthropic
+ * whitelists their own console URL as the OAuth redirect, so the user logs
+ * in on claude.ai, lands on console.anthropic.com which displays the code,
+ * and pastes the `{code}#{state}` blob back into clawrocket.
+ *
+ * Used by:
+ *   - `web/routes/llm-oauth.ts` (initiate / submit-code endpoints)
+ *   - `agents/llm-client.ts` (refresh-on-401 for stored subscription tokens)
+ *   - Editorial Room runtime (panel turns, optimize rounds)
+ */
+
+import { createHash, randomBytes } from 'crypto';
+
+// ─── Constants — match Claude Code / Hermes / pi-ai for OAuth gate routing ─
+
+export const ANTHROPIC_OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+
+export const ANTHROPIC_OAUTH_AUTHORIZE_URL =
+  'https://claude.ai/oauth/authorize';
+
+// Anthropic's own console URL catches the redirect and displays the code.
+// Whitelisted with the public Claude Code OAuth client; users paste the
+// `{code}#{state}` blob back into clawrocket to complete the flow.
+export const ANTHROPIC_OAUTH_REDIRECT_URI =
+  'https://console.anthropic.com/oauth/code/callback';
+
+// Try platform.claude.com first, fall back to console.anthropic.com.
+// Both endpoints accept the same payload; Hermes/pi-ai do the same.
+export const ANTHROPIC_OAUTH_TOKEN_URLS = [
+  'https://platform.claude.com/v1/oauth/token',
+  'https://console.anthropic.com/v1/oauth/token',
+] as const;
+
+export const ANTHROPIC_OAUTH_SCOPES = [
+  'org:create_api_key',
+  'user:profile',
+  'user:inference',
+] as const;
+
+export const ANTHROPIC_VERSION_HEADER = '2023-06-01';
+
+// User-Agent the Anthropic OAuth gate validates. Bump alongside Claude
+// Code releases — stale versions get cryptic 429s back.
+export const ANTHROPIC_CLAUDE_CODE_VERSION_FALLBACK = '2.1.113';
+
+// System-prompt identity prefix Anthropic's OAuth gate keys on. Without
+// this exact string as the first system block, oauth-routed requests come
+// back as minimal-body 429s like {"error":{"type":"Error"}}.
+export const ANTHROPIC_CLAUDE_CODE_SYSTEM_PREFIX =
+  "You are Claude Code, Anthropic's official CLI for Claude.";
+
+export const ANTHROPIC_COMMON_BETAS = [
+  'interleaved-thinking-2025-05-14',
+  'fine-grained-tool-streaming-2025-05-14',
+] as const;
+
+export const ANTHROPIC_OAUTH_ONLY_BETAS = [
+  'claude-code-20250219',
+  'oauth-2025-04-20',
+] as const;
+
+export const ANTHROPIC_OAUTH_BETAS = [
+  ...ANTHROPIC_COMMON_BETAS,
+  ...ANTHROPIC_OAUTH_ONLY_BETAS,
+] as const;
+
+export const ANTHROPIC_DEFAULT_VALIDATION_MODEL = 'claude-sonnet-4-20250514';
+
+// ─── PKCE ────────────────────────────────────────────────────────────────────
+
+export interface PkcePair {
+  verifier: string;
+  challenge: string;
+}
+
+function toBase64Url(bytes: Buffer): string {
+  return bytes
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+export function createPkcePair(): PkcePair {
+  // 64 url-safe characters of entropy. randomBytes(48) base64-url-encoded
+  // gives us 64 url-safe characters; trim defensively.
+  const verifierBytes = randomBytes(48);
+  const verifier = toBase64Url(verifierBytes).slice(0, 64);
+  const challengeBytes = createHash('sha256').update(verifier).digest();
+  const challenge = toBase64Url(challengeBytes);
+  return { verifier, challenge };
+}
+
+// ─── URL builder ─────────────────────────────────────────────────────────────
+
+export interface BuildAuthorizeUrlInput {
+  codeChallenge: string;
+  state: string;
+  redirectUri?: string;
+}
+
+export function buildAuthorizeUrl(input: BuildAuthorizeUrlInput): string {
+  const url = new URL(ANTHROPIC_OAUTH_AUTHORIZE_URL);
+  url.searchParams.set('code', 'true');
+  url.searchParams.set('client_id', ANTHROPIC_OAUTH_CLIENT_ID);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set(
+    'redirect_uri',
+    input.redirectUri ?? ANTHROPIC_OAUTH_REDIRECT_URI,
+  );
+  url.searchParams.set('scope', ANTHROPIC_OAUTH_SCOPES.join(' '));
+  url.searchParams.set('code_challenge', input.codeChallenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', input.state);
+  return url.toString();
+}
+
+// ─── Headers / system prompt builders ────────────────────────────────────────
+
+export type AnthropicCredentialKind = 'api_key' | 'oauth_subscription';
+
+export interface BuildAnthropicHeadersInput {
+  credentialKind: AnthropicCredentialKind;
+  token: string;
+  claudeCodeVersion?: string;
+}
+
+export function buildAnthropicHeaders(
+  input: BuildAnthropicHeadersInput,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    'anthropic-version': ANTHROPIC_VERSION_HEADER,
+  };
+
+  if (input.credentialKind === 'oauth_subscription') {
+    headers.Authorization = `Bearer ${input.token}`;
+    headers['anthropic-beta'] = ANTHROPIC_OAUTH_BETAS.join(',');
+    headers['user-agent'] = `claude-cli/${
+      input.claudeCodeVersion ?? ANTHROPIC_CLAUDE_CODE_VERSION_FALLBACK
+    } (external, cli)`;
+    headers['x-app'] = 'cli';
+    return headers;
+  }
+
+  headers['anthropic-beta'] = ANTHROPIC_COMMON_BETAS.join(',');
+  headers['x-api-key'] = input.token;
+  return headers;
+}
+
+export type AnthropicSystemBlock = { type: 'text'; text: string };
+export type AnthropicSystemPrompt = string | AnthropicSystemBlock[];
+
+// OAuth-routed requests must send the system prompt as a content-block
+// array with the Claude Code identity as the first block. API-key requests
+// keep the plain-string form.
+export function buildAnthropicSystemPrompt(input: {
+  credentialKind: AnthropicCredentialKind;
+  systemPrompt: string;
+}): AnthropicSystemPrompt {
+  if (input.credentialKind !== 'oauth_subscription') {
+    return input.systemPrompt;
+  }
+  const identity: AnthropicSystemBlock = {
+    type: 'text',
+    text: ANTHROPIC_CLAUDE_CODE_SYSTEM_PREFIX,
+  };
+  if (!input.systemPrompt) {
+    return [identity];
+  }
+  return [identity, { type: 'text', text: input.systemPrompt }];
+}
+
+// ─── Token exchange + refresh ────────────────────────────────────────────────
+
+export interface ExchangeAuthorizationCodeInput {
+  code: string;
+  codeVerifier: string;
+  state: string;
+  redirectUri?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface AnthropicOAuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: string;
+}
+
+async function postJson(
+  url: string,
+  body: unknown,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  return fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'User-Agent': `claude-cli/${ANTHROPIC_CLAUDE_CODE_VERSION_FALLBACK} (external, cli)`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function postForm(
+  url: string,
+  params: URLSearchParams,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  return fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': `claude-cli/${ANTHROPIC_CLAUDE_CODE_VERSION_FALLBACK} (external, cli)`,
+    },
+    body: params.toString(),
+  });
+}
+
+function expiresInToIsoExpiry(expiresInSeconds: unknown): string {
+  const n = Math.max(1, Number(expiresInSeconds ?? 3600));
+  return new Date(Date.now() + n * 1000).toISOString();
+}
+
+export async function exchangeAuthorizationCode(
+  input: ExchangeAuthorizationCodeInput,
+): Promise<AnthropicOAuthTokens> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  // Hermes / Claude Code / pi-ai / OpenCode all use a JSON body that
+  // includes `state` alongside the PKCE verifier. Form-urlencoded without
+  // state gets a 400 from Anthropic's token endpoint for this OAuth client.
+  const body = {
+    client_id: ANTHROPIC_OAUTH_CLIENT_ID,
+    code: input.code,
+    code_verifier: input.codeVerifier,
+    grant_type: 'authorization_code' as const,
+    redirect_uri: input.redirectUri ?? ANTHROPIC_OAUTH_REDIRECT_URI,
+    state: input.state,
+  };
+
+  let lastError: Error | null = null;
+  for (const endpoint of ANTHROPIC_OAUTH_TOKEN_URLS) {
+    try {
+      const response = await postJson(endpoint, body, fetchImpl);
+      if (!response.ok) {
+        const text = await response.text().catch(() => '');
+        lastError = new Error(
+          `Anthropic OAuth code exchange failed (${response.status})${
+            text ? `: ${text.slice(0, 300)}` : ''
+          }`,
+        );
+        continue;
+      }
+      const payload = (await response.json()) as Record<string, unknown>;
+      const accessToken = String(payload.access_token ?? '').trim();
+      const refreshToken = String(payload.refresh_token ?? '').trim();
+      if (!accessToken || !refreshToken) {
+        lastError = new Error(
+          'Anthropic OAuth code exchange response was incomplete',
+        );
+        continue;
+      }
+      return {
+        accessToken,
+        refreshToken,
+        expiresAt: expiresInToIsoExpiry(payload.expires_in),
+      };
+    } catch (err) {
+      lastError =
+        err instanceof Error
+          ? err
+          : new Error('Anthropic OAuth code exchange failed');
+    }
+  }
+  throw lastError ?? new Error('Anthropic OAuth code exchange failed');
+}
+
+export interface RefreshOAuthTokenInput {
+  refreshToken: string;
+  fetchImpl?: typeof fetch;
+}
+
+export async function refreshOAuthToken(
+  input: RefreshOAuthTokenInput,
+): Promise<AnthropicOAuthTokens> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const params = new URLSearchParams({
+    client_id: ANTHROPIC_OAUTH_CLIENT_ID,
+    grant_type: 'refresh_token',
+    refresh_token: input.refreshToken,
+  });
+
+  let lastError: Error | null = null;
+  for (const endpoint of ANTHROPIC_OAUTH_TOKEN_URLS) {
+    try {
+      const response = await postForm(endpoint, params, fetchImpl);
+      if (!response.ok) {
+        lastError = new Error(
+          `Anthropic OAuth refresh failed (${response.status})`,
+        );
+        continue;
+      }
+      const payload = (await response.json()) as Record<string, unknown>;
+      const accessToken = String(payload.access_token ?? '').trim();
+      if (!accessToken) {
+        lastError = new Error(
+          'Anthropic OAuth refresh response was missing access_token',
+        );
+        continue;
+      }
+      const refreshedRefreshToken =
+        String(payload.refresh_token ?? input.refreshToken).trim() ||
+        input.refreshToken;
+      return {
+        accessToken,
+        refreshToken: refreshedRefreshToken,
+        expiresAt: expiresInToIsoExpiry(payload.expires_in),
+      };
+    } catch (err) {
+      lastError =
+        err instanceof Error
+          ? err
+          : new Error('Anthropic OAuth refresh failed');
+    }
+  }
+  throw lastError ?? new Error('Anthropic OAuth refresh failed');
+}
+
+// ─── Expiry check ────────────────────────────────────────────────────────────
+
+export function isOAuthTokenExpiring(
+  expiresAt: string | null | undefined,
+  skewMs = 60_000,
+): boolean {
+  if (!expiresAt) return true;
+  const ms = Date.parse(expiresAt);
+  if (Number.isNaN(ms)) return true;
+  return ms <= Date.now() + skewMs;
+}

--- a/src/clawrocket/llm/provider-secret-store.test.ts
+++ b/src/clawrocket/llm/provider-secret-store.test.ts
@@ -27,6 +27,7 @@ describe('provider secret store', () => {
 
     const storeA = await import('./provider-secret-store.js');
     const ciphertext = storeA.encryptProviderSecret({
+      kind: 'api_key',
       apiKey: 'sk-test-123',
     });
 

--- a/src/clawrocket/llm/provider-secret-store.ts
+++ b/src/clawrocket/llm/provider-secret-store.ts
@@ -41,16 +41,88 @@ function deriveKey(): Buffer {
 function validateProviderSecretPayload(
   payload: ProviderSecretPayload,
 ): ProviderSecretPayload {
-  if (!payload.apiKey || typeof payload.apiKey !== 'string') {
-    throw new Error('Provider secret payload missing apiKey');
+  switch (payload.kind) {
+    case 'api_key': {
+      if (!payload.apiKey || typeof payload.apiKey !== 'string') {
+        throw new Error('Provider secret payload missing apiKey');
+      }
+      if (
+        payload.organizationId !== undefined &&
+        typeof payload.organizationId !== 'string'
+      ) {
+        throw new Error(
+          'Provider secret payload organizationId must be a string',
+        );
+      }
+      return payload;
+    }
+    case 'anthropic_oauth': {
+      if (!payload.accessToken || typeof payload.accessToken !== 'string') {
+        throw new Error('Anthropic OAuth payload missing accessToken');
+      }
+      if (!payload.refreshToken || typeof payload.refreshToken !== 'string') {
+        throw new Error('Anthropic OAuth payload missing refreshToken');
+      }
+      if (!payload.expiresAt || typeof payload.expiresAt !== 'string') {
+        throw new Error('Anthropic OAuth payload missing expiresAt');
+      }
+      if (Number.isNaN(Date.parse(payload.expiresAt))) {
+        throw new Error('Anthropic OAuth expiresAt is not a valid ISO date');
+      }
+      return payload;
+    }
+    case 'openai_codex': {
+      if (!payload.accessToken || typeof payload.accessToken !== 'string') {
+        throw new Error('OpenAI Codex payload missing accessToken');
+      }
+      if (
+        payload.refreshToken !== undefined &&
+        typeof payload.refreshToken !== 'string'
+      ) {
+        throw new Error(
+          'OpenAI Codex refreshToken must be a string when present',
+        );
+      }
+      if (
+        payload.expiresAt !== undefined &&
+        Number.isNaN(Date.parse(payload.expiresAt))
+      ) {
+        throw new Error('OpenAI Codex expiresAt is not a valid ISO date');
+      }
+      return payload;
+    }
+    default: {
+      // Exhaustive — TS narrows away the union at compile time, runtime
+      // protection for malformed payloads.
+      const _exhaustive: never = payload;
+      throw new Error(
+        `Provider secret payload has unknown kind: ${(_exhaustive as { kind?: unknown }).kind}`,
+      );
+    }
   }
-  if (
-    payload.organizationId !== undefined &&
-    typeof payload.organizationId !== 'string'
-  ) {
-    throw new Error('Provider secret payload organizationId must be a string');
+}
+
+// Decode the legacy shape (no `kind` field, just `{ apiKey, organizationId? }`)
+// into the new discriminated union. Runs before validation so old DB rows
+// keep working without a migration.
+function backfillLegacyPayload(raw: unknown): ProviderSecretPayload {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('Provider secret payload is not an object');
   }
-  return payload;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.kind === 'string') {
+    return obj as unknown as ProviderSecretPayload;
+  }
+  // No discriminant — assume it's the pre-union api_key shape.
+  if (typeof obj.apiKey === 'string') {
+    return {
+      kind: 'api_key',
+      apiKey: obj.apiKey,
+      organizationId:
+        typeof obj.organizationId === 'string' ? obj.organizationId : undefined,
+    };
+  }
+  throw new Error('Provider secret payload missing kind discriminator');
 }
 
 export function encryptProviderSecret(payload: ProviderSecretPayload): string {
@@ -97,6 +169,7 @@ export function decryptProviderSecret(
     decipher.update(Buffer.from(parsed.data, 'base64')),
     decipher.final(),
   ]).toString('utf8');
-  const payload = JSON.parse(plaintext) as ProviderSecretPayload;
+  const raw = JSON.parse(plaintext) as unknown;
+  const payload = backfillLegacyPayload(raw);
   return validateProviderSecretPayload(payload);
 }

--- a/src/clawrocket/llm/types.ts
+++ b/src/clawrocket/llm/types.ts
@@ -157,7 +157,44 @@ export interface TalkRouteUsageCounts {
   assignedTalkCount: number;
 }
 
-export interface ProviderSecretPayload {
+// ProviderSecretPayload — what gets encrypted in `LlmProviderSecretRecord`.
+// Discriminated union so we can store API keys (current behavior) plus
+// subscription-OAuth credentials (Anthropic Claude.ai login, OpenAI Codex
+// CLI piggyback) without forking the storage layer.
+//
+// Backwards compatibility: existing rows in the DB encrypted before this
+// change have shape `{ apiKey, organizationId? }` with no `kind` field.
+// `decryptProviderSecret` treats a missing `kind` as `'api_key'` so old
+// rows decode without re-encryption.
+export type ProviderSecretPayload =
+  | ProviderApiKeySecret
+  | ProviderAnthropicOAuthSecret
+  | ProviderOpenaiCodexSecret;
+
+export interface ProviderApiKeySecret {
+  kind: 'api_key';
   apiKey: string;
   organizationId?: string;
+}
+
+export interface ProviderAnthropicOAuthSecret {
+  kind: 'anthropic_oauth';
+  accessToken: string;
+  refreshToken: string;
+  // ISO-8601 instant when the access token expires.
+  expiresAt: string;
+  // The Claude Code CLI version we sent on the originating User-Agent.
+  // Anthropic gates oauth-routed requests on a recent CLI version; we record
+  // the value so refreshes mirror it.
+  claudeCodeVersion?: string;
+}
+
+export interface ProviderOpenaiCodexSecret {
+  kind: 'openai_codex';
+  accessToken: string;
+  refreshToken?: string;
+  // Account ID returned by Codex CLI's auth.json.
+  accountId?: string;
+  // ISO-8601; optional because Codex CLI's auth.json doesn't always include it.
+  expiresAt?: string;
 }

--- a/src/clawrocket/web/routes/ai-agents.test.ts
+++ b/src/clawrocket/web/routes/ai-agents.test.ts
@@ -43,6 +43,7 @@ function seedProviderSecret(
     .run(
       providerId,
       encryptProviderSecret({
+        kind: 'api_key',
         apiKey,
         ...(organizationId ? { organizationId } : {}),
       }),

--- a/src/clawrocket/web/routes/ai-agents.ts
+++ b/src/clawrocket/web/routes/ai-agents.ts
@@ -129,7 +129,12 @@ function maskApiKey(apiKey: string): string {
 
 function parseStoredSecret(ciphertext: string): LlmSecret | null {
   try {
-    return decryptProviderSecret(ciphertext);
+    const payload = decryptProviderSecret(ciphertext);
+    // ai-agents endpoints surface the API-key view of credentials. OAuth
+    // subscription tokens are managed via the dedicated /oauth routes
+    // and not represented in this view.
+    if (payload.kind !== 'api_key') return null;
+    return { apiKey: payload.apiKey };
   } catch {
     return null;
   }
@@ -732,6 +737,7 @@ export async function putAiProviderCredentialRoute(
   ).run(
     providerId,
     encryptProviderSecret({
+      kind: 'api_key',
       apiKey,
       ...(organizationId ? { organizationId } : {}),
     }),

--- a/src/clawrocket/web/routes/executor-settings.test.ts
+++ b/src/clawrocket/web/routes/executor-settings.test.ts
@@ -39,7 +39,7 @@ function seedAnthropicSecret(apiKey = 'sk-ant-test'): void {
        ON CONFLICT(provider_id) DO UPDATE SET ciphertext = excluded.ciphertext,
          updated_at = excluded.updated_at, updated_by = excluded.updated_by`,
     )
-    .run(encryptProviderSecret({ apiKey }), now, auth.userId);
+    .run(encryptProviderSecret({ kind: 'api_key', apiKey }), now, auth.userId);
 }
 
 describe('executor-settings routes', () => {

--- a/src/clawrocket/web/routes/executor-settings.ts
+++ b/src/clawrocket/web/routes/executor-settings.ts
@@ -215,7 +215,9 @@ function getAnthropicApiKey(): string | null {
   const row = getAnthropicSecretRow();
   if (!row?.ciphertext) return null;
   try {
-    return decryptProviderSecret(row.ciphertext).apiKey.trim();
+    const payload = decryptProviderSecret(row.ciphertext);
+    if (payload.kind !== 'api_key') return null;
+    return payload.apiKey.trim();
   } catch {
     return null;
   }
@@ -598,7 +600,7 @@ function saveAnthropicApiKey(apiKey: string, userId: string): void {
        ON CONFLICT(provider_id) DO UPDATE SET ciphertext = excluded.ciphertext,
          updated_at = excluded.updated_at, updated_by = excluded.updated_by`,
     )
-    .run(encryptProviderSecret({ apiKey }), now, userId);
+    .run(encryptProviderSecret({ kind: 'api_key', apiKey }), now, userId);
   upsertSettingValue({
     key: 'executor.updatedAt',
     value: now,


### PR DESCRIPTION
## Summary

Foundation for slice 1 of LLM-driven Editorial Room features. Ports the Claude.ai subscription OAuth flow from rocketboard into clawrocket, plus extends the provider secret store to carry OAuth tokens alongside API keys.

This PR is **just the foundation modules + tests** — no HTTP routes, no UI yet. Routes + Settings UI come in PR 2 (then Editorial Room slice 1 in PR 3).

## What's new

### `src/clawrocket/llm/anthropic-oauth.ts` (~340 lines)

Port of rocketboard's `anthropic-auth.shared.ts` + `_shared/anthropic-auth.ts` adapted for clawrocket's runtime (Node crypto, no Supabase, no Deno-isms).

- `createPkcePair()` — 64-char url-safe verifier + SHA-256 challenge
- `buildAuthorizeUrl()` — wraps the Claude.ai authorize URL with PKCE + scopes
- `buildAnthropicHeaders()` — handles both `api_key` (x-api-key) and `oauth_subscription` (Bearer + Claude Code identity headers)
- `buildAnthropicSystemPrompt()` — prepends the Claude Code identity block for OAuth-routed requests (Anthropic's gate keys on this exact string)
- `exchangeAuthorizationCode()` / `refreshOAuthToken()` — JSON+form fallback chain across `platform.claude.com` and `console.anthropic.com` token endpoints
- `isOAuthTokenExpiring()` — skew-aware expiry check

Pattern shared with Claude Code, Hermes, pi-ai, OpenCode — Anthropic whitelists their own console URL as the OAuth redirect, so users paste `{code}#{state}` back from `console.anthropic.com`.

### `anthropic-oauth.test.ts` — 20 tests

Covers PKCE, URL building, header construction, system-prompt block layout, expiry semantics, and code-exchange/refresh fallback via mocked `fetch`.

### Extended `ProviderSecretPayload` (discriminated union)

```ts
type ProviderSecretPayload =
  | { kind: 'api_key'; apiKey: string; organizationId?: string }
  | { kind: 'anthropic_oauth'; accessToken; refreshToken; expiresAt }
  | { kind: 'openai_codex'; accessToken; refreshToken?; accountId?; expiresAt? };
```

Existing rows without a `kind` discriminator decode as `api_key` via a legacy backfill path in `decryptProviderSecret` — no migration required.

## Call site updates

`executor-settings`, `ai-agents`, `execution-planner`, `execution-resolver` now narrow on `kind === 'api_key'` before reading `.apiKey`. The Talk runtime explicitly errors when it encounters an OAuth subscription credential — Talk uses x-api-key auth and is incompatible with Bearer + Claude Code identity headers. Editorial Room handles OAuth subscription requests separately in PR 3.

## Test plan

- [ ] `node scripts/run-vitest.mjs run src/clawrocket/llm/anthropic-oauth.test.ts` → 20/20 pass
- [ ] `node scripts/run-vitest.mjs run src/clawrocket/llm/provider-secret-store.test.ts` → 1/1 pass
- [ ] `node scripts/run-vitest.mjs run src/clawrocket/contracts/editorial-room.test.ts` → 99/99 pass (no contract regression)
- [ ] Backend + webapp typecheck clean

Two pre-existing tests (execution-preview, main-channel) require Docker; they fail in environments without it, unrelated to this change. Verified by running on plain main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)