### PR TITLE
feat: editorial panel-turn LLM dispatch + SSE route

### DIFF
--- a/src/clawrocket/llm/editorial-llm-call.test.ts
+++ b/src/clawrocket/llm/editorial-llm-call.test.ts
@@ -1,0 +1,424 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getDb } from '../../db.js';
+import { _initTestDatabase, upsertUser } from '../db/index.js';
+import {
+  providerIdForFixtureProvider,
+  resolveAgentCredential,
+  streamPanelTurn,
+} from './editorial-llm-call.js';
+import {
+  decryptProviderSecret,
+  encryptProviderSecret,
+} from './provider-secret-store.js';
+
+function seedProviderSecret(
+  providerId: string,
+  payload: Parameters<typeof encryptProviderSecret>[0],
+): void {
+  const now = new Date().toISOString();
+  getDb()
+    .prepare(
+      `INSERT INTO llm_provider_secrets (provider_id, ciphertext, updated_at, updated_by)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(provider_id) DO UPDATE SET ciphertext = excluded.ciphertext,
+         updated_at = excluded.updated_at, updated_by = excluded.updated_by`,
+    )
+    .run(providerId, encryptProviderSecret(payload), now, 'tester');
+}
+
+function readStoredSecret(providerId: string) {
+  const row = getDb()
+    .prepare(
+      'SELECT ciphertext FROM llm_provider_secrets WHERE provider_id = ?',
+    )
+    .get(providerId) as { ciphertext: string } | undefined;
+  return row ? decryptProviderSecret(row.ciphertext) : null;
+}
+
+function makeStreamResponse(chunks: string[], status = 200): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
+async function collect<T>(iter: AsyncGenerator<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const event of iter) out.push(event);
+  return out;
+}
+
+describe('providerIdForFixtureProvider', () => {
+  it('maps each fixture string to its catalog id', () => {
+    expect(providerIdForFixtureProvider('ANTHROPIC')).toBe(
+      'provider.anthropic',
+    );
+    expect(providerIdForFixtureProvider('OPENAI')).toBe('provider.openai');
+    expect(providerIdForFixtureProvider('GOOGLE')).toBe('provider.gemini');
+    expect(providerIdForFixtureProvider('GEMINI')).toBe('provider.gemini');
+    expect(providerIdForFixtureProvider('NVIDIA')).toBe('provider.nvidia');
+  });
+
+  it('is case-insensitive and returns null for unknown providers', () => {
+    expect(providerIdForFixtureProvider('anthropic')).toBe(
+      'provider.anthropic',
+    );
+    expect(providerIdForFixtureProvider('mistral')).toBeNull();
+    expect(providerIdForFixtureProvider('')).toBeNull();
+  });
+});
+
+describe('resolveAgentCredential', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    upsertUser({
+      id: 'tester',
+      email: 'tester@example.com',
+      displayName: 'tester',
+      role: 'owner',
+    });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws when no secret is stored for the provider', async () => {
+    await expect(resolveAgentCredential('GEMINI')).rejects.toThrow(
+      /No stored credential/,
+    );
+  });
+
+  it('returns the api_key secret + transport for gemini', async () => {
+    seedProviderSecret('provider.gemini', { kind: 'api_key', apiKey: 'g-1' });
+    const cred = await resolveAgentCredential('GEMINI');
+    expect(cred.providerId).toBe('provider.gemini');
+    expect(cred.transport).toBe('openai_chat');
+    expect(cred.baseUrl).toContain('generativelanguage.googleapis.com');
+    expect(cred.model).toBe('gemini-2.5-flash');
+    expect(cred.secret.kind).toBe('api_key');
+  });
+
+  it('honours modelOverride when provided', async () => {
+    seedProviderSecret('provider.nvidia', {
+      kind: 'api_key',
+      apiKey: 'nv-1',
+    });
+    const cred = await resolveAgentCredential('NVIDIA', {
+      modelOverride: 'meta/llama-4-instruct',
+    });
+    expect(cred.model).toBe('meta/llama-4-instruct');
+  });
+
+  it('refreshes anthropic_oauth tokens that are about to expire and persists the rotation', async () => {
+    const expiringAt = new Date(Date.now() + 30_000).toISOString();
+    seedProviderSecret('provider.anthropic', {
+      kind: 'anthropic_oauth',
+      accessToken: 'old-access',
+      refreshToken: 'old-refresh',
+      expiresAt: expiringAt,
+      claudeCodeVersion: '2.1.113',
+    });
+
+    const fetchImpl = vi.fn().mockImplementation(async () => {
+      return new Response(
+        JSON.stringify({
+          access_token: 'new-access',
+          refresh_token: 'new-refresh',
+          expires_in: 3600,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    });
+
+    const cred = await resolveAgentCredential('ANTHROPIC', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(cred.secret.kind).toBe('anthropic_oauth');
+    if (cred.secret.kind !== 'anthropic_oauth') return;
+    expect(cred.secret.accessToken).toBe('new-access');
+    expect(cred.secret.refreshToken).toBe('new-refresh');
+    expect(cred.secret.claudeCodeVersion).toBe('2.1.113');
+
+    const stored = readStoredSecret('provider.anthropic');
+    expect(stored?.kind).toBe('anthropic_oauth');
+    if (stored && stored.kind === 'anthropic_oauth') {
+      expect(stored.accessToken).toBe('new-access');
+    }
+  });
+
+  it('does not refresh anthropic_oauth tokens that are still valid', async () => {
+    const expiresAt = new Date(Date.now() + 24 * 3600 * 1000).toISOString();
+    seedProviderSecret('provider.anthropic', {
+      kind: 'anthropic_oauth',
+      accessToken: 'still-good',
+      refreshToken: 'rt',
+      expiresAt,
+    });
+    const fetchImpl = vi.fn();
+    const cred = await resolveAgentCredential('ANTHROPIC', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(cred.secret.kind).toBe('anthropic_oauth');
+    if (cred.secret.kind === 'anthropic_oauth') {
+      expect(cred.secret.accessToken).toBe('still-good');
+    }
+  });
+});
+
+describe('streamPanelTurn — transport dispatch', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    upsertUser({
+      id: 'tester',
+      email: 'tester@example.com',
+      displayName: 'tester',
+      role: 'owner',
+    });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('dispatches anthropic_messages and yields parsed text deltas + completed', async () => {
+    seedProviderSecret('provider.anthropic', {
+      kind: 'anthropic_oauth',
+      accessToken: 'tok',
+      refreshToken: 'rt',
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    });
+
+    const fetchImpl = vi.fn().mockImplementation(async (url: string) => {
+      expect(url).toBe('https://api.anthropic.com/v1/messages');
+      return makeStreamResponse([
+        'event: content_block_delta\n' +
+          'data: {"type":"content_block_delta","delta":{"text":"hel"}}\n\n',
+        'event: content_block_delta\n' +
+          'data: {"type":"content_block_delta","delta":{"text":"lo"}}\n\n',
+        'event: message_stop\n' + 'data: {"type":"message_stop"}\n\n',
+      ]);
+    });
+
+    const events = await collect(
+      streamPanelTurn({
+        fixtureProvider: 'ANTHROPIC',
+        systemPrompt: 'system',
+        userMessage: 'hi',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const calledBody = JSON.parse(
+      fetchImpl.mock.calls[0][1].body as string,
+    ) as Record<string, unknown>;
+    expect(calledBody.stream).toBe(true);
+    expect(calledBody.model).toBe('claude-sonnet-4-20250514');
+    // OAuth subscription system prompt comes back as content blocks with the
+    // Claude Code identity prefix as the first block.
+    expect(Array.isArray(calledBody.system)).toBe(true);
+    expect(
+      ((calledBody.system as Array<{ text: string }>)[0].text ?? '').startsWith(
+        'You are Claude Code',
+      ),
+    ).toBe(true);
+
+    expect(events.filter((e) => e.type === 'text_delta')).toEqual([
+      { type: 'text_delta', text: 'hel' },
+      { type: 'text_delta', text: 'lo' },
+    ]);
+    const completed = events.find((e) => e.type === 'completed');
+    expect(completed?.type).toBe('completed');
+    if (completed?.type === 'completed') {
+      expect(completed.text).toBe('hello');
+      expect(completed.durationMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('dispatches openai_chat for gemini and parses Chat Completions deltas', async () => {
+    seedProviderSecret('provider.gemini', {
+      kind: 'api_key',
+      apiKey: 'gem-key',
+    });
+
+    const fetchImpl = vi
+      .fn()
+      .mockImplementation(async (url: string, init: RequestInit) => {
+        expect(url).toBe(
+          'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
+        );
+        const headers = init.headers as Record<string, string>;
+        expect(headers.Authorization).toBe('Bearer gem-key');
+        return makeStreamResponse([
+          'data: {"choices":[{"delta":{"content":"foo "}}]}\n\n',
+          'data: {"choices":[{"delta":{"content":"bar"}}]}\n\n',
+          'data: [DONE]\n\n',
+        ]);
+      });
+
+    const events = await collect(
+      streamPanelTurn({
+        fixtureProvider: 'GEMINI',
+        systemPrompt: 'sys',
+        userMessage: 'hi',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    );
+
+    const completed = events.find((e) => e.type === 'completed');
+    expect(completed?.type).toBe('completed');
+    if (completed?.type === 'completed') {
+      expect(completed.text).toBe('foo bar');
+    }
+  });
+
+  it('dispatches openai_responses for openai subscription and parses delta events', async () => {
+    seedProviderSecret('provider.openai', {
+      kind: 'openai_codex',
+      accessToken: 'codex-token',
+      refreshToken: 'codex-refresh',
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    });
+
+    const fetchImpl = vi
+      .fn()
+      .mockImplementation(async (url: string, init: RequestInit) => {
+        expect(url).toBe('https://chatgpt.com/backend-api/codex/responses');
+        const headers = init.headers as Record<string, string>;
+        expect(headers.Authorization).toBe('Bearer codex-token');
+        expect(headers.originator).toBe('codex_cli_rs');
+        const body = JSON.parse(init.body as string) as Record<string, unknown>;
+        expect(body.stream).toBe(true);
+        expect(body.instructions).toBe('sys');
+        return makeStreamResponse([
+          'event: response.output_text.delta\n' +
+            'data: {"type":"response.output_text.delta","delta":"hi"}\n\n',
+          'event: response.completed\n' +
+            'data: {"type":"response.completed"}\n\n',
+        ]);
+      });
+
+    const events = await collect(
+      streamPanelTurn({
+        fixtureProvider: 'OPENAI',
+        systemPrompt: 'sys',
+        userMessage: 'hello',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    );
+
+    const completed = events.find((e) => e.type === 'completed');
+    if (completed?.type === 'completed') {
+      expect(completed.text).toBe('hi');
+    } else {
+      throw new Error('Expected completed event');
+    }
+  });
+
+  it('refreshes the OAuth token once on a 401 and retries the request', async () => {
+    seedProviderSecret('provider.anthropic', {
+      kind: 'anthropic_oauth',
+      accessToken: 'stale',
+      refreshToken: 'rt',
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    });
+
+    const fetchImpl = vi
+      .fn()
+      // 1st call: anthropic /v1/messages → 401
+      .mockResolvedValueOnce(
+        new Response('{"error":{"message":"expired"}}', { status: 401 }),
+      )
+      // 2nd call: refresh /v1/oauth/token → new token
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'fresh',
+            refresh_token: 'rt2',
+            expires_in: 3600,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      )
+      // 3rd call: anthropic /v1/messages retry → stream
+      .mockResolvedValueOnce(
+        makeStreamResponse([
+          'event: content_block_delta\n' +
+            'data: {"type":"content_block_delta","delta":{"text":"ok"}}\n\n',
+        ]),
+      );
+
+    const events = await collect(
+      streamPanelTurn({
+        fixtureProvider: 'ANTHROPIC',
+        systemPrompt: 's',
+        userMessage: 'u',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    const completed = events.find((e) => e.type === 'completed');
+    if (completed?.type === 'completed') {
+      expect(completed.text).toBe('ok');
+    } else {
+      throw new Error('Expected completed event');
+    }
+    const stored = readStoredSecret('provider.anthropic');
+    if (stored?.kind === 'anthropic_oauth') {
+      expect(stored.accessToken).toBe('fresh');
+    } else {
+      throw new Error('Expected anthropic_oauth secret');
+    }
+  });
+
+  it('does not retry an api_key 401 — yields a single error event', async () => {
+    seedProviderSecret('provider.gemini', {
+      kind: 'api_key',
+      apiKey: 'bad',
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response('{"error":"unauth"}', { status: 401 }),
+      );
+
+    const events = await collect(
+      streamPanelTurn({
+        fixtureProvider: 'GEMINI',
+        systemPrompt: 's',
+        userMessage: 'u',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(events.find((e) => e.type === 'error')?.type).toBe('error');
+    expect(events.find((e) => e.type === 'completed')).toBeUndefined();
+  });
+
+  it('yields an error event when no credential is stored', async () => {
+    const events = await collect(
+      streamPanelTurn({
+        fixtureProvider: 'NVIDIA',
+        systemPrompt: 's',
+        userMessage: 'u',
+      }),
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('error');
+    if (events[0].type === 'error') {
+      expect(events[0].message).toMatch(/No stored credential/);
+    }
+  });
+});

--- a/src/clawrocket/llm/editorial-llm-call.ts
+++ b/src/clawrocket/llm/editorial-llm-call.ts
@@ -1,0 +1,758 @@
+/**
+ * editorial-llm-call.ts
+ *
+ * Editorial Room panel-turn LLM dispatch. Resolves an agent's stored
+ * credential (api_key | anthropic_oauth | openai_codex), refreshes OAuth
+ * tokens about to expire, and streams a single panel turn against the
+ * provider's native streaming format. Used by `web/routes/editorial-panel.ts`.
+ *
+ * Three transports are supported, mirroring the catalog in
+ * `webapp/src/lib/llm-providers.ts`:
+ *   - anthropic_messages → POST api.anthropic.com/v1/messages
+ *   - openai_responses   → POST chatgpt.com/backend-api/codex/responses
+ *   - openai_chat        → POST <baseUrl>/chat/completions
+ *
+ * v0p scope: text-only, single-turn, no tool calls, no image input. The
+ * caller passes a system prompt + a single user message; the helper yields
+ * `text_delta` events as tokens arrive and a `completed` event with the
+ * accumulated text + latency at the end. Errors yield `error` events.
+ *
+ * Refresh-on-401: if the first request returns 401 with a body that looks
+ * like an expired-token signal, OAuth credentials get refreshed once and
+ * the request is retried. API-key credentials never retry.
+ */
+
+import { getDb } from '../../db.js';
+import {
+  ANTHROPIC_DEFAULT_VALIDATION_MODEL,
+  buildAnthropicHeaders,
+  buildAnthropicSystemPrompt,
+  isOAuthTokenExpiring,
+  refreshOAuthToken,
+} from './anthropic-oauth.js';
+import {
+  refreshDeviceCodeToken,
+  type ExchangeDeviceCodeResult,
+} from './openai-codex-oauth.js';
+import {
+  decryptProviderSecret,
+  encryptProviderSecret,
+} from './provider-secret-store.js';
+import type {
+  ProviderAnthropicOAuthSecret,
+  ProviderApiKeySecret,
+  ProviderOpenaiCodexSecret,
+  ProviderSecretPayload,
+} from './types.js';
+
+// ─── Catalog (mirrors webapp/src/lib/llm-providers.ts) ──────────────────────
+//
+// Kept as a tiny backend-side mirror so this helper can stand alone without
+// importing from the webapp folder. The IDs match the backend
+// BUILTIN_ADDITIONAL_PROVIDERS list; runtime defaults pick a working model
+// per transport when the caller doesn't pin one.
+
+export type EditorialTransport =
+  | 'anthropic_messages'
+  | 'openai_responses'
+  | 'openai_chat';
+
+export interface EditorialProviderEntry {
+  id: string;
+  transport: EditorialTransport;
+  baseUrl: string;
+  defaultModel: string;
+}
+
+const PROVIDERS: ReadonlyArray<EditorialProviderEntry> = [
+  {
+    id: 'provider.anthropic',
+    transport: 'anthropic_messages',
+    baseUrl: 'https://api.anthropic.com',
+    defaultModel: ANTHROPIC_DEFAULT_VALIDATION_MODEL,
+  },
+  {
+    id: 'provider.openai',
+    transport: 'openai_responses',
+    baseUrl: 'https://chatgpt.com/backend-api/codex',
+    defaultModel: 'gpt-5',
+  },
+  {
+    id: 'provider.gemini',
+    transport: 'openai_chat',
+    baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+    defaultModel: 'gemini-2.5-flash',
+  },
+  {
+    id: 'provider.nvidia',
+    transport: 'openai_chat',
+    baseUrl: 'https://integrate.api.nvidia.com/v1',
+    defaultModel: 'moonshotai/kimi-k2.5',
+  },
+];
+
+const FIXTURE_PROVIDER_TO_ID: Record<string, string> = {
+  ANTHROPIC: 'provider.anthropic',
+  OPENAI: 'provider.openai',
+  GOOGLE: 'provider.gemini',
+  GEMINI: 'provider.gemini',
+  NVIDIA: 'provider.nvidia',
+};
+
+export function providerIdForFixtureProvider(
+  fixtureProvider: string,
+): string | null {
+  return FIXTURE_PROVIDER_TO_ID[fixtureProvider.toUpperCase()] ?? null;
+}
+
+export function getEditorialProvider(
+  providerId: string,
+): EditorialProviderEntry | null {
+  return PROVIDERS.find((p) => p.id === providerId) ?? null;
+}
+
+// ─── Credential resolution + refresh ────────────────────────────────────────
+
+export interface ResolvedCredential {
+  providerId: string;
+  transport: EditorialTransport;
+  baseUrl: string;
+  model: string;
+  secret: ProviderSecretPayload;
+}
+
+export interface ResolveAgentCredentialOptions {
+  fetchImpl?: typeof fetch;
+  /** Override the default model for the agent's provider. Optional — most
+   *  panel turns use the provider's documented default. */
+  modelOverride?: string;
+  /** Skip the refresh-on-expiring step (useful for tests). */
+  skipRefresh?: boolean;
+}
+
+/**
+ * Look up the secret for a fixture-provider string (e.g. 'ANTHROPIC') and
+ * refresh OAuth tokens that are within 60s of expiring. Throws when the
+ * provider is unknown, has no stored credential, or the refresh failed.
+ */
+export async function resolveAgentCredential(
+  fixtureProvider: string,
+  options: ResolveAgentCredentialOptions = {},
+): Promise<ResolvedCredential> {
+  const providerId = providerIdForFixtureProvider(fixtureProvider);
+  if (!providerId) {
+    throw new Error(
+      `No catalog provider for fixture provider '${fixtureProvider}'.`,
+    );
+  }
+  const provider = getEditorialProvider(providerId);
+  if (!provider) {
+    throw new Error(
+      `Provider '${providerId}' is not in the editorial catalog.`,
+    );
+  }
+
+  const db = getDb();
+  const row = db
+    .prepare(
+      `SELECT ciphertext FROM llm_provider_secrets WHERE provider_id = ?`,
+    )
+    .get(providerId) as { ciphertext: string } | undefined;
+  if (!row) {
+    throw new Error(
+      `No stored credential for provider '${providerId}'. Connect it from Setup → LLM Room.`,
+    );
+  }
+
+  let secret = decryptProviderSecret(row.ciphertext);
+
+  if (!options.skipRefresh) {
+    secret = await maybeRefreshSecret(providerId, secret, options.fetchImpl);
+  }
+
+  return {
+    providerId,
+    transport: provider.transport,
+    baseUrl: provider.baseUrl,
+    model: options.modelOverride?.trim() || provider.defaultModel,
+    secret,
+  };
+}
+
+async function maybeRefreshSecret(
+  providerId: string,
+  secret: ProviderSecretPayload,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ProviderSecretPayload> {
+  if (secret.kind === 'anthropic_oauth') {
+    if (!isOAuthTokenExpiring(secret.expiresAt)) return secret;
+    const refreshed = await refreshOAuthToken({
+      refreshToken: secret.refreshToken,
+      fetchImpl,
+    });
+    const next: ProviderAnthropicOAuthSecret = {
+      kind: 'anthropic_oauth',
+      accessToken: refreshed.accessToken,
+      refreshToken: refreshed.refreshToken,
+      expiresAt: refreshed.expiresAt,
+      ...(secret.claudeCodeVersion
+        ? { claudeCodeVersion: secret.claudeCodeVersion }
+        : {}),
+    };
+    persistRefreshedSecret(providerId, next);
+    return next;
+  }
+
+  if (secret.kind === 'openai_codex') {
+    if (!secret.expiresAt || !secret.refreshToken) return secret;
+    if (!isOAuthTokenExpiring(secret.expiresAt)) return secret;
+    let refreshed: ExchangeDeviceCodeResult;
+    try {
+      refreshed = await refreshDeviceCodeToken({
+        refreshToken: secret.refreshToken,
+        fetchImpl,
+      });
+    } catch {
+      // Refresh failed; surface the original token and let the request
+      // surface the 401, which the caller's refresh-on-401 path can handle.
+      return secret;
+    }
+    const next: ProviderOpenaiCodexSecret = {
+      kind: 'openai_codex',
+      accessToken: refreshed.accessToken,
+      refreshToken: refreshed.refreshToken,
+      expiresAt: refreshed.expiresAt,
+      ...(secret.accountId ? { accountId: secret.accountId } : {}),
+    };
+    persistRefreshedSecret(providerId, next);
+    return next;
+  }
+
+  return secret;
+}
+
+function persistRefreshedSecret(
+  providerId: string,
+  secret: ProviderSecretPayload,
+): void {
+  const db = getDb();
+  const now = new Date().toISOString();
+  db.prepare(
+    `UPDATE llm_provider_secrets
+     SET ciphertext = ?, updated_at = ?
+     WHERE provider_id = ?`,
+  ).run(encryptProviderSecret(secret), now, providerId);
+}
+
+// ─── Streaming dispatch ─────────────────────────────────────────────────────
+
+export type PanelTurnEvent =
+  | { type: 'text_delta'; text: string }
+  | { type: 'completed'; text: string; durationMs: number }
+  | { type: 'error'; message: string };
+
+export interface PanelTurnInput {
+  /** Fixture provider tag (uppercase string from FIXTURE_AGENT_PROFILES). */
+  fixtureProvider: string;
+  /** Optional override; otherwise the catalog default for the provider. */
+  modelOverride?: string;
+  /** System-prompt text. The Anthropic OAuth path prepends the Claude Code
+   *  identity block; api-key paths use the value as-is. */
+  systemPrompt: string;
+  /** Single user message for the turn. */
+  userMessage: string;
+  /** Test seam. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Stream a single panel turn for the given agent. Yields `text_delta`
+ * events as tokens arrive, then a `completed` event with the full text and
+ * elapsed wall time. On failure, yields exactly one `error` event and
+ * returns.
+ */
+export async function* streamPanelTurn(
+  input: PanelTurnInput,
+): AsyncGenerator<PanelTurnEvent, void, void> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  let credential: ResolvedCredential;
+  try {
+    credential = await resolveAgentCredential(input.fixtureProvider, {
+      fetchImpl,
+      modelOverride: input.modelOverride,
+    });
+  } catch (err) {
+    yield {
+      type: 'error',
+      message:
+        err instanceof Error ? err.message : 'Failed to resolve credential.',
+    };
+    return;
+  }
+
+  const startedAt = Date.now();
+  let accumulated = '';
+
+  // Refresh-on-401: api-key paths never retry; OAuth paths retry once after
+  // forcing a token refresh.
+  try {
+    let retried = false;
+    let outerAttempt = streamForTransport(credential, input, fetchImpl);
+    for await (const event of outerAttempt) {
+      if (event.type === 'auth_failed') {
+        if (
+          retried ||
+          (credential.secret.kind !== 'anthropic_oauth' &&
+            credential.secret.kind !== 'openai_codex')
+        ) {
+          yield { type: 'error', message: event.message };
+          return;
+        }
+        retried = true;
+        // Force a refresh by clearing the expiry and re-resolving.
+        try {
+          const forced = await forceRefresh(credential, fetchImpl);
+          credential = forced;
+        } catch (err) {
+          yield {
+            type: 'error',
+            message:
+              err instanceof Error
+                ? err.message
+                : 'Failed to refresh OAuth token after 401.',
+          };
+          return;
+        }
+        outerAttempt = streamForTransport(credential, input, fetchImpl);
+        for await (const retryEvent of outerAttempt) {
+          if (retryEvent.type === 'auth_failed') {
+            yield { type: 'error', message: retryEvent.message };
+            return;
+          }
+          if (retryEvent.type === 'text_delta') {
+            accumulated += retryEvent.text;
+          }
+          yield retryEvent;
+        }
+        break;
+      }
+      if (event.type === 'text_delta') {
+        accumulated += event.text;
+      }
+      yield event;
+    }
+  } catch (err) {
+    yield {
+      type: 'error',
+      message: err instanceof Error ? err.message : 'Panel turn failed.',
+    };
+    return;
+  }
+
+  yield {
+    type: 'completed',
+    text: accumulated,
+    durationMs: Date.now() - startedAt,
+  };
+}
+
+async function forceRefresh(
+  cred: ResolvedCredential,
+  fetchImpl: typeof fetch,
+): Promise<ResolvedCredential> {
+  if (cred.secret.kind === 'anthropic_oauth') {
+    const refreshed = await refreshOAuthToken({
+      refreshToken: cred.secret.refreshToken,
+      fetchImpl,
+    });
+    const next: ProviderAnthropicOAuthSecret = {
+      kind: 'anthropic_oauth',
+      accessToken: refreshed.accessToken,
+      refreshToken: refreshed.refreshToken,
+      expiresAt: refreshed.expiresAt,
+      ...(cred.secret.claudeCodeVersion
+        ? { claudeCodeVersion: cred.secret.claudeCodeVersion }
+        : {}),
+    };
+    persistRefreshedSecret(cred.providerId, next);
+    return { ...cred, secret: next };
+  }
+  if (cred.secret.kind === 'openai_codex' && cred.secret.refreshToken) {
+    const refreshed = await refreshDeviceCodeToken({
+      refreshToken: cred.secret.refreshToken,
+      fetchImpl,
+    });
+    const next: ProviderOpenaiCodexSecret = {
+      kind: 'openai_codex',
+      accessToken: refreshed.accessToken,
+      refreshToken: refreshed.refreshToken,
+      expiresAt: refreshed.expiresAt,
+      ...(cred.secret.accountId ? { accountId: cred.secret.accountId } : {}),
+    };
+    persistRefreshedSecret(cred.providerId, next);
+    return { ...cred, secret: next };
+  }
+  throw new Error(
+    `Cannot refresh credential of kind '${cred.secret.kind}' for ${cred.providerId}.`,
+  );
+}
+
+type StreamEvent = PanelTurnEvent | { type: 'auth_failed'; message: string };
+
+async function* streamForTransport(
+  cred: ResolvedCredential,
+  input: PanelTurnInput,
+  fetchImpl: typeof fetch,
+): AsyncGenerator<StreamEvent, void, void> {
+  switch (cred.transport) {
+    case 'anthropic_messages':
+      yield* streamAnthropicMessages(cred, input, fetchImpl);
+      return;
+    case 'openai_responses':
+      yield* streamOpenAIResponses(cred, input, fetchImpl);
+      return;
+    case 'openai_chat':
+      yield* streamOpenAIChat(cred, input, fetchImpl);
+      return;
+  }
+}
+
+// ─── Anthropic Messages ─────────────────────────────────────────────────────
+
+async function* streamAnthropicMessages(
+  cred: ResolvedCredential,
+  input: PanelTurnInput,
+  fetchImpl: typeof fetch,
+): AsyncGenerator<StreamEvent, void, void> {
+  if (
+    cred.secret.kind !== 'anthropic_oauth' &&
+    cred.secret.kind !== 'api_key'
+  ) {
+    yield {
+      type: 'error',
+      message: `Anthropic transport cannot use credential kind '${cred.secret.kind}'.`,
+    };
+    return;
+  }
+  const credentialKind: 'oauth_subscription' | 'api_key' =
+    cred.secret.kind === 'anthropic_oauth' ? 'oauth_subscription' : 'api_key';
+  const token =
+    cred.secret.kind === 'anthropic_oauth'
+      ? cred.secret.accessToken
+      : (cred.secret as ProviderApiKeySecret).apiKey;
+
+  const headers: Record<string, string> = {
+    ...buildAnthropicHeaders({
+      credentialKind,
+      token,
+      claudeCodeVersion:
+        cred.secret.kind === 'anthropic_oauth'
+          ? cred.secret.claudeCodeVersion
+          : undefined,
+    }),
+    'Content-Type': 'application/json',
+    Accept: 'text/event-stream',
+  };
+
+  const body = {
+    model: cred.model,
+    max_tokens: 1024,
+    stream: true,
+    system: buildAnthropicSystemPrompt({
+      credentialKind,
+      systemPrompt: input.systemPrompt,
+    }),
+    messages: [{ role: 'user', content: input.userMessage }],
+  };
+
+  const response = await fetchImpl(`${cred.baseUrl}/v1/messages`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    yield* handleNonOk(response, 'Anthropic');
+    return;
+  }
+  if (!response.body) {
+    yield { type: 'error', message: 'Anthropic response had no stream body.' };
+    return;
+  }
+
+  for await (const event of parseSse(response.body)) {
+    const payload = event.data;
+    if (!payload || payload === '[DONE]') continue;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(payload) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    if (parsed.type === 'content_block_delta') {
+      const delta = parsed.delta as { text?: unknown } | undefined;
+      if (typeof delta?.text === 'string' && delta.text.length > 0) {
+        yield { type: 'text_delta', text: delta.text };
+      }
+    } else if (parsed.type === 'error') {
+      const msg =
+        (parsed.error as { message?: unknown } | undefined)?.message ??
+        'Anthropic stream returned error.';
+      yield { type: 'error', message: String(msg) };
+      return;
+    }
+  }
+}
+
+// ─── OpenAI Responses (ChatGPT subscription) ────────────────────────────────
+
+async function* streamOpenAIResponses(
+  cred: ResolvedCredential,
+  input: PanelTurnInput,
+  fetchImpl: typeof fetch,
+): AsyncGenerator<StreamEvent, void, void> {
+  if (cred.secret.kind !== 'openai_codex') {
+    yield {
+      type: 'error',
+      message: `OpenAI Responses transport requires openai_codex credential, not '${cred.secret.kind}'.`,
+    };
+    return;
+  }
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${cred.secret.accessToken}`,
+    'Content-Type': 'application/json',
+    Accept: 'text/event-stream',
+    // Cloudflare in front of chatgpt.com/backend-api/codex requires a
+    // first-party originator + matching User-Agent or it serves 403s.
+    originator: 'codex_cli_rs',
+    'User-Agent': 'codex_cli_rs/0.0.0 (clawrocket)',
+  };
+  const accountId = extractChatGPTAccountId(cred.secret.accessToken);
+  if (accountId) headers['ChatGPT-Account-ID'] = accountId;
+
+  const body = {
+    model: cred.model,
+    stream: true,
+    instructions: input.systemPrompt,
+    input: [
+      {
+        role: 'user',
+        content: [{ type: 'input_text', text: input.userMessage }],
+      },
+    ],
+  };
+
+  const response = await fetchImpl(`${cred.baseUrl}/responses`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    yield* handleNonOk(response, 'OpenAI Responses');
+    return;
+  }
+  if (!response.body) {
+    yield { type: 'error', message: 'OpenAI Responses had no stream body.' };
+    return;
+  }
+
+  for await (const event of parseSse(response.body)) {
+    const payload = event.data;
+    if (!payload || payload === '[DONE]') continue;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(payload) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const eventType = String(parsed.type ?? '');
+    if (eventType === 'response.output_text.delta') {
+      const delta = parsed.delta;
+      if (typeof delta === 'string' && delta.length > 0) {
+        yield { type: 'text_delta', text: delta };
+      }
+    } else if (eventType === 'response.error' || eventType === 'error') {
+      const errMsg =
+        (parsed.error as { message?: unknown } | undefined)?.message ??
+        parsed.message ??
+        'OpenAI Responses stream returned error.';
+      yield { type: 'error', message: String(errMsg) };
+      return;
+    }
+  }
+}
+
+function extractChatGPTAccountId(jwt: string): string | null {
+  // Best-effort decode of the JWT's middle segment to pull out
+  // `https://api.openai.com/auth.chatgpt_account_id`. Bad tokens just
+  // return null — the surrounding 401 path will handle the actual auth
+  // failure.
+  try {
+    const parts = jwt.split('.');
+    if (parts.length < 2) return null;
+    const padded = parts[1] + '='.repeat((4 - (parts[1].length % 4)) % 4);
+    const json = Buffer.from(padded, 'base64url').toString('utf8');
+    const claims = JSON.parse(json) as Record<string, unknown>;
+    const auth = claims['https://api.openai.com/auth'];
+    if (!auth || typeof auth !== 'object') return null;
+    const acctId = (auth as Record<string, unknown>).chatgpt_account_id;
+    return typeof acctId === 'string' && acctId ? acctId : null;
+  } catch {
+    return null;
+  }
+}
+
+// ─── OpenAI Chat Completions (Gemini, NVIDIA, anything OAI-compat) ──────────
+
+async function* streamOpenAIChat(
+  cred: ResolvedCredential,
+  input: PanelTurnInput,
+  fetchImpl: typeof fetch,
+): AsyncGenerator<StreamEvent, void, void> {
+  if (cred.secret.kind !== 'api_key') {
+    yield {
+      type: 'error',
+      message: `OpenAI Chat transport requires api_key credential, not '${cred.secret.kind}'.`,
+    };
+    return;
+  }
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${cred.secret.apiKey}`,
+    'Content-Type': 'application/json',
+    Accept: 'text/event-stream',
+  };
+
+  const body = {
+    model: cred.model,
+    stream: true,
+    messages: [
+      ...(input.systemPrompt
+        ? [{ role: 'system' as const, content: input.systemPrompt }]
+        : []),
+      { role: 'user' as const, content: input.userMessage },
+    ],
+  };
+
+  const response = await fetchImpl(`${cred.baseUrl}/chat/completions`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    yield* handleNonOk(response, cred.providerId);
+    return;
+  }
+  if (!response.body) {
+    yield {
+      type: 'error',
+      message: `${cred.providerId} response had no stream body.`,
+    };
+    return;
+  }
+
+  for await (const event of parseSse(response.body)) {
+    const payload = event.data;
+    if (!payload || payload === '[DONE]') continue;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(payload) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const choices = parsed.choices;
+    if (!Array.isArray(choices) || choices.length === 0) continue;
+    const delta = (choices[0] as Record<string, unknown>).delta as
+      | Record<string, unknown>
+      | undefined;
+    if (
+      delta &&
+      typeof delta.content === 'string' &&
+      delta.content.length > 0
+    ) {
+      yield { type: 'text_delta', text: delta.content };
+    }
+  }
+}
+
+// ─── Shared error + SSE parsing ─────────────────────────────────────────────
+
+async function* handleNonOk(
+  response: Response,
+  providerLabel: string,
+): AsyncGenerator<StreamEvent, void, void> {
+  const text = await response.text().catch(() => '');
+  if (response.status === 401) {
+    yield {
+      type: 'auth_failed',
+      message: `${providerLabel}: 401 Unauthorized${text ? ` — ${truncate(text, 240)}` : ''}`,
+    };
+    return;
+  }
+  yield {
+    type: 'error',
+    message: `${providerLabel}: HTTP ${response.status}${text ? ` — ${truncate(text, 240)}` : ''}`,
+  };
+}
+
+function truncate(str: string, max: number): string {
+  return str.length <= max ? str : `${str.slice(0, max)}…`;
+}
+
+interface SseEvent {
+  event?: string;
+  data: string;
+}
+
+/**
+ * Minimal SSE parser. Reads UTF-8 chunks from a ReadableStream and yields
+ * one event per blank-line-terminated record. Concatenates multi-line
+ * `data:` fields with a newline per the spec. Ignores `id:` and `retry:`.
+ */
+async function* parseSse(
+  stream: ReadableStream<Uint8Array>,
+): AsyncGenerator<SseEvent, void, void> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder('utf-8');
+  let buffer = '';
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let idx: number;
+      while ((idx = buffer.indexOf('\n\n')) >= 0) {
+        const raw = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 2);
+        const event = parseSseRecord(raw);
+        if (event) yield event;
+      }
+    }
+    buffer += decoder.decode();
+    const tail = buffer.trim();
+    if (tail.length > 0) {
+      const event = parseSseRecord(tail);
+      if (event) yield event;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function parseSseRecord(raw: string): SseEvent | null {
+  const lines = raw.split(/\r?\n/);
+  let eventName: string | undefined;
+  const dataLines: string[] = [];
+  for (const line of lines) {
+    if (!line || line.startsWith(':')) continue;
+    const colon = line.indexOf(':');
+    const field = colon === -1 ? line : line.slice(0, colon);
+    const valueRaw = colon === -1 ? '' : line.slice(colon + 1);
+    const value = valueRaw.startsWith(' ') ? valueRaw.slice(1) : valueRaw;
+    if (field === 'event') eventName = value;
+    else if (field === 'data') dataLines.push(value);
+  }
+  if (dataLines.length === 0 && !eventName) return null;
+  return {
+    event: eventName,
+    data: dataLines.join('\n'),
+  };
+}

--- a/src/clawrocket/web/routes/editorial-panel.ts
+++ b/src/clawrocket/web/routes/editorial-panel.ts
@@ -1,0 +1,253 @@
+/**
+ * editorial-panel.ts
+ *
+ * POST /api/v1/editorial/panel-turn — streams a single Editorial Room
+ * panel turn against an LLM provider as Server-Sent Events. The Draft
+ * editor's `+ ASK` composer wires up to this endpoint; setup decides which
+ * agent to use.
+ *
+ * Request body:
+ *   {
+ *     fixtureProvider: 'ANTHROPIC' | 'OPENAI' | 'GOOGLE' | 'GEMINI' | 'NVIDIA',
+ *     agentName: string,
+ *     agentRole: string,
+ *     userMessage: string,
+ *     segmentContext?: string,    // optional active-segment markdown
+ *     scopePointIndex?: number,   // optional point index for routing context
+ *     modelOverride?: string      // optional; defaults to per-provider catalog model
+ *   }
+ *
+ * SSE events:
+ *   event: text_delta   data: { text: string }
+ *   event: completed    data: { text: string, durationMs: number }
+ *   event: error        data: { message: string }
+ *
+ * v0p scope: stateless, single user message, text-only. Agent identity
+ * comes from the request body — no DB-backed agent profiles yet (those
+ * live in webapp's FIXTURE_AGENT_PROFILES). Tests cover credential
+ * resolution and transport dispatch via mocked fetch.
+ */
+
+import { Context } from 'hono';
+
+import { logger } from '../../../logger.js';
+import {
+  providerIdForFixtureProvider,
+  streamPanelTurn,
+  type PanelTurnEvent,
+} from '../../llm/editorial-llm-call.js';
+import type { AuthContext } from '../types.js';
+
+interface PanelTurnRequestBody {
+  fixtureProvider?: unknown;
+  agentName?: unknown;
+  agentRole?: unknown;
+  userMessage?: unknown;
+  segmentContext?: unknown;
+  scopePointIndex?: unknown;
+  modelOverride?: unknown;
+}
+
+interface ParsedPanelTurnRequest {
+  fixtureProvider: string;
+  agentName: string;
+  agentRole: string;
+  userMessage: string;
+  segmentContext: string;
+  scopePointIndex: number | null;
+  modelOverride: string | undefined;
+}
+
+function parsePanelTurnRequest(
+  body: PanelTurnRequestBody,
+): { ok: true; req: ParsedPanelTurnRequest } | { ok: false; error: string } {
+  const fixtureProvider =
+    typeof body.fixtureProvider === 'string' ? body.fixtureProvider.trim() : '';
+  if (!fixtureProvider) {
+    return { ok: false, error: 'fixtureProvider is required.' };
+  }
+  if (!providerIdForFixtureProvider(fixtureProvider)) {
+    return {
+      ok: false,
+      error: `fixtureProvider '${fixtureProvider}' is not in the editorial catalog.`,
+    };
+  }
+
+  const agentName =
+    typeof body.agentName === 'string' ? body.agentName.trim() : '';
+  if (!agentName) {
+    return { ok: false, error: 'agentName is required.' };
+  }
+  const agentRole =
+    typeof body.agentRole === 'string' ? body.agentRole.trim() : '';
+  if (!agentRole) {
+    return { ok: false, error: 'agentRole is required.' };
+  }
+  const userMessage =
+    typeof body.userMessage === 'string' ? body.userMessage.trim() : '';
+  if (!userMessage) {
+    return { ok: false, error: 'userMessage is required.' };
+  }
+  const segmentContext =
+    typeof body.segmentContext === 'string' ? body.segmentContext : '';
+  const scopePointIndex =
+    typeof body.scopePointIndex === 'number' &&
+    Number.isFinite(body.scopePointIndex)
+      ? Math.max(0, Math.trunc(body.scopePointIndex))
+      : null;
+  const modelOverride =
+    typeof body.modelOverride === 'string' && body.modelOverride.trim()
+      ? body.modelOverride.trim()
+      : undefined;
+
+  return {
+    ok: true,
+    req: {
+      fixtureProvider,
+      agentName,
+      agentRole,
+      userMessage,
+      segmentContext,
+      scopePointIndex,
+      modelOverride,
+    },
+  };
+}
+
+/**
+ * Build the system prompt that tells the LLM which agent it's playing and
+ * what context it has. Kept compact for v0p — the panel turn is a single
+ * critique reply, not a multi-turn conversation.
+ */
+function buildSystemPrompt(req: ParsedPanelTurnRequest): string {
+  const lines: string[] = [];
+  lines.push(
+    `You are ${req.agentName}, the ${req.agentRole} on a small editorial panel reviewing a draft in progress.`,
+  );
+  lines.push(
+    'Reply in 2–4 sentences with one concrete critique or question. Be direct, terse, and useful — no preamble, no flattery, no caveats. Focus on what would actually improve the draft.',
+  );
+  if (req.scopePointIndex !== null) {
+    lines.push(`The user is editing Point ${req.scopePointIndex + 1}.`);
+  }
+  if (req.segmentContext) {
+    lines.push('---');
+    lines.push('Active segment:');
+    lines.push(req.segmentContext.slice(0, 4000));
+    lines.push('---');
+  }
+  return lines.join('\n\n');
+}
+
+function sseHeaders(): Record<string, string> {
+  return {
+    'content-type': 'text/event-stream; charset=utf-8',
+    'cache-control': 'no-cache',
+    connection: 'keep-alive',
+    'x-clawrocket-sse-mode': 'editorial-panel-turn',
+  };
+}
+
+function formatSseEvent(event: PanelTurnEvent): string {
+  const name = event.type;
+  const data = JSON.stringify(
+    event.type === 'completed'
+      ? { text: event.text, durationMs: event.durationMs }
+      : event.type === 'text_delta'
+        ? { text: event.text }
+        : { message: event.message },
+  );
+  return `event: ${name}\ndata: ${data}\n\n`;
+}
+
+export async function handleEditorialPanelTurn(
+  c: Context,
+  auth: AuthContext,
+): Promise<Response> {
+  let body: PanelTurnRequestBody;
+  try {
+    body = (await c.req.json()) as PanelTurnRequestBody;
+  } catch {
+    return c.json(
+      {
+        ok: false,
+        error: { code: 'invalid_json', message: 'Body must be valid JSON.' },
+      },
+      400,
+    );
+  }
+  const parsed = parsePanelTurnRequest(body);
+  if (!parsed.ok) {
+    return c.json(
+      {
+        ok: false,
+        error: { code: 'invalid_input', message: parsed.error },
+      },
+      400,
+    );
+  }
+
+  const req = parsed.req;
+  const systemPrompt = buildSystemPrompt(req);
+  const requestSignal = c.req.raw.signal;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start: async (controller) => {
+      const encoder = new TextEncoder();
+      let cancelled = false;
+      const write = (event: PanelTurnEvent): void => {
+        if (cancelled) return;
+        try {
+          controller.enqueue(encoder.encode(formatSseEvent(event)));
+        } catch {
+          cancelled = true;
+        }
+      };
+      const onAbort = (): void => {
+        cancelled = true;
+        try {
+          controller.close();
+        } catch {
+          // ignored; already closed
+        }
+      };
+      requestSignal.addEventListener('abort', onAbort, { once: true });
+
+      try {
+        const turn = streamPanelTurn({
+          fixtureProvider: req.fixtureProvider,
+          modelOverride: req.modelOverride,
+          systemPrompt,
+          userMessage: req.userMessage,
+        });
+        for await (const event of turn) {
+          if (cancelled) break;
+          write(event);
+          if (event.type === 'error' || event.type === 'completed') break;
+        }
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'Panel turn dispatch failed.';
+        logger.error(
+          { err, userId: auth.userId, fixtureProvider: req.fixtureProvider },
+          'editorial-panel-turn dispatch error',
+        );
+        write({ type: 'error', message });
+      } finally {
+        requestSignal.removeEventListener('abort', onAbort);
+        if (!cancelled) {
+          try {
+            controller.close();
+          } catch {
+            // ignored
+          }
+        }
+      }
+    },
+    cancel: () => {
+      // Client disconnected; nothing to clean up beyond the closure above.
+    },
+  });
+
+  return new Response(stream, { status: 200, headers: sseHeaders() });
+}

--- a/src/clawrocket/web/server.ts
+++ b/src/clawrocket/web/server.ts
@@ -138,6 +138,7 @@ import {
   initiateOpenAIOAuthRoute,
   pollOpenAIOAuthRoute,
 } from './routes/llm-oauth-openai.js';
+import { handleEditorialPanelTurn } from './routes/editorial-panel.js';
 import {
   listUserToolPermissionsRoute,
   updateUserToolPermissionRoute,
@@ -1234,6 +1235,14 @@ function buildApp(opts: WebServerOptions): Hono {
       status: result.statusCode,
       headers: { 'content-type': 'application/json; charset=utf-8' },
     });
+  });
+
+  // ── /api/v1/editorial/panel-turn ─ Editorial Room panel turn (SSE) ───────
+
+  app.post('/api/v1/editorial/panel-turn', async (c) => {
+    const auth = requireAuth(c);
+    if (!auth) return unauthorized(c);
+    return handleEditorialPanelTurn(c, auth);
   });
 
   // ── POST /api/v1/settings/executor/verify ─ credential verification ───


### PR DESCRIPTION
## Summary

- New `src/clawrocket/llm/editorial-llm-call.ts` resolves an agent's stored credential by fixture-provider tag (ANTHROPIC / OPENAI / GEMINI / NVIDIA), refreshes anthropic_oauth and openai_codex tokens within 60s of expiry, and exposes a `streamPanelTurn` async generator yielding `text_delta` / `completed` / `error` events.
- Per-transport adapters dispatch to the right surface:
  - `anthropic_messages` → `api.anthropic.com/v1/messages` with the Claude Code identity prefix as the first system block.
  - `openai_responses` → `chatgpt.com/backend-api/codex/responses` with `originator: codex_cli_rs` + `ChatGPT-Account-ID` extracted from the JWT.
  - `openai_chat` → `<baseUrl>/chat/completions` for Gemini / NVIDIA.
- New `POST /api/v1/editorial/panel-turn` SSE route accepts `{ fixtureProvider, agentName, agentRole, userMessage, segmentContext?, scopePointIndex?, modelOverride? }` and streams events back to the Draft editor's `+ ASK` composer (PR 3).
- Refresh-on-401: OAuth paths force a token refresh + retry once; api_key paths surface the 401 directly so the user re-enters a key.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] 13 new tests in `editorial-llm-call.test.ts` covering credential resolution (missing / api_key / oauth refresh / not-yet-expired / model override) and transport dispatch (Anthropic, OpenAI Responses, OpenAI Chat parsing, refresh-on-401 retry, api_key 401 no-retry, error propagation).
- [x] Existing `ai-agents.test.ts` (7 tests), `anthropic-oauth.test.ts` (20 tests), `provider-secret-store.test.ts` (1 test) — all still passing.
- [ ] Manual: connect Gemini API key, hit `POST /api/v1/editorial/panel-turn` with a stub agent → confirm tokens stream back as SSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)