### PR TITLE
feat: OpenAI ChatGPT subscription auth — device-code flow

### DIFF
--- a/src/clawrocket/llm/openai-codex-oauth.ts
+++ b/src/clawrocket/llm/openai-codex-oauth.ts
@@ -1,0 +1,300 @@
+/**
+ * openai-codex-oauth.ts
+ *
+ * OpenAI ChatGPT subscription OAuth via the device-code flow — port of
+ * openclaw's `extensions/openai/openai-codex-device-code.ts`, adapted for
+ * clawrocket's runtime.
+ *
+ * Flow (different from Anthropic's paste-back PKCE):
+ *   1. POST /api/accounts/deviceauth/usercode  → { device_auth_id, user_code, interval }
+ *   2. Display user_code + verificationUrl to the user. They open the URL,
+ *      type the user_code, and approve in their browser.
+ *   3. Poll /api/accounts/deviceauth/token until authorized → returns
+ *      { authorization_code, code_verifier } (PKCE pair generated server-side
+ *      by OpenAI, not by us)
+ *   4. POST /oauth/token with the authorization_code + code_verifier →
+ *      returns { access_token, refresh_token, expires_in }
+ *
+ * Used by:
+ *   - `web/routes/llm-oauth-openai.ts` (initiate / poll / status / disconnect)
+ *   - Editorial Room runtime when an agent's `provider` is `openai`
+ */
+
+const OPENAI_AUTH_BASE_URL = 'https://auth.openai.com';
+const OPENAI_CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+const OPENAI_CODEX_DEVICE_CODE_TIMEOUT_MS = 15 * 60_000;
+const OPENAI_CODEX_DEVICE_CODE_DEFAULT_INTERVAL_MS = 5_000;
+const OPENAI_CODEX_DEVICE_CODE_MIN_INTERVAL_MS = 1_000;
+const OPENAI_CODEX_DEVICE_CALLBACK_URL = `${OPENAI_AUTH_BASE_URL}/deviceauth/callback`;
+
+export const OPENAI_CODEX_DEVICE_VERIFICATION_URL = `${OPENAI_AUTH_BASE_URL}/codex/device`;
+export {
+  OPENAI_CODEX_DEVICE_CODE_TIMEOUT_MS,
+  OPENAI_CODEX_DEVICE_CODE_DEFAULT_INTERVAL_MS,
+};
+
+function trimNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseJsonObject(text: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === 'object'
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizePositiveMilliseconds(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return Math.trunc(value * 1000);
+  }
+  if (typeof value === 'string' && /^\d+$/.test(value.trim())) {
+    const seconds = Number.parseInt(value.trim(), 10);
+    return seconds > 0 ? seconds * 1000 : undefined;
+  }
+  return undefined;
+}
+
+function normalizeTokenLifetimeMs(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return Math.trunc(value * 1000);
+  }
+  if (typeof value === 'string' && /^\d+$/.test(value.trim())) {
+    return Number.parseInt(value.trim(), 10) * 1000;
+  }
+  return undefined;
+}
+
+function buildHeaders(contentType: string): Record<string, string> {
+  return {
+    'Content-Type': contentType,
+    originator: 'clawrocket',
+    'User-Agent': 'clawrocket',
+  };
+}
+
+function formatErrorBody(prefix: string, status: number, body: string): string {
+  const parsed = parseJsonObject(body);
+  const error = trimNonEmptyString(parsed?.error);
+  const description = trimNonEmptyString(parsed?.error_description);
+  if (error && description) return `${prefix}: ${error} (${description})`;
+  if (error) return `${prefix}: ${error}`;
+  if (body.trim()) return `${prefix}: HTTP ${status} ${body.slice(0, 300)}`;
+  return `${prefix}: HTTP ${status}`;
+}
+
+// ─── Step 1: Request device code ────────────────────────────────────────────
+
+export interface DeviceCodeRequest {
+  deviceAuthId: string;
+  userCode: string;
+  verificationUrl: string;
+  intervalMs: number;
+  expiresAtMs: number;
+}
+
+export async function requestDeviceCode(
+  fetchImpl: typeof fetch = fetch,
+): Promise<DeviceCodeRequest> {
+  const response = await fetchImpl(
+    `${OPENAI_AUTH_BASE_URL}/api/accounts/deviceauth/usercode`,
+    {
+      method: 'POST',
+      headers: buildHeaders('application/json'),
+      body: JSON.stringify({ client_id: OPENAI_CODEX_CLIENT_ID }),
+    },
+  );
+  const bodyText = await response.text();
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error(
+        'OpenAI Codex device code login is not enabled for this client. ' +
+          'OpenAI may have rotated the public client id.',
+      );
+    }
+    throw new Error(
+      formatErrorBody(
+        'OpenAI device code request failed',
+        response.status,
+        bodyText,
+      ),
+    );
+  }
+
+  const parsed = parseJsonObject(bodyText);
+  const deviceAuthId = trimNonEmptyString(parsed?.device_auth_id);
+  const userCode =
+    trimNonEmptyString(parsed?.user_code) ??
+    trimNonEmptyString(parsed?.usercode);
+  if (!deviceAuthId || !userCode) {
+    throw new Error(
+      'OpenAI device code response was missing device_auth_id or user_code.',
+    );
+  }
+  const intervalMs =
+    normalizePositiveMilliseconds(parsed?.interval) ??
+    OPENAI_CODEX_DEVICE_CODE_DEFAULT_INTERVAL_MS;
+  return {
+    deviceAuthId,
+    userCode,
+    verificationUrl: OPENAI_CODEX_DEVICE_VERIFICATION_URL,
+    intervalMs,
+    expiresAtMs: Date.now() + OPENAI_CODEX_DEVICE_CODE_TIMEOUT_MS,
+  };
+}
+
+// ─── Step 2: Poll for authorization ─────────────────────────────────────────
+
+export type PollResult =
+  | { status: 'pending' }
+  | { status: 'authorized'; authorizationCode: string; codeVerifier: string }
+  | { status: 'error'; message: string };
+
+export async function pollDeviceCode(input: {
+  deviceAuthId: string;
+  userCode: string;
+  fetchImpl?: typeof fetch;
+}): Promise<PollResult> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const response = await fetchImpl(
+    `${OPENAI_AUTH_BASE_URL}/api/accounts/deviceauth/token`,
+    {
+      method: 'POST',
+      headers: buildHeaders('application/json'),
+      body: JSON.stringify({
+        device_auth_id: input.deviceAuthId,
+        user_code: input.userCode,
+      }),
+    },
+  );
+  const bodyText = await response.text();
+
+  if (response.ok) {
+    const parsed = parseJsonObject(bodyText);
+    const authorizationCode = trimNonEmptyString(parsed?.authorization_code);
+    const codeVerifier = trimNonEmptyString(parsed?.code_verifier);
+    if (!authorizationCode || !codeVerifier) {
+      return {
+        status: 'error',
+        message:
+          'OpenAI device authorization response was missing exchange code or verifier.',
+      };
+    }
+    return { status: 'authorized', authorizationCode, codeVerifier };
+  }
+  if (response.status === 403 || response.status === 404) {
+    return { status: 'pending' };
+  }
+  return {
+    status: 'error',
+    message: formatErrorBody(
+      'OpenAI device authorization failed',
+      response.status,
+      bodyText,
+    ),
+  };
+}
+
+// ─── Step 3: Exchange authorization code for tokens ──────────────────────────
+
+export interface ExchangeDeviceCodeResult {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: string;
+}
+
+export async function exchangeDeviceCode(input: {
+  authorizationCode: string;
+  codeVerifier: string;
+  fetchImpl?: typeof fetch;
+}): Promise<ExchangeDeviceCodeResult> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const response = await fetchImpl(`${OPENAI_AUTH_BASE_URL}/oauth/token`, {
+    method: 'POST',
+    headers: buildHeaders('application/x-www-form-urlencoded'),
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: input.authorizationCode,
+      redirect_uri: OPENAI_CODEX_DEVICE_CALLBACK_URL,
+      client_id: OPENAI_CODEX_CLIENT_ID,
+      code_verifier: input.codeVerifier,
+    }),
+  });
+  const bodyText = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      formatErrorBody(
+        'OpenAI device token exchange failed',
+        response.status,
+        bodyText,
+      ),
+    );
+  }
+  const parsed = parseJsonObject(bodyText);
+  const accessToken = trimNonEmptyString(parsed?.access_token);
+  const refreshToken = trimNonEmptyString(parsed?.refresh_token);
+  if (!accessToken || !refreshToken) {
+    throw new Error(
+      'OpenAI token exchange succeeded but did not return access + refresh tokens.',
+    );
+  }
+  const expiresInMs = normalizeTokenLifetimeMs(parsed?.expires_in);
+  const expiresAt = new Date(
+    Date.now() + (expiresInMs ?? 60 * 60 * 1000),
+  ).toISOString();
+  return { accessToken, refreshToken, expiresAt };
+}
+
+// ─── Refresh ────────────────────────────────────────────────────────────────
+
+export interface RefreshOpenAIInput {
+  refreshToken: string;
+  fetchImpl?: typeof fetch;
+}
+
+export async function refreshDeviceCodeToken(
+  input: RefreshOpenAIInput,
+): Promise<ExchangeDeviceCodeResult> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const response = await fetchImpl(`${OPENAI_AUTH_BASE_URL}/oauth/token`, {
+    method: 'POST',
+    headers: buildHeaders('application/x-www-form-urlencoded'),
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: input.refreshToken,
+      client_id: OPENAI_CODEX_CLIENT_ID,
+    }),
+  });
+  const bodyText = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      formatErrorBody(
+        'OpenAI device token refresh failed',
+        response.status,
+        bodyText,
+      ),
+    );
+  }
+  const parsed = parseJsonObject(bodyText);
+  const accessToken = trimNonEmptyString(parsed?.access_token);
+  if (!accessToken) {
+    throw new Error('OpenAI refresh response missing access_token.');
+  }
+  const refreshToken =
+    trimNonEmptyString(parsed?.refresh_token) ?? input.refreshToken;
+  const expiresInMs = normalizeTokenLifetimeMs(parsed?.expires_in);
+  const expiresAt = new Date(
+    Date.now() + (expiresInMs ?? 60 * 60 * 1000),
+  ).toISOString();
+  return { accessToken, refreshToken, expiresAt };
+}
+
+export const _internal = {
+  OPENAI_CODEX_DEVICE_CODE_MIN_INTERVAL_MS,
+};

