### PR TITLE
feat: Anthropic OAuth — HTTP routes + Sign in UI

### DIFF
--- a/src/clawrocket/llm/anthropic-oauth-state-store.ts
+++ b/src/clawrocket/llm/anthropic-oauth-state-store.ts
@@ -1,0 +1,79 @@
+/**
+ * anthropic-oauth-state-store.ts
+ *
+ * In-memory store for the PKCE verifier + state pairs that bridge the
+ * `/initiate` and `/submit-code` halves of the OAuth flow. Single-process
+ * clawrocket; restart loses state which forces the user to re-initiate
+ * (rare and recoverable).
+ *
+ * State entries:
+ *   - state (uuid): random correlation id sent to claude.ai
+ *   - verifier: PKCE verifier; never leaves the server, only sent to Anthropic's
+ *     token endpoint at exchange time
+ *   - userId: who initiated; submit-code rejects if a different user submits
+ *   - createdAt: TTL anchor (10 minute window matches rocketboard)
+ *
+ * Cleanup: lazy on every read, plus an opportunistic sweep on every write.
+ */
+
+const STATE_TTL_MS = 10 * 60 * 1000;
+
+interface StoredState {
+  verifier: string;
+  userId: string;
+  createdAt: number;
+}
+
+const store = new Map<string, StoredState>();
+
+function isExpired(entry: StoredState): boolean {
+  return Date.now() - entry.createdAt > STATE_TTL_MS;
+}
+
+function sweepExpired(): void {
+  for (const [state, entry] of store.entries()) {
+    if (isExpired(entry)) store.delete(state);
+  }
+}
+
+export function storeState(input: {
+  state: string;
+  verifier: string;
+  userId: string;
+}): void {
+  sweepExpired();
+  store.set(input.state, {
+    verifier: input.verifier,
+    userId: input.userId,
+    createdAt: Date.now(),
+  });
+}
+
+export type ConsumeResult =
+  | { kind: 'ok'; verifier: string }
+  | { kind: 'not_found' }
+  | { kind: 'expired' }
+  | { kind: 'wrong_user' };
+
+export function consumeState(input: {
+  state: string;
+  userId: string;
+}): ConsumeResult {
+  const entry = store.get(input.state);
+  if (!entry) return { kind: 'not_found' };
+
+  // Always delete on consumption (one-time use).
+  store.delete(input.state);
+
+  if (isExpired(entry)) return { kind: 'expired' };
+  if (entry.userId !== input.userId) {
+    // Don't leak that the state existed for a different user.
+    return { kind: 'wrong_user' };
+  }
+  return { kind: 'ok', verifier: entry.verifier };
+}
+
+// Test-only — clears all stored states. Not exported via the barrel.
+export function _resetStateStoreForTests(): void {
+  store.clear();
+}

