### PR TITLE
feat: clear-panel-history affordance in Draft right rail

### DIFF
--- a/webapp/src/pages/DraftWorkspacePage.tsx
+++ b/webapp/src/pages/DraftWorkspacePage.tsx
@@ -1330,6 +1330,28 @@ export function DraftWorkspacePage(_props: Props) {
   // Streams a single panel turn from the active agent against the active
   // point's segment context. Live turns are persisted under
   // editorial-room.draft.panel-turns-v0 keyed by activePoint.
+  // Clear all live panel turns for the active point. Fixtures reappear
+  // afterward (they're the first-time-UX fallback). Per-point because the
+  // whole-history nuke is rarely what the user wants — usually they're
+  // clearing a single bad/errored point.
+  const handleClearPanelHistory = (): void => {
+    if (activePoint < 0) return;
+    const pointKey = String(activePoint);
+    setLivePanelTurns((prev) => {
+      if (!prev[pointKey]) return prev;
+      const next = { ...prev };
+      delete next[pointKey];
+      persistLivePanelTurns(next);
+      return next;
+    });
+    setComposerError(null);
+  };
+
+  // True iff the active point has at least one live (non-fixture) turn.
+  // The CLEAR chip in the panel header only renders when this is true.
+  const hasLiveTurnsForActivePoint =
+    activePoint >= 0 && (livePanelTurns[String(activePoint)]?.length ?? 0) > 0;
+
   const handleSubmitPanelTurn = async (): Promise<void> => {
     if (!activeAgent) return;
     if (activePoint < 0) return;
@@ -2472,6 +2494,16 @@ export function DraftWorkspacePage(_props: Props) {
               <span className="editorial-po-draft-panel-last">
                 LAST {scopedPanelTurns[0].timestamp}
               </span>
+            ) : null}
+            {hasLiveTurnsForActivePoint ? (
+              <button
+                type="button"
+                className="editorial-po-draft-panel-clear"
+                onClick={handleClearPanelHistory}
+                title="Clear live panel turns for this point. Fixture turns will reappear."
+              >
+                ✕ CLEAR
+              </button>
             ) : null}
           </header>
 

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -8299,6 +8299,24 @@ a.editorial-phase-pill:hover {
   color: #6c6655;
 }
 
+.editorial-po-draft-panel-clear {
+  background: none;
+  border: 1px solid #c9c0a8;
+  border-radius: 3px;
+  padding: 0.1rem 0.4rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.55rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6c6655;
+  cursor: pointer;
+}
+
+.editorial-po-draft-panel-clear:hover {
+  border-color: #b7372a;
+  color: #b7372a;
+}
+
 .editorial-po-draft-panel-summary {
   margin: 0;
   padding: 0.5rem 0.75rem;


### PR DESCRIPTION
## Summary

Small ✕ CLEAR chip in the Panel header that drops live panel turns for the active point. Fixture turns reappear afterward (they're the first-time-UX fallback). Per-point so a stale/errored turn on one point doesn't force the user to nuke history on others.

The chip only renders when livePanelTurns has at least one entry for the active point, keeping the empty-state UI clean.

## Test plan

- [x] `npm --prefix webapp run typecheck`
- [x] `npm --prefix webapp run build`
- [ ] Manual: ask the panel a question on Point 1 → confirm CLEAR chip appears, click it → confirm fixture turns reappear and CLEAR chip disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)