--- a/src/clawrocket/llm/openai-oauth-state-store.ts
+++ b/src/clawrocket/llm/openai-oauth-state-store.ts
@@ -1,0 +1,89 @@
+/**
+ * openai-oauth-state-store.ts
+ *
+ * In-memory store for OpenAI device code flow state — bridges the
+ * `/initiate` and `/poll` halves of the flow. Each state holds the
+ * deviceAuthId + userCode that we got back from auth.openai.com so we
+ * can resume polling on every /poll request.
+ *
+ * Single-process clawrocket; restart loses state. Cleanup is lazy on
+ * write + reads.
+ */
+
+const STATE_TTL_MS = 16 * 60 * 1000; // device code flow has a 15-min timeout
+
+interface StoredState {
+  deviceAuthId: string;
+  userCode: string;
+  userId: string;
+  createdAt: number;
+}
+
+const store = new Map<string, StoredState>();
+
+function isExpired(entry: StoredState): boolean {
+  return Date.now() - entry.createdAt > STATE_TTL_MS;
+}
+
+function sweepExpired(): void {
+  for (const [state, entry] of store.entries()) {
+    if (isExpired(entry)) store.delete(state);
+  }
+}
+
+export function storeOpenAIState(input: {
+  state: string;
+  deviceAuthId: string;
+  userCode: string;
+  userId: string;
+}): void {
+  sweepExpired();
+  store.set(input.state, {
+    deviceAuthId: input.deviceAuthId,
+    userCode: input.userCode,
+    userId: input.userId,
+    createdAt: Date.now(),
+  });
+}
+
+export type LookupOpenAIResult =
+  | {
+      kind: 'ok';
+      deviceAuthId: string;
+      userCode: string;
+    }
+  | { kind: 'not_found' }
+  | { kind: 'expired' }
+  | { kind: 'wrong_user' };
+
+// Looks up state but does NOT delete — polling needs the entry across
+// many calls. Caller deletes via `consumeOpenAIState` after authorization.
+export function peekOpenAIState(input: {
+  state: string;
+  userId: string;
+}): LookupOpenAIResult {
+  const entry = store.get(input.state);
+  if (!entry) return { kind: 'not_found' };
+  if (isExpired(entry)) {
+    store.delete(input.state);
+    return { kind: 'expired' };
+  }
+  if (entry.userId !== input.userId) {
+    return { kind: 'wrong_user' };
+  }
+  return {
+    kind: 'ok',
+    deviceAuthId: entry.deviceAuthId,
+    userCode: entry.userCode,
+  };
+}
+
+// Delete the state — call after the device code is authorized + tokens
+// stored, or when the user cancels.
+export function consumeOpenAIState(state: string): void {
+  store.delete(state);
+}
+
+export function _resetOpenAIStateStoreForTests(): void {
+  store.clear();
+}