--- a/src/clawrocket/web/routes/llm-oauth.ts
+++ b/src/clawrocket/web/routes/llm-oauth.ts
@@ -1,0 +1,326 @@
+/**
+ * llm-oauth.ts
+ *
+ * HTTP routes for LLM-provider OAuth flows. Currently covers Anthropic
+ * (Claude.ai subscription); OpenAI Codex CLI piggyback lands in a follow-up.
+ *
+ * Routes:
+ *   POST /api/v1/agents/providers/anthropic/oauth/initiate
+ *     → returns { authorizeUrl, state }; user opens authorizeUrl in a new
+ *       tab, logs into claude.ai, lands on console.anthropic.com which
+ *       displays a code, then pastes the code+state back via /submit
+ *
+ *   POST /api/v1/agents/providers/anthropic/oauth/submit
+ *     → exchanges code for tokens, encrypts + stores in
+ *       llm_provider_secrets keyed by 'provider.anthropic'
+ *
+ *   GET  /api/v1/agents/providers/anthropic/oauth/status
+ *     → returns { connected, expiresAt, kind } so the Settings page can
+ *       show whether a Claude subscription credential is on file
+ *
+ *   POST /api/v1/agents/providers/anthropic/oauth/disconnect
+ *     → removes the stored OAuth credential (does NOT touch any API-key
+ *       credential at the same provider)
+ */
+
+import { randomUUID } from 'crypto';
+
+import { getDb } from '../../../db.js';
+import { logger } from '../../../logger.js';
+import {
+  buildAuthorizeUrl,
+  createPkcePair,
+  exchangeAuthorizationCode,
+} from '../../llm/anthropic-oauth.js';
+import {
+  consumeState,
+  storeState,
+} from '../../llm/anthropic-oauth-state-store.js';
+import {
+  decryptProviderSecret,
+  encryptProviderSecret,
+} from '../../llm/provider-secret-store.js';
+import type { AuthContext, ApiEnvelope } from '../types.js';
+
+const ANTHROPIC_PROVIDER_ID = 'provider.anthropic';
+
+export interface InitiateOAuthResult {
+  authorizeUrl: string;
+  state: string;
+}
+
+export interface OAuthStatus {
+  connected: boolean;
+  kind: 'oauth_subscription' | 'api_key' | 'none';
+  expiresAt: string | null;
+  expiringSoon: boolean;
+}
+
+export interface SubmitOAuthBody {
+  code?: unknown;
+  state?: unknown;
+}
+
+function envelopeError<T>(
+  statusCode: number,
+  code: string,
+  message: string,
+): { statusCode: number; body: ApiEnvelope<T> } {
+  return {
+    statusCode,
+    body: { ok: false, error: { code, message } },
+  };
+}
+
+/** POST /api/v1/agents/providers/anthropic/oauth/initiate */
+export async function initiateAnthropicOAuthRoute(
+  auth: AuthContext,
+): Promise<{ statusCode: number; body: ApiEnvelope<InitiateOAuthResult> }> {
+  const pair = createPkcePair();
+  const state = randomUUID();
+
+  storeState({
+    state,
+    verifier: pair.verifier,
+    userId: auth.userId,
+  });
+
+  const authorizeUrl = buildAuthorizeUrl({
+    codeChallenge: pair.challenge,
+    state,
+  });
+
+  return {
+    statusCode: 200,
+    body: { ok: true, data: { authorizeUrl, state } },
+  };
+}
+
+/** POST /api/v1/agents/providers/anthropic/oauth/submit */
+export async function submitAnthropicOAuthRoute(
+  auth: AuthContext,
+  body: SubmitOAuthBody,
+): Promise<{ statusCode: number; body: ApiEnvelope<OAuthStatus> }> {
+  const code = typeof body.code === 'string' ? body.code.trim() : '';
+  const state = typeof body.state === 'string' ? body.state.trim() : '';
+
+  if (!code) {
+    return envelopeError(
+      400,
+      'invalid_input',
+      'Missing or empty code. Paste the full code+state blob from console.anthropic.com.',
+    );
+  }
+  if (!state) {
+    return envelopeError(
+      400,
+      'invalid_input',
+      'Missing or empty state. Paste the full code+state blob from console.anthropic.com.',
+    );
+  }
+
+  const consumed = consumeState({ state, userId: auth.userId });
+  switch (consumed.kind) {
+    case 'not_found':
+      return envelopeError(
+        400,
+        'invalid_state',
+        'OAuth state not found. Click Sign in with Claude again to start a fresh flow.',
+      );
+    case 'expired':
+      return envelopeError(
+        400,
+        'expired_state',
+        'OAuth flow timed out (10-minute window). Click Sign in with Claude again.',
+      );
+    case 'wrong_user':
+      return envelopeError(
+        400,
+        'invalid_state',
+        'OAuth state did not match your session. Click Sign in with Claude again.',
+      );
+  }
+
+  let tokens;
+  try {
+    tokens = await exchangeAuthorizationCode({
+      code,
+      codeVerifier: consumed.verifier,
+      state,
+    });
+  } catch (err) {
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'anthropic OAuth code exchange failed',
+    );
+    return envelopeError(
+      400,
+      'exchange_failed',
+      err instanceof Error
+        ? err.message
+        : 'Anthropic rejected the OAuth code. Try Sign in with Claude again.',
+    );
+  }
+
+  const ciphertext = encryptProviderSecret({
+    kind: 'anthropic_oauth',
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    expiresAt: tokens.expiresAt,
+  });
+
+  const now = new Date().toISOString();
+  getDb()
+    .prepare(
+      `INSERT INTO llm_provider_secrets (provider_id, ciphertext, updated_at, updated_by)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(provider_id) DO UPDATE SET
+         ciphertext = excluded.ciphertext,
+         updated_at = excluded.updated_at,
+         updated_by = excluded.updated_by`,
+    )
+    .run(ANTHROPIC_PROVIDER_ID, ciphertext, now, auth.userId);
+
+  return {
+    statusCode: 200,
+    body: {
+      ok: true,
+      data: {
+        connected: true,
+        kind: 'oauth_subscription',
+        expiresAt: tokens.expiresAt,
+        expiringSoon: false,
+      },
+    },
+  };
+}
+
+/** GET /api/v1/agents/providers/anthropic/oauth/status */
+export async function getAnthropicOAuthStatusRoute(
+  _auth: AuthContext,
+): Promise<{ statusCode: number; body: ApiEnvelope<OAuthStatus> }> {
+  const row = getDb()
+    .prepare(
+      `SELECT ciphertext FROM llm_provider_secrets WHERE provider_id = ?`,
+    )
+    .get(ANTHROPIC_PROVIDER_ID) as { ciphertext: string } | undefined;
+
+  if (!row?.ciphertext) {
+    return {
+      statusCode: 200,
+      body: {
+        ok: true,
+        data: {
+          connected: false,
+          kind: 'none',
+          expiresAt: null,
+          expiringSoon: false,
+        },
+      },
+    };
+  }
+
+  try {
+    const payload = decryptProviderSecret(row.ciphertext);
+    if (payload.kind === 'anthropic_oauth') {
+      const expiresAtMs = Date.parse(payload.expiresAt);
+      const expiringSoon = !Number.isNaN(expiresAtMs)
+        ? expiresAtMs <= Date.now() + 5 * 60 * 1000
+        : true;
+      return {
+        statusCode: 200,
+        body: {
+          ok: true,
+          data: {
+            connected: true,
+            kind: 'oauth_subscription',
+            expiresAt: payload.expiresAt,
+            expiringSoon,
+          },
+        },
+      };
+    }
+    if (payload.kind === 'api_key') {
+      return {
+        statusCode: 200,
+        body: {
+          ok: true,
+          data: {
+            connected: true,
+            kind: 'api_key',
+            expiresAt: null,
+            expiringSoon: false,
+          },
+        },
+      };
+    }
+    return {
+      statusCode: 200,
+      body: {
+        ok: true,
+        data: {
+          connected: false,
+          kind: 'none',
+          expiresAt: null,
+          expiringSoon: false,
+        },
+      },
+    };
+  } catch {
+    return {
+      statusCode: 200,
+      body: {
+        ok: true,
+        data: {
+          connected: false,
+          kind: 'none',
+          expiresAt: null,
+          expiringSoon: false,
+        },
+      },
+    };
+  }
+}
+
+/** POST /api/v1/agents/providers/anthropic/oauth/disconnect */
+export async function disconnectAnthropicOAuthRoute(
+  _auth: AuthContext,
+): Promise<{ statusCode: number; body: ApiEnvelope<OAuthStatus> }> {
+  // Only remove the row if the stored credential is OAuth — we don't want
+  // to nuke an API-key credential that happens to share the same provider
+  // record. (At v0p one row per provider, but the discriminant guards it.)
+  const row = getDb()
+    .prepare(
+      `SELECT ciphertext FROM llm_provider_secrets WHERE provider_id = ?`,
+    )
+    .get(ANTHROPIC_PROVIDER_ID) as { ciphertext: string } | undefined;
+
+  if (row?.ciphertext) {
+    try {
+      const payload = decryptProviderSecret(row.ciphertext);
+      if (payload.kind === 'anthropic_oauth') {
+        getDb()
+          .prepare(`DELETE FROM llm_provider_secrets WHERE provider_id = ?`)
+          .run(ANTHROPIC_PROVIDER_ID);
+      }
+    } catch {
+      // If the existing row can't be decoded, drop it.
+      getDb()
+        .prepare(`DELETE FROM llm_provider_secrets WHERE provider_id = ?`)
+        .run(ANTHROPIC_PROVIDER_ID);
+    }
+  }
+
+  return {
+    statusCode: 200,
+    body: {
+      ok: true,
+      data: {
+        connected: false,
+        kind: 'none',
+        expiresAt: null,
+        expiringSoon: false,
+      },
+    },
+  };
+}

