### PR TITLE
fix: surface OpenAI device-code prereq in the OAuth card

### DIFF
--- a/webapp/src/pages/EditorialSetupPage.tsx
+++ b/webapp/src/pages/EditorialSetupPage.tsx
@@ -1219,6 +1219,21 @@ function OpenAICodexOAuthCard() {
         </div>
       </div>
 
+      {!isConnectedOAuth && !pending ? (
+        <p className="editorial-oauth-prereq">
+          First time? Enable <strong>Device code authorization</strong> in your{' '}
+          <a
+            href="https://chatgpt.com/#settings/Security"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            ChatGPT Security Settings
+          </a>{' '}
+          before signing in — otherwise the consent page will show a disabled
+          Continue button.
+        </p>
+      ) : null}
+
       {pending ? (
         <div className="editorial-oauth-paste">
           <p className="editorial-oauth-paste-blurb">
@@ -1236,6 +1251,18 @@ function OpenAICodexOAuthCard() {
               OPEN VERIFICATION URL ↗
             </a>
           </div>
+          <p className="editorial-oauth-paste-blurb">
+            If <strong>Continue</strong> is disabled on auth.openai.com, enable
+            Device code authorization in{' '}
+            <a
+              href="https://chatgpt.com/#settings/Security"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              ChatGPT Security Settings
+            </a>{' '}
+            and reload the consent page.
+          </p>
           {pollMessage ? (
             <p className="editorial-oauth-poll-message">⌛ {pollMessage}</p>
           ) : null}

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -5387,6 +5387,22 @@ a {
   font-style: italic;
 }
 
+.editorial-oauth-prereq {
+  margin: 0;
+  padding: 0.5rem 0.65rem;
+  background: #fff8e7;
+  border: 1px solid #c98a2c;
+  border-radius: 5px;
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  font-size: 0.82rem;
+  color: #4a4738;
+  line-height: 1.45;
+}
+
+.editorial-oauth-prereq a {
+  color: #b7372a;
+}
+
 /* Setup · LLM Room section */
 
 .editorial-agents-selected {


### PR DESCRIPTION
## Summary

OpenAI gates the device-code consent flow behind an account-level toggle (\"Device code authorization for Codex\" in ChatGPT Security Settings). Without it enabled, the consent page on auth.openai.com loads but the Continue button stays disabled — confusing for first-time users.

Adds an amber prereq notice above SIGN IN WITH CHATGPT plus a fallback hint in the pending-state UI. Both link directly to chatgpt.com/#settings/Security.

🤖 Generated with [Claude Code](https://claude.com/claude-code)