--- a/src/clawrocket/web/routes/llm-oauth-openai.ts
+++ b/src/clawrocket/web/routes/llm-oauth-openai.ts
@@ -1,0 +1,330 @@
+/**
+ * llm-oauth-openai.ts
+ *
+ * HTTP routes for OpenAI ChatGPT subscription auth via device-code flow.
+ *
+ * Routes:
+ *   POST /api/v1/agents/providers/openai/oauth/initiate
+ *     → server requests device code from OpenAI, stores in state map,
+ *       returns { state, userCode, verificationUrl, intervalMs, expiresAtMs }
+ *
+ *   POST /api/v1/agents/providers/openai/oauth/poll  { state }
+ *     → server polls OpenAI's deviceauth/token endpoint once. Returns
+ *       { status: 'pending' | 'authorized' | 'error' }. On 'authorized',
+ *       exchanges code, stores tokens encrypted, and clears state.
+ *
+ *   GET  /api/v1/agents/providers/openai/oauth/status
+ *     → returns current OpenAI credential state
+ *
+ *   POST /api/v1/agents/providers/openai/oauth/disconnect
+ *     → removes the stored OpenAI Codex credential
+ */
+
+import { randomUUID } from 'crypto';
+
+import { getDb } from '../../../db.js';
+import { logger } from '../../../logger.js';
+import {
+  exchangeDeviceCode,
+  pollDeviceCode,
+  requestDeviceCode,
+} from '../../llm/openai-codex-oauth.js';
+import {
+  consumeOpenAIState,
+  peekOpenAIState,
+  storeOpenAIState,
+} from '../../llm/openai-oauth-state-store.js';
+import {
+  decryptProviderSecret,
+  encryptProviderSecret,
+} from '../../llm/provider-secret-store.js';
+import type { AuthContext, ApiEnvelope } from '../types.js';
+
+const OPENAI_PROVIDER_ID = 'provider.openai';
+
+export interface InitiateOpenAIOAuthResult {
+  state: string;
+  userCode: string;
+  verificationUrl: string;
+  intervalMs: number;
+  expiresAtMs: number;
+}
+
+export interface PollOpenAIOAuthBody {
+  state?: unknown;
+}
+
+export type PollOpenAIOAuthResult =
+  | { status: 'pending' }
+  | { status: 'authorized'; expiresAt: string }
+  | { status: 'expired' }
+  | { status: 'error'; message: string };
+
+export interface OpenAIOAuthStatus {
+  connected: boolean;
+  kind: 'oauth_subscription' | 'api_key' | 'none';
+  expiresAt: string | null;
+}
+
+function envelopeError<T>(
+  statusCode: number,
+  code: string,
+  message: string,
+): { statusCode: number; body: ApiEnvelope<T> } {
+  return {
+    statusCode,
+    body: { ok: false, error: { code, message } },
+  };
+}
+
+/** POST /api/v1/agents/providers/openai/oauth/initiate */
+export async function initiateOpenAIOAuthRoute(auth: AuthContext): Promise<{
+  statusCode: number;
+  body: ApiEnvelope<InitiateOpenAIOAuthResult>;
+}> {
+  let device;
+  try {
+    device = await requestDeviceCode();
+  } catch (err) {
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'OpenAI device code request failed',
+    );
+    return envelopeError(
+      502,
+      'request_failed',
+      err instanceof Error
+        ? err.message
+        : 'Could not request a device code from OpenAI.',
+    );
+  }
+
+  const state = randomUUID();
+  storeOpenAIState({
+    state,
+    deviceAuthId: device.deviceAuthId,
+    userCode: device.userCode,
+    userId: auth.userId,
+  });
+
+  return {
+    statusCode: 200,
+    body: {
+      ok: true,
+      data: {
+        state,
+        userCode: device.userCode,
+        verificationUrl: device.verificationUrl,
+        intervalMs: device.intervalMs,
+        expiresAtMs: device.expiresAtMs,
+      },
+    },
+  };
+}
+
+/** POST /api/v1/agents/providers/openai/oauth/poll */
+export async function pollOpenAIOAuthRoute(
+  auth: AuthContext,
+  body: PollOpenAIOAuthBody,
+): Promise<{ statusCode: number; body: ApiEnvelope<PollOpenAIOAuthResult> }> {
+  const state = typeof body.state === 'string' ? body.state.trim() : '';
+  if (!state) {
+    return envelopeError(400, 'invalid_input', 'Missing state.');
+  }
+
+  const lookup = peekOpenAIState({ state, userId: auth.userId });
+  switch (lookup.kind) {
+    case 'not_found':
+      return {
+        statusCode: 200,
+        body: { ok: true, data: { status: 'expired' } },
+      };
+    case 'expired':
+      return {
+        statusCode: 200,
+        body: { ok: true, data: { status: 'expired' } },
+      };
+    case 'wrong_user':
+      return envelopeError(
+        400,
+        'invalid_state',
+        'OAuth state did not match your session.',
+      );
+  }
+
+  const pollResult = await pollDeviceCode({
+    deviceAuthId: lookup.deviceAuthId,
+    userCode: lookup.userCode,
+  });
+
+  if (pollResult.status === 'pending') {
+    return {
+      statusCode: 200,
+      body: { ok: true, data: { status: 'pending' } },
+    };
+  }
+
+  if (pollResult.status === 'error') {
+    consumeOpenAIState(state);
+    return {
+      statusCode: 200,
+      body: {
+        ok: true,
+        data: { status: 'error', message: pollResult.message },
+      },
+    };
+  }
+
+  // 'authorized' — exchange the code for tokens, store, return success.
+  let tokens;
+  try {
+    tokens = await exchangeDeviceCode({
+      authorizationCode: pollResult.authorizationCode,
+      codeVerifier: pollResult.codeVerifier,
+    });
+  } catch (err) {
+    consumeOpenAIState(state);
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'OpenAI device code exchange failed',
+    );
+    return {
+      statusCode: 200,
+      body: {
+        ok: true,
+        data: {
+          status: 'error',
+          message:
+            err instanceof Error
+              ? err.message
+              : 'OpenAI rejected the device code exchange.',
+        },
+      },
+    };
+  }
+
+  const ciphertext = encryptProviderSecret({
+    kind: 'openai_codex',
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    expiresAt: tokens.expiresAt,
+  });
+
+  const now = new Date().toISOString();
+  getDb()
+    .prepare(
+      `INSERT INTO llm_provider_secrets (provider_id, ciphertext, updated_at, updated_by)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(provider_id) DO UPDATE SET
+         ciphertext = excluded.ciphertext,
+         updated_at = excluded.updated_at,
+         updated_by = excluded.updated_by`,
+    )
+    .run(OPENAI_PROVIDER_ID, ciphertext, now, auth.userId);
+
+  consumeOpenAIState(state);
+
+  return {
+    statusCode: 200,
+    body: {
+      ok: true,
+      data: { status: 'authorized', expiresAt: tokens.expiresAt },
+    },
+  };
+}
+
+/** GET /api/v1/agents/providers/openai/oauth/status */
+export async function getOpenAIOAuthStatusRoute(
+  _auth: AuthContext,
+): Promise<{ statusCode: number; body: ApiEnvelope<OpenAIOAuthStatus> }> {
+  const row = getDb()
+    .prepare(
+      `SELECT ciphertext FROM llm_provider_secrets WHERE provider_id = ?`,
+    )
+    .get(OPENAI_PROVIDER_ID) as { ciphertext: string } | undefined;
+
+  if (!row?.ciphertext) {
+    return {
+      statusCode: 200,
+      body: {
+        ok: true,
+        data: { connected: false, kind: 'none', expiresAt: null },
+      },
+    };
+  }
+
+  try {
+    const payload = decryptProviderSecret(row.ciphertext);
+    if (payload.kind === 'openai_codex') {
+      return {
+        statusCode: 200,
+        body: {
+          ok: true,
+          data: {
+            connected: true,
+            kind: 'oauth_subscription',
+            expiresAt: payload.expiresAt ?? null,
+          },
+        },
+      };
+    }
+    if (payload.kind === 'api_key') {
+      return {
+        statusCode: 200,
+        body: {
+          ok: true,
+          data: { connected: true, kind: 'api_key', expiresAt: null },
+        },
+      };
+    }
+    return {
+      statusCode: 200,
+      body: {
+        ok: true,
+        data: { connected: false, kind: 'none', expiresAt: null },
+      },
+    };
+  } catch {
+    return {
+      statusCode: 200,
+      body: {
+        ok: true,
+        data: { connected: false, kind: 'none', expiresAt: null },
+      },
+    };
+  }
+}
+
+/** POST /api/v1/agents/providers/openai/oauth/disconnect */
+export async function disconnectOpenAIOAuthRoute(
+  _auth: AuthContext,
+): Promise<{ statusCode: number; body: ApiEnvelope<OpenAIOAuthStatus> }> {
+  const row = getDb()
+    .prepare(
+      `SELECT ciphertext FROM llm_provider_secrets WHERE provider_id = ?`,
+    )
+    .get(OPENAI_PROVIDER_ID) as { ciphertext: string } | undefined;
+
+  if (row?.ciphertext) {
+    try {
+      const payload = decryptProviderSecret(row.ciphertext);
+      if (payload.kind === 'openai_codex') {
+        getDb()
+          .prepare(`DELETE FROM llm_provider_secrets WHERE provider_id = ?`)
+          .run(OPENAI_PROVIDER_ID);
+      }
+    } catch {
+      getDb()
+        .prepare(`DELETE FROM llm_provider_secrets WHERE provider_id = ?`)
+        .run(OPENAI_PROVIDER_ID);
+    }
+  }
+
+  return {
+    statusCode: 200,
+    body: {
+      ok: true,
+      data: { connected: false, kind: 'none', expiresAt: null },
+    },
+  };
+}