--- a/src/clawrocket/web/server.ts
+++ b/src/clawrocket/web/server.ts
@@ -127,6 +127,12 @@ import {
   verifyAiProviderCredentialRoute,
 } from './routes/ai-agents.js';
 import {
+  disconnectAnthropicOAuthRoute,
+  getAnthropicOAuthStatusRoute,
+  initiateAnthropicOAuthRoute,
+  submitAnthropicOAuthRoute,
+} from './routes/llm-oauth.js';
+import {
   listUserToolPermissionsRoute,
   updateUserToolPermissionRoute,
   getEffectiveToolsRoute,
@@ -1132,6 +1138,49 @@ function buildApp(opts: WebServerOptions): Hono {
     if (!auth) return unauthorized(c);
     const providerId = c.req.param('providerId');
     const result = await verifyAiProviderCredentialRoute(auth, providerId);
+    return new Response(JSON.stringify(result.body), {
+      status: result.statusCode,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    });
+  });
+
+  // ── /api/v1/agents/providers/anthropic/oauth/* ─ Claude.ai subscription ──
+
+  app.post('/api/v1/agents/providers/anthropic/oauth/initiate', async (c) => {
+    const auth = requireAuth(c);
+    if (!auth) return unauthorized(c);
+    const result = await initiateAnthropicOAuthRoute(auth);
+    return new Response(JSON.stringify(result.body), {
+      status: result.statusCode,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    });
+  });
+
+  app.post('/api/v1/agents/providers/anthropic/oauth/submit', async (c) => {
+    const auth = requireAuth(c);
+    if (!auth) return unauthorized(c);
+    const body = await c.req.json();
+    const result = await submitAnthropicOAuthRoute(auth, body);
+    return new Response(JSON.stringify(result.body), {
+      status: result.statusCode,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    });
+  });
+
+  app.get('/api/v1/agents/providers/anthropic/oauth/status', async (c) => {
+    const auth = requireAuth(c);
+    if (!auth) return unauthorized(c);
+    const result = await getAnthropicOAuthStatusRoute(auth);
+    return new Response(JSON.stringify(result.body), {
+      status: result.statusCode,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    });
+  });
+
+  app.post('/api/v1/agents/providers/anthropic/oauth/disconnect', async (c) => {
+    const auth = requireAuth(c);
+    if (!auth) return unauthorized(c);
+    const result = await disconnectAnthropicOAuthRoute(auth);
     return new Response(JSON.stringify(result.body), {
       status: result.statusCode,
       headers: { 'content-type': 'application/json; charset=utf-8' },

--- a/webapp/src/pages/EditorialSetupPage.tsx
+++ b/webapp/src/pages/EditorialSetupPage.tsx
@@ -682,6 +682,268 @@ function AudienceSection({
   );
 }
 
+type OAuthStatus = {
+  connected: boolean;
+  kind: 'oauth_subscription' | 'api_key' | 'none';
+  expiresAt: string | null;
+  expiringSoon: boolean;
+};
+
+function AnthropicOAuthCard() {
+  const [status, setStatus] = useState<OAuthStatus | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [pasteOpen, setPasteOpen] = useState<boolean>(false);
+  const [pendingState, setPendingState] = useState<string | null>(null);
+  const [pasteValue, setPasteValue] = useState<string>('');
+  const [working, setWorking] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = async (): Promise<void> => {
+    try {
+      const res = await fetch(
+        '/api/v1/agents/providers/anthropic/oauth/status',
+        { credentials: 'include' },
+      );
+      const json = (await res.json()) as
+        | { ok: true; data: OAuthStatus }
+        | { ok: false; error: { message: string } };
+      if (json.ok) setStatus(json.data);
+    } catch {
+      // best-effort; keep last status
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  const handleSignIn = async (): Promise<void> => {
+    setError(null);
+    setWorking(true);
+    try {
+      const res = await fetch(
+        '/api/v1/agents/providers/anthropic/oauth/initiate',
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+      const json = (await res.json()) as
+        | {
+            ok: true;
+            data: { authorizeUrl: string; state: string };
+          }
+        | { ok: false; error: { message: string } };
+      if (!json.ok) {
+        setError(json.error.message);
+        return;
+      }
+      setPendingState(json.data.state);
+      setPasteOpen(true);
+      window.open(json.data.authorizeUrl, '_blank', 'noopener,noreferrer');
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Failed to start the Claude sign-in flow.',
+      );
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  const handleSubmit = async (): Promise<void> => {
+    setError(null);
+    if (!pendingState) {
+      setError(
+        'No active OAuth flow. Click Sign in with Claude to start a fresh one.',
+      );
+      return;
+    }
+    // Anthropic's console displays the code as `code#state`. If the user
+    // pasted the whole blob, split it; otherwise treat the whole input as
+    // the code and rely on the stored state.
+    const trimmed = pasteValue.trim();
+    let code: string;
+    let stateFromPaste: string | null = null;
+    if (trimmed.includes('#')) {
+      const idx = trimmed.indexOf('#');
+      code = trimmed.slice(0, idx).trim();
+      stateFromPaste = trimmed.slice(idx + 1).trim();
+    } else {
+      code = trimmed;
+    }
+    if (!code) {
+      setError('Paste the code+state blob from console.anthropic.com.');
+      return;
+    }
+    const state = stateFromPaste || pendingState;
+
+    setWorking(true);
+    try {
+      const res = await fetch(
+        '/api/v1/agents/providers/anthropic/oauth/submit',
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code, state }),
+        },
+      );
+      const json = (await res.json()) as
+        | { ok: true; data: OAuthStatus }
+        | { ok: false; error: { message: string } };
+      if (!json.ok) {
+        setError(json.error.message);
+        return;
+      }
+      setStatus(json.data);
+      setPasteOpen(false);
+      setPendingState(null);
+      setPasteValue('');
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to submit the OAuth code.',
+      );
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  const handleDisconnect = async (): Promise<void> => {
+    setError(null);
+    setWorking(true);
+    try {
+      const res = await fetch(
+        '/api/v1/agents/providers/anthropic/oauth/disconnect',
+        {
+          method: 'POST',
+          credentials: 'include',
+        },
+      );
+      const json = (await res.json()) as
+        | { ok: true; data: OAuthStatus }
+        | { ok: false; error: { message: string } };
+      if (json.ok) setStatus(json.data);
+      else setError(json.error.message);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to disconnect.');
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  const expiresLabel = (() => {
+    if (!status?.expiresAt) return null;
+    const ms = Date.parse(status.expiresAt);
+    if (Number.isNaN(ms)) return null;
+    const minutes = Math.round((ms - Date.now()) / 60000);
+    if (minutes < 0) return 'expired';
+    if (minutes < 60) return `expires in ${minutes}m`;
+    const hours = Math.round(minutes / 60);
+    return `expires in ${hours}h`;
+  })();
+
+  const isConnectedOAuth =
+    status?.connected && status.kind === 'oauth_subscription';
+
+  return (
+    <div className="editorial-oauth-card">
+      <div className="editorial-oauth-row">
+        <div className="editorial-oauth-row-text">
+          <span className="editorial-oauth-label">ANTHROPIC AUTH</span>
+          <span
+            className={`editorial-oauth-status${
+              isConnectedOAuth ? ' editorial-oauth-status-connected' : ''
+            }`}
+          >
+            {loading
+              ? 'CHECKING…'
+              : isConnectedOAuth
+                ? `● CONNECTED (Claude.ai subscription${expiresLabel ? ` · ${expiresLabel}` : ''})`
+                : status?.kind === 'api_key'
+                  ? '● CONNECTED (API key)'
+                  : '○ NOT CONNECTED — agents will fail without an Anthropic credential'}
+          </span>
+        </div>
+        <div className="editorial-oauth-actions">
+          {!isConnectedOAuth ? (
+            <button
+              type="button"
+              className="editorial-chip-button editorial-chip-button-primary"
+              onClick={() => {
+                void handleSignIn();
+              }}
+              disabled={working}
+            >
+              {working ? 'STARTING…' : 'SIGN IN WITH CLAUDE'}
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="editorial-chip-button"
+              onClick={() => {
+                void handleDisconnect();
+              }}
+              disabled={working}
+            >
+              DISCONNECT
+            </button>
+          )}
+        </div>
+      </div>
+
+      {pasteOpen ? (
+        <div className="editorial-oauth-paste">
+          <p className="editorial-oauth-paste-blurb">
+            A new tab opened to claude.ai. Sign in, then{' '}
+            <strong>console.anthropic.com</strong> will display a code. Paste
+            the entire <code>code#state</code> blob below.
+          </p>
+          <textarea
+            className="editorial-oauth-paste-textarea"
+            placeholder="code#state"
+            value={pasteValue}
+            onChange={(e) => setPasteValue(e.target.value)}
+            rows={2}
+            spellCheck={false}
+          />
+          <div className="editorial-oauth-paste-actions">
+            <button
+              type="button"
+              className="editorial-chip-button"
+              onClick={() => {
+                setPasteOpen(false);
+                setPendingState(null);
+                setPasteValue('');
+                setError(null);
+              }}
+              disabled={working}
+            >
+              CANCEL
+            </button>
+            <button
+              type="button"
+              className="editorial-chip-button editorial-chip-button-primary"
+              onClick={() => {
+                void handleSubmit();
+              }}
+              disabled={working || !pasteValue.trim()}
+            >
+              {working ? 'EXCHANGING…' : 'COMPLETE SIGN-IN'}
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {error ? <p className="editorial-oauth-error">{error}</p> : null}
+    </div>
+  );
+}
+
 function LLMRoomSection({
   setup,
   update,
@@ -737,6 +999,8 @@ function LLMRoomSection({
         copy="Pick agent profiles that critique, propose, and score during the run. Each one is a named voice with a surface model, a stance, and a per-turn cost — never an anonymous chip."
         nav={nav}
       />
+
+      <AnthropicOAuthCard />
 
       <div className="editorial-agents-selected">
         <h3 className="editorial-personas-section-label">

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -5238,6 +5238,121 @@ a {
   gap: 0.4rem;
 }
 
+/* Setup · Anthropic OAuth status card (top of LLM Room section) */
+
+.editorial-oauth-card {
+  margin-top: 1.4rem;
+  background: #fff;
+  border: 1px solid #ddd6c8;
+  border-radius: 6px;
+  padding: 0.75rem 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.editorial-oauth-row {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+}
+
+.editorial-oauth-row-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.editorial-oauth-label {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #6c6655;
+}
+
+.editorial-oauth-status {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  color: #c98a2c;
+}
+
+.editorial-oauth-status-connected {
+  color: #2e7d62;
+}
+
+.editorial-oauth-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.editorial-oauth-paste {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border-top: 1px dashed #c9c0a8;
+  padding-top: 0.6rem;
+}
+
+.editorial-oauth-paste-blurb {
+  margin: 0;
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-size: 0.86rem;
+  font-style: italic;
+  color: #4a4738;
+  line-height: 1.45;
+}
+
+.editorial-oauth-paste-blurb code {
+  background: #fbf8f2;
+  border: 1px solid #e2dccc;
+  border-radius: 3px;
+  padding: 0 0.3rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.78rem;
+  font-style: normal;
+}
+
+.editorial-oauth-paste-textarea {
+  width: 100%;
+  border: 1px solid #c9c0a8;
+  border-radius: 5px;
+  padding: 0.5rem 0.6rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.8rem;
+  background: #fbf8f2;
+  color: #1f1c14;
+  resize: vertical;
+}
+
+.editorial-oauth-paste-textarea:focus {
+  outline: none;
+  border-color: #b7372a;
+  box-shadow: 0 0 0 1px #b7372a;
+}
+
+.editorial-oauth-paste-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.4rem;
+}
+
+.editorial-oauth-error {
+  margin: 0;
+  padding: 0.5rem 0.65rem;
+  background: #fff0eb;
+  border: 1px solid #b7372a;
+  border-radius: 5px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  color: #b7372a;
+  letter-spacing: 0.02em;
+}
+
 /* Setup · LLM Room section */
 
 .editorial-agents-selected {


### PR DESCRIPTION
## Summary

Wires the OAuth foundation (#286) into a working sign-in flow. After this PR, you can actually sign in with your Claude.ai subscription from the Editorial Setup page.

## Backend

- **New `web/routes/llm-oauth.ts`** — initiate / submit / status / disconnect for \`provider.anthropic\`
- **`lib/anthropic-oauth-state-store.ts`** — in-memory state map, 10-min TTL, lazy cleanup, single-process
- Routes mounted under \`/api/v1/agents/providers/anthropic/oauth/*\`

## Frontend

- **\`AnthropicOAuthCard\`** at the top of the LLM Room section
- Status pill: \`○ NOT CONNECTED\` / \`● CONNECTED (Claude.ai subscription · expires in 5h)\`
- \`SIGN IN WITH CLAUDE\` button opens authorize URL in a new tab + reveals paste-back textarea
- Submit parses \`code#state\` (Anthropic's console concatenates them with \`#\`), POSTs to /submit, refreshes status
- \`DISCONNECT\` removes the OAuth secret only (won't touch an API-key credential at the same provider)

## User flow

1. \`/editorial/setup\` → LLM Room tab → click \`SIGN IN WITH CLAUDE\`
2. New tab opens \`claude.ai/oauth/authorize\` → log in
3. \`console.anthropic.com\` shows the code+state blob
4. Paste blob back, click \`COMPLETE SIGN-IN\`
5. Server exchanges code, stores tokens encrypted

## Compatibility

The OAuth flow doesn't interfere with the existing core-executor \"subscription\" mode (\`executor.claudeOauthToken\`) — that's a different mechanism (containerized Claude Code) for a different runtime.

## Test plan

- [ ] \`/editorial/setup\` → LLM Room. OAuth card shows \`○ NOT CONNECTED\`.
- [ ] Click SIGN IN WITH CLAUDE. New tab opens to claude.ai. Paste-back textarea appears.
- [ ] Complete flow on claude.ai. Paste \`code#state\` → COMPLETE SIGN-IN. Card flips to \`● CONNECTED (Claude.ai subscription · expires in Nh)\`.
- [ ] Reload — status persists.
- [ ] DISCONNECT → reverts to \`○ NOT CONNECTED\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)