--- a/src/clawrocket/web/server.ts
+++ b/src/clawrocket/web/server.ts
@@ -133,6 +133,12 @@ import {
   submitAnthropicOAuthRoute,
 } from './routes/llm-oauth.js';
 import {
+  disconnectOpenAIOAuthRoute,
+  getOpenAIOAuthStatusRoute,
+  initiateOpenAIOAuthRoute,
+  pollOpenAIOAuthRoute,
+} from './routes/llm-oauth-openai.js';
+import {
   listUserToolPermissionsRoute,
   updateUserToolPermissionRoute,
   getEffectiveToolsRoute,
@@ -1181,6 +1187,49 @@ function buildApp(opts: WebServerOptions): Hono {
     const auth = requireAuth(c);
     if (!auth) return unauthorized(c);
     const result = await disconnectAnthropicOAuthRoute(auth);
+    return new Response(JSON.stringify(result.body), {
+      status: result.statusCode,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    });
+  });
+
+  // ── /api/v1/agents/providers/openai/oauth/* ─ ChatGPT subscription ───────
+
+  app.post('/api/v1/agents/providers/openai/oauth/initiate', async (c) => {
+    const auth = requireAuth(c);
+    if (!auth) return unauthorized(c);
+    const result = await initiateOpenAIOAuthRoute(auth);
+    return new Response(JSON.stringify(result.body), {
+      status: result.statusCode,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    });
+  });
+
+  app.post('/api/v1/agents/providers/openai/oauth/poll', async (c) => {
+    const auth = requireAuth(c);
+    if (!auth) return unauthorized(c);
+    const body = await c.req.json();
+    const result = await pollOpenAIOAuthRoute(auth, body);
+    return new Response(JSON.stringify(result.body), {
+      status: result.statusCode,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    });
+  });
+
+  app.get('/api/v1/agents/providers/openai/oauth/status', async (c) => {
+    const auth = requireAuth(c);
+    if (!auth) return unauthorized(c);
+    const result = await getOpenAIOAuthStatusRoute(auth);
+    return new Response(JSON.stringify(result.body), {
+      status: result.statusCode,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    });
+  });
+
+  app.post('/api/v1/agents/providers/openai/oauth/disconnect', async (c) => {
+    const auth = requireAuth(c);
+    if (!auth) return unauthorized(c);
+    const result = await disconnectOpenAIOAuthRoute(auth);
     return new Response(JSON.stringify(result.body), {
       status: result.statusCode,
       headers: { 'content-type': 'application/json; charset=utf-8' },

--- a/webapp/src/pages/EditorialSetupPage.tsx
+++ b/webapp/src/pages/EditorialSetupPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
 import {
@@ -944,6 +944,309 @@ function AnthropicOAuthCard() {
   );
 }
 
+type OpenAIStatus = {
+  connected: boolean;
+  kind: 'oauth_subscription' | 'api_key' | 'none';
+  expiresAt: string | null;
+};
+
+function OpenAICodexOAuthCard() {
+  const [status, setStatus] = useState<OpenAIStatus | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [working, setWorking] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  // Active device-code flow state.
+  const [pending, setPending] = useState<{
+    state: string;
+    userCode: string;
+    verificationUrl: string;
+    intervalMs: number;
+    expiresAtMs: number;
+  } | null>(null);
+  const [pollMessage, setPollMessage] = useState<string>('');
+  const pollTimerRef = useRef<number | null>(null);
+
+  const refresh = async (): Promise<void> => {
+    try {
+      const res = await fetch('/api/v1/agents/providers/openai/oauth/status', {
+        credentials: 'include',
+      });
+      const json = (await res.json()) as
+        | { ok: true; data: OpenAIStatus }
+        | { ok: false; error: { message: string } };
+      if (json.ok) setStatus(json.data);
+    } catch {
+      // best-effort
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+    return () => {
+      if (pollTimerRef.current !== null) {
+        window.clearTimeout(pollTimerRef.current);
+      }
+    };
+  }, []);
+
+  const stopPolling = (): void => {
+    if (pollTimerRef.current !== null) {
+      window.clearTimeout(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  };
+
+  const startPolling = (
+    state: string,
+    intervalMs: number,
+    expiresAtMs: number,
+  ): void => {
+    const tick = async (): Promise<void> => {
+      if (Date.now() > expiresAtMs) {
+        setError('OpenAI device code expired before authorization. Try again.');
+        setPending(null);
+        setPollMessage('');
+        return;
+      }
+      try {
+        const res = await fetch('/api/v1/agents/providers/openai/oauth/poll', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ state }),
+        });
+        const json = (await res.json()) as
+          | {
+              ok: true;
+              data:
+                | { status: 'pending' }
+                | { status: 'authorized'; expiresAt: string }
+                | { status: 'expired' }
+                | { status: 'error'; message: string };
+            }
+          | { ok: false; error: { message: string } };
+        if (!json.ok) {
+          setError(json.error.message);
+          setPending(null);
+          setPollMessage('');
+          return;
+        }
+        if (json.data.status === 'pending') {
+          setPollMessage('Waiting for browser authorization…');
+          pollTimerRef.current = window.setTimeout(() => {
+            void tick();
+          }, intervalMs);
+          return;
+        }
+        if (json.data.status === 'expired') {
+          setError(
+            'OpenAI device code expired or not found. Try Sign in again.',
+          );
+          setPending(null);
+          setPollMessage('');
+          return;
+        }
+        if (json.data.status === 'error') {
+          setError(json.data.message);
+          setPending(null);
+          setPollMessage('');
+          return;
+        }
+        // authorized
+        setPending(null);
+        setPollMessage('');
+        setError(null);
+        await refresh();
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : 'Failed to poll OpenAI for authorization status.',
+        );
+        setPending(null);
+        setPollMessage('');
+      }
+    };
+    pollTimerRef.current = window.setTimeout(() => {
+      void tick();
+    }, intervalMs);
+  };
+
+  const handleSignIn = async (): Promise<void> => {
+    setError(null);
+    setWorking(true);
+    stopPolling();
+    try {
+      const res = await fetch(
+        '/api/v1/agents/providers/openai/oauth/initiate',
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+      const json = (await res.json()) as
+        | {
+            ok: true;
+            data: {
+              state: string;
+              userCode: string;
+              verificationUrl: string;
+              intervalMs: number;
+              expiresAtMs: number;
+            };
+          }
+        | { ok: false; error: { message: string } };
+      if (!json.ok) {
+        setError(json.error.message);
+        return;
+      }
+      setPending(json.data);
+      setPollMessage('Open the link below + enter the code…');
+      window.open(json.data.verificationUrl, '_blank', 'noopener,noreferrer');
+      startPolling(
+        json.data.state,
+        json.data.intervalMs,
+        json.data.expiresAtMs,
+      );
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Failed to start the ChatGPT sign-in flow.',
+      );
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  const handleCancel = (): void => {
+    stopPolling();
+    setPending(null);
+    setPollMessage('');
+    setError(null);
+  };
+
+  const handleDisconnect = async (): Promise<void> => {
+    setError(null);
+    setWorking(true);
+    try {
+      const res = await fetch(
+        '/api/v1/agents/providers/openai/oauth/disconnect',
+        { method: 'POST', credentials: 'include' },
+      );
+      const json = (await res.json()) as
+        | { ok: true; data: OpenAIStatus }
+        | { ok: false; error: { message: string } };
+      if (json.ok) setStatus(json.data);
+      else setError(json.error.message);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to disconnect.');
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  const expiresLabel = (() => {
+    if (!status?.expiresAt) return null;
+    const ms = Date.parse(status.expiresAt);
+    if (Number.isNaN(ms)) return null;
+    const minutes = Math.round((ms - Date.now()) / 60000);
+    if (minutes < 0) return 'expired';
+    if (minutes < 60) return `expires in ${minutes}m`;
+    const hours = Math.round(minutes / 60);
+    return `expires in ${hours}h`;
+  })();
+
+  const isConnectedOAuth =
+    status?.connected && status.kind === 'oauth_subscription';
+
+  return (
+    <div className="editorial-oauth-card">
+      <div className="editorial-oauth-row">
+        <div className="editorial-oauth-row-text">
+          <span className="editorial-oauth-label">OPENAI AUTH</span>
+          <span
+            className={`editorial-oauth-status${
+              isConnectedOAuth ? ' editorial-oauth-status-connected' : ''
+            }`}
+          >
+            {loading
+              ? 'CHECKING…'
+              : isConnectedOAuth
+                ? `● CONNECTED (ChatGPT subscription${expiresLabel ? ` · ${expiresLabel}` : ''})`
+                : status?.kind === 'api_key'
+                  ? '● CONNECTED (API key)'
+                  : '○ NOT CONNECTED — OpenAI agents will fail without a credential'}
+          </span>
+        </div>
+        <div className="editorial-oauth-actions">
+          {!isConnectedOAuth && !pending ? (
+            <button
+              type="button"
+              className="editorial-chip-button editorial-chip-button-primary"
+              onClick={() => {
+                void handleSignIn();
+              }}
+              disabled={working}
+            >
+              {working ? 'STARTING…' : 'SIGN IN WITH CHATGPT'}
+            </button>
+          ) : null}
+          {isConnectedOAuth ? (
+            <button
+              type="button"
+              className="editorial-chip-button"
+              onClick={() => {
+                void handleDisconnect();
+              }}
+              disabled={working}
+            >
+              DISCONNECT
+            </button>
+          ) : null}
+          {pending ? (
+            <button
+              type="button"
+              className="editorial-chip-button"
+              onClick={handleCancel}
+            >
+              CANCEL
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {pending ? (
+        <div className="editorial-oauth-paste">
+          <p className="editorial-oauth-paste-blurb">
+            A new tab opened to <strong>auth.openai.com/codex/device</strong>.
+            Sign in with your ChatGPT account, then enter this code:
+          </p>
+          <div className="editorial-oauth-usercode">
+            <code>{pending.userCode}</code>
+            <a
+              href={pending.verificationUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="editorial-chip-button"
+            >
+              OPEN VERIFICATION URL ↗
+            </a>
+          </div>
+          {pollMessage ? (
+            <p className="editorial-oauth-poll-message">⌛ {pollMessage}</p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {error ? <p className="editorial-oauth-error">{error}</p> : null}
+    </div>
+  );
+}
+
 function LLMRoomSection({
   setup,
   update,
@@ -1001,6 +1304,7 @@ function LLMRoomSection({
       />
 
       <AnthropicOAuthCard />
+      <OpenAICodexOAuthCard />
 
       <div className="editorial-agents-selected">
         <h3 className="editorial-personas-section-label">

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -5353,6 +5353,40 @@ a {
   letter-spacing: 0.02em;
 }
 
+.editorial-oauth-usercode {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  background: #fbf8f2;
+  border: 1px solid #c9c0a8;
+  border-radius: 5px;
+  padding: 0.5rem 0.65rem;
+}
+
+.editorial-oauth-usercode code {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 1.4rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  color: #1f1c14;
+  background: #fff;
+  border: 1px solid #c9c0a8;
+  border-radius: 4px;
+  padding: 0.25rem 0.65rem;
+  flex: 1;
+  text-align: center;
+}
+
+.editorial-oauth-poll-message {
+  margin: 0;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  color: #6c6655;
+  font-style: italic;
+}
+
 /* Setup · LLM Room section */
 
 .editorial-agents-selected {


### PR DESCRIPTION
## Summary

Adds the OpenAI sibling to the Anthropic OAuth path. Different flow (device code instead of paste-back), same outcome: users with a ChatGPT subscription can sign in without an OpenAI API key.

Port from openclaw's \`openai-codex-device-code.ts\`.

## Three-step flow

1. Server requests a device code from auth.openai.com → \`{ device_auth_id, user_code, interval }\`
2. Display \`user_code\` + verification URL to the user. They open the URL in their browser, type the code, and approve in their ChatGPT account.
3. Server polls \`auth.openai.com/api/accounts/deviceauth/token\` until OpenAI returns \`{ authorization_code, code_verifier }\` (PKCE pair OpenAI generates server-side). Server then exchanges those at \`/oauth/token\` for \`{ access_token, refresh_token, expires_in }\`.

## New modules

- \`lib/openai-codex-oauth.ts\` — request, poll, exchange, refresh. Public client id \`app_EMoamEEZ73f0CkXaXp7hrann\` (Codex CLI's).
- \`lib/openai-oauth-state-store.ts\` — in-memory state map. Holds deviceAuthId+userCode for each active flow, 16-min TTL.
- \`web/routes/llm-oauth-openai.ts\` — initiate / poll / status / disconnect. Polling is client-driven: client calls /poll every intervalMs from the initiate response, server polls OpenAI once per call.

## Frontend

- New \`OpenAICodexOAuthCard\` rendered alongside the existing \`AnthropicOAuthCard\` in the LLM Room section. Two cards, two independent flows.
- Sign-in opens \`auth.openai.com/codex/device\` in a new tab + shows the user code prominently (1.4rem mono, letter-spaced) so it's easy to copy.
- Auto-polls every \`intervalMs\` (default 5s) until authorized, expired, or error. Cancel button stops polling.

## Test plan

- [ ] \`/editorial/setup\` → LLM Room. Two OAuth cards visible: ANTHROPIC AUTH (already connected) and OPENAI AUTH (○ NOT CONNECTED).
- [ ] Click \`SIGN IN WITH CHATGPT\`. New tab opens auth.openai.com/codex/device. User code shows on the card.
- [ ] Type the user code on auth.openai.com, approve. Within 5s the card flips to \`● CONNECTED (ChatGPT subscription · expires in Nh)\`.
- [ ] DISCONNECT works.
- [ ] Anthropic card unaffected by OpenAI flow and vice versa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)