### PR TITLE
feat: multi-agent fan-out for + ASK panel turns

### DIFF
--- a/webapp/src/lib/llm-provider-auth.ts
+++ b/webapp/src/lib/llm-provider-auth.ts
@@ -1,0 +1,117 @@
+// Editorial Room provider-auth state — shared between Setup (LLM Room
+// section) and Draft (right-rail panel composer). Polls the OAuth status
+// endpoints for OAuth providers and the /api/v1/agents endpoint for
+// API-key providers, then exposes a `{providerId: connected}` map that
+// `isAgentAuthed` uses to filter the agent picker.
+//
+// Extracted from EditorialSetupPage.tsx so DraftWorkspacePage's `+ ASK`
+// composer can ask "which of the selected agents have an authed provider
+// right now?" without a page→page import.
+
+import { useCallback, useEffect, useState } from 'react';
+
+import type { AgentProfile } from './editorial-fixtures';
+import { PROVIDER_CATALOG, catalogIdForFixtureProvider } from './llm-providers';
+
+export type ProviderAuthMap = Record<string, boolean>;
+
+export type AdditionalProviderCard = {
+  id: string;
+  hasCredential: boolean;
+  credentialHint: string | null;
+  verificationStatus:
+    | 'verified'
+    | 'invalid'
+    | 'unavailable'
+    | 'missing'
+    | 'not_verified';
+};
+
+export type AdditionalProviderCardMap = Record<string, AdditionalProviderCard>;
+
+export function useProviderAuth(): {
+  authed: ProviderAuthMap;
+  cards: AdditionalProviderCardMap;
+  refresh: () => Promise<void>;
+} {
+  const [authed, setAuthed] = useState<ProviderAuthMap>({});
+  const [cards, setCards] = useState<AdditionalProviderCardMap>({});
+
+  const refresh = useCallback(async (): Promise<void> => {
+    const next: ProviderAuthMap = {};
+    const nextCards: AdditionalProviderCardMap = {};
+
+    const oauthEntries = PROVIDER_CATALOG.filter((p) => p.oauthStatusEndpoint);
+    const apiKeyEntries = PROVIDER_CATALOG.filter(
+      (p) => p.authType === 'api_key',
+    );
+
+    await Promise.all([
+      ...oauthEntries.map(async (p) => {
+        try {
+          const res = await fetch(p.oauthStatusEndpoint!, {
+            credentials: 'include',
+          });
+          const json = (await res.json()) as
+            | { ok: true; data: { connected: boolean } }
+            | { ok: false };
+          next[p.id] = !!(
+            'ok' in json &&
+            json.ok &&
+            (json.data as { connected?: boolean }).connected
+          );
+        } catch {
+          next[p.id] = false;
+        }
+      }),
+      apiKeyEntries.length > 0
+        ? (async () => {
+            try {
+              const res = await fetch('/api/v1/agents', {
+                credentials: 'include',
+              });
+              const json = (await res.json()) as
+                | {
+                    ok: true;
+                    data: {
+                      additionalProviders: AdditionalProviderCard[];
+                    };
+                  }
+                | { ok: false };
+              if ('ok' in json && json.ok) {
+                for (const p of apiKeyEntries) {
+                  const found = json.data.additionalProviders.find(
+                    (ap) => ap.id === p.id,
+                  );
+                  next[p.id] = !!found?.hasCredential;
+                  if (found) nextCards[p.id] = found;
+                }
+              } else {
+                for (const p of apiKeyEntries) next[p.id] = false;
+              }
+            } catch {
+              for (const p of apiKeyEntries) next[p.id] = false;
+            }
+          })()
+        : Promise.resolve(),
+    ]);
+
+    setAuthed(next);
+    setCards(nextCards);
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { authed, cards, refresh };
+}
+
+export function isAgentAuthed(
+  a: AgentProfile,
+  authed: ProviderAuthMap,
+): boolean {
+  const catalogId = catalogIdForFixtureProvider(a.provider);
+  if (!catalogId) return false;
+  return !!authed[catalogId];
+}

--- a/webapp/src/pages/DraftWorkspacePage.tsx
+++ b/webapp/src/pages/DraftWorkspacePage.tsx
@@ -26,6 +26,7 @@ import {
   type Destination,
   type SetupState,
 } from '../lib/editorial-setup';
+import { isAgentAuthed, useProviderAuth } from '../lib/llm-provider-auth';
 import { serializeDocToMarkdown, type JSONNode } from '../lib/markdown-export';
 import { parseMarkdownToDoc } from '../lib/markdown-import';
 
@@ -1059,6 +1060,10 @@ export function DraftWorkspacePage(_props: Props) {
   const [optimizeOpen, setOptimizeOpen] = useState<boolean>(false);
   const [destination, setDestination] = useState<Destination>(loadDestination);
   const [setup, setSetup] = useState<SetupState>(loadSetupState);
+  // Provider auth state — drives the agent picker for `+ ASK`. Refetches on
+  // mount; the composer's panel size reflects which providers are connected
+  // right now, not what the user picked in Setup.
+  const { authed: providerAuthed } = useProviderAuth();
 
   // Live panel turns produced by the `+ ASK` composer, keyed by activePoint.
   // Persisted to localStorage so they survive reloads. Fixture turns are
@@ -1307,16 +1312,22 @@ export function DraftWorkspacePage(_props: Props) {
     return PANEL_TURNS.filter((t) => t.scopePointIndex === activePoint);
   }, [activePoint, livePanelTurns]);
 
-  // Active agent — first selected agent profile that exists in the fixture
-  // library. The composer surfaces the agent's name + role + provider to
-  // the user before submit so it's never an anonymous chip.
-  const activeAgent = useMemo<AgentProfile | null>(() => {
-    for (const id of setup.llm_room_agent_profile_ids) {
-      const profile = getAgentProfileById(id);
-      if (profile) return profile;
-    }
-    return null;
-  }, [setup.llm_room_agent_profile_ids]);
+  // Selected agent profiles — the full set the user picked in Setup → LLM
+  // Room, including any whose provider has since lost auth (those still
+  // show up in Setup as ⚠ AUTH MISSING). `panelAgents` is the subset we'll
+  // actually fan `+ ASK` out to: connected providers only.
+  const selectedAgents = useMemo<AgentProfile[]>(
+    () =>
+      setup.llm_room_agent_profile_ids
+        .map((id) => getAgentProfileById(id))
+        .filter((a): a is AgentProfile => a !== null),
+    [setup.llm_room_agent_profile_ids],
+  );
+  const panelAgents = useMemo<AgentProfile[]>(
+    () => selectedAgents.filter((a) => isAgentAuthed(a, providerAuthed)),
+    [selectedAgents, providerAuthed],
+  );
+  const skippedAgentCount = selectedAgents.length - panelAgents.length;
 
   const scopeText = scopeChipText(cursor);
   const statusText = activeStatusText(cursor, orderedOutline, activePoint);
@@ -1327,9 +1338,12 @@ export function DraftWorkspacePage(_props: Props) {
   };
 
   // ─── + ASK composer dispatch ──────────────────────────────────────────
-  // Streams a single panel turn from the active agent against the active
-  // point's segment context. Live turns are persisted under
-  // editorial-room.draft.panel-turns-v0 keyed by activePoint.
+  // Fans a single user message out to every authed panel agent in parallel.
+  // Each agent gets its own placeholder turn that streams independently;
+  // one agent's failure does not affect the others (matches the contract's
+  // partial_provider_failures semantics in EDITORIAL_ROOM_CONTRACT.md §4.4).
+  // Live turns are persisted under editorial-room.draft.panel-turns-v0
+  // keyed by activePoint.
   // Clear all live panel turns for the active point. Fixtures reappear
   // afterward (they're the first-time-UX fallback). Per-point because the
   // whole-history nuke is rarely what the user wants — usually they're
@@ -1353,7 +1367,7 @@ export function DraftWorkspacePage(_props: Props) {
     activePoint >= 0 && (livePanelTurns[String(activePoint)]?.length ?? 0) > 0;
 
   const handleSubmitPanelTurn = async (): Promise<void> => {
-    if (!activeAgent) return;
+    if (panelAgents.length === 0) return;
     if (activePoint < 0) return;
     if (composerSubmitting) return;
     const userMessage = composerValue.trim();
@@ -1362,7 +1376,7 @@ export function DraftWorkspacePage(_props: Props) {
     setComposerSubmitting(true);
     setComposerError(null);
 
-    // Build segment context from the paragraphs in the active point's bucket.
+    // Build segment context once — same for every agent in the panel.
     const segmentContext = (() => {
       if (!editor) return '';
       const paragraphs = getDocParagraphs(editor);
@@ -1378,136 +1392,159 @@ export function DraftWorkspacePage(_props: Props) {
       return text.join('\n\n');
     })();
 
-    const turnId = `live-${Date.now()}`;
     const pointKey = String(activePoint);
-    const placeholder: PanelTurn = {
+    const submittedAt = Date.now();
+    const timestamp = new Date(submittedAt).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+
+    type PlannedTurn = { agent: AgentProfile; turnId: string };
+    const planned: PlannedTurn[] = panelAgents.map((agent, idx) => ({
+      agent,
+      turnId: `live-${submittedAt}-${idx}`,
+    }));
+    const placeholders: PanelTurn[] = planned.map(({ agent, turnId }) => ({
       id: turnId,
       scopePointIndex: activePoint,
-      personaInitial: activeAgent.monogram,
-      personaName: activeAgent.name.toUpperCase(),
-      personaRole: activeAgent.role.toUpperCase(),
+      personaInitial: agent.monogram,
+      personaName: agent.name.toUpperCase(),
+      personaRole: agent.role.toUpperCase(),
       body: '',
-      timestamp: new Date().toLocaleTimeString([], {
-        hour: '2-digit',
-        minute: '2-digit',
-        hour12: false,
-      }),
+      timestamp,
       streaming: true,
-    };
+    }));
 
     setLivePanelTurns((prev) => {
       const existing = prev[pointKey] ?? [];
-      const next = { ...prev, [pointKey]: [placeholder, ...existing] };
-      return next;
+      return { ...prev, [pointKey]: [...placeholders, ...existing] };
     });
     setComposerValue('');
 
-    const updateTurn = (patch: Partial<PanelTurn>): void => {
+    const updateTurn = (turnId: string, patch: Partial<PanelTurn>): void => {
       setLivePanelTurns((prev) => {
         const arr = prev[pointKey] ?? [];
-        const next = {
+        return {
           ...prev,
           [pointKey]: arr.map((t) =>
             t.id === turnId ? { ...t, ...patch } : t,
           ),
         };
-        return next;
       });
     };
 
-    try {
-      const res = await fetch('/api/v1/editorial/panel-turn', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          fixtureProvider: activeAgent.provider,
-          agentName: activeAgent.name,
-          agentRole: activeAgent.role,
-          userMessage,
-          segmentContext,
-          scopePointIndex: activePoint,
-        }),
-      });
+    const streamForAgent = async ({
+      agent,
+      turnId,
+    }: PlannedTurn): Promise<void> => {
+      try {
+        const res = await fetch('/api/v1/editorial/panel-turn', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            fixtureProvider: agent.provider,
+            agentName: agent.name,
+            agentRole: agent.role,
+            userMessage,
+            segmentContext,
+            scopePointIndex: activePoint,
+          }),
+        });
 
-      if (!res.ok) {
-        const text = await res.text().catch(() => '');
-        throw new Error(
-          `HTTP ${res.status}${text ? ` — ${text.slice(0, 200)}` : ''}`,
-        );
-      }
-      if (!res.body) {
-        throw new Error('Response had no stream body.');
-      }
+        if (!res.ok) {
+          const text = await res.text().catch(() => '');
+          throw new Error(
+            `HTTP ${res.status}${text ? ` — ${text.slice(0, 200)}` : ''}`,
+          );
+        }
+        if (!res.body) {
+          throw new Error('Response had no stream body.');
+        }
 
-      const decoder = new TextDecoder('utf-8');
-      const reader = res.body.getReader();
-      let buffer = '';
-      let accumulated = '';
-      let streamErrorMessage: string | null = null;
+        const decoder = new TextDecoder('utf-8');
+        const reader = res.body.getReader();
+        let buffer = '';
+        let accumulated = '';
+        let streamErrorMessage: string | null = null;
 
-      for (;;) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        let idx: number;
-        while ((idx = buffer.indexOf('\n\n')) >= 0) {
-          const raw = buffer.slice(0, idx);
-          buffer = buffer.slice(idx + 2);
-          const event = parseClientSseRecord(raw);
-          if (!event) continue;
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          let idx: number;
+          while ((idx = buffer.indexOf('\n\n')) >= 0) {
+            const raw = buffer.slice(0, idx);
+            buffer = buffer.slice(idx + 2);
+            const event = parseClientSseRecord(raw);
+            if (!event) continue;
 
-          if (event.event === 'text_delta') {
-            try {
-              const data = JSON.parse(event.data) as { text?: string };
-              if (typeof data.text === 'string') {
-                accumulated += data.text;
-                updateTurn({ body: accumulated });
+            if (event.event === 'text_delta') {
+              try {
+                const data = JSON.parse(event.data) as { text?: string };
+                if (typeof data.text === 'string') {
+                  accumulated += data.text;
+                  updateTurn(turnId, { body: accumulated });
+                }
+              } catch {
+                // ignore malformed SSE record
               }
-            } catch {
-              // ignore malformed SSE record
-            }
-          } else if (event.event === 'completed') {
-            try {
-              const data = JSON.parse(event.data) as { text?: string };
-              if (typeof data.text === 'string' && data.text.length > 0) {
-                accumulated = data.text;
+            } else if (event.event === 'completed') {
+              try {
+                const data = JSON.parse(event.data) as { text?: string };
+                if (typeof data.text === 'string' && data.text.length > 0) {
+                  accumulated = data.text;
+                }
+              } catch {
+                // ignore
               }
-            } catch {
-              // ignore
-            }
-          } else if (event.event === 'error') {
-            try {
-              const data = JSON.parse(event.data) as { message?: string };
-              streamErrorMessage = data.message ?? 'Panel turn errored.';
-            } catch {
-              streamErrorMessage = 'Panel turn errored.';
+            } else if (event.event === 'error') {
+              try {
+                const data = JSON.parse(event.data) as { message?: string };
+                streamErrorMessage = data.message ?? 'Panel turn errored.';
+              } catch {
+                streamErrorMessage = 'Panel turn errored.';
+              }
             }
           }
         }
-      }
 
-      if (streamErrorMessage) throw new Error(streamErrorMessage);
-      // Final body — any drained-from-completed text wins over accumulator
-      // so the persisted turn matches the server's authoritative final value.
-      updateTurn({ body: accumulated, streaming: false });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Panel turn failed.';
+        if (streamErrorMessage) throw new Error(streamErrorMessage);
+        // Drained-from-completed text wins over the accumulator so the
+        // persisted turn matches the server's authoritative final value.
+        updateTurn(turnId, { body: accumulated, streaming: false });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Panel turn failed.';
+        updateTurn(turnId, {
+          body: msg,
+          streaming: false,
+          errored: true,
+        });
+        throw err;
+      }
+    };
+
+    const results = await Promise.allSettled(planned.map(streamForAgent));
+
+    // Composer-level error fires only when EVERY agent failed. Per-agent
+    // errors already render inside the failed agent's own turn.
+    if (results.length > 0 && results.every((r) => r.status === 'rejected')) {
+      const first = results[0] as PromiseRejectedResult;
+      const msg =
+        first.reason instanceof Error
+          ? first.reason.message
+          : 'Panel turn failed.';
       setComposerError(msg);
-      updateTurn({
-        body: msg,
-        streaming: false,
-        errored: true,
-      });
-    } finally {
-      setComposerSubmitting(false);
-      // Persist the final state regardless of success/failure so the user
-      // can see what happened on reload.
-      setLivePanelTurns((prev) => {
-        persistLivePanelTurns(prev);
-        return prev;
-      });
     }
+
+    setComposerSubmitting(false);
+    // Persist the final state regardless of per-agent outcomes so the user
+    // sees what happened on reload.
+    setLivePanelTurns((prev) => {
+      persistLivePanelTurns(prev);
+      return prev;
+    });
   };
 
   const namedVersions = useMemo(
@@ -2579,15 +2616,23 @@ export function DraftWorkspacePage(_props: Props) {
             <textarea
               className="editorial-po-draft-panel-input"
               placeholder={
-                !activeAgent
-                  ? 'Add an agent in Setup → LLM Room to ask the panel…'
+                panelAgents.length === 0
+                  ? selectedAgents.length === 0
+                    ? 'Add an agent in Setup → LLM Room to ask the panel…'
+                    : 'No connected providers — reconnect in Setup → LLM Room.'
                   : activePoint < 0
                     ? 'Click into a paragraph to scope your question…'
-                    : `Ask ${activeAgent.name} (${activeAgent.role})…`
+                    : panelAgents.length === 1
+                      ? `Ask ${panelAgents[0].name} (${panelAgents[0].role})…`
+                      : `Ask the panel (${panelAgents.length} agents)…`
               }
               value={composerValue}
               onChange={(e) => setComposerValue(e.target.value)}
-              disabled={!activeAgent || activePoint < 0 || composerSubmitting}
+              disabled={
+                panelAgents.length === 0 ||
+                activePoint < 0 ||
+                composerSubmitting
+              }
               rows={2}
               onKeyDown={(e) => {
                 if (
@@ -2603,7 +2648,7 @@ export function DraftWorkspacePage(_props: Props) {
               type="button"
               className="editorial-po-draft-panel-ask"
               disabled={
-                !activeAgent ||
+                panelAgents.length === 0 ||
                 activePoint < 0 ||
                 composerSubmitting ||
                 !composerValue.trim()
@@ -2612,18 +2657,34 @@ export function DraftWorkspacePage(_props: Props) {
                 void handleSubmitPanelTurn();
               }}
               title={
-                !activeAgent
-                  ? 'No agent selected — add one in Setup → LLM Room.'
+                panelAgents.length === 0
+                  ? selectedAgents.length === 0
+                    ? 'No agent selected — add one in Setup → LLM Room.'
+                    : 'No connected providers — reconnect in Setup → LLM Room.'
                   : activePoint < 0
                     ? 'Click into a paragraph to scope the turn.'
                     : composerSubmitting
-                      ? 'Streaming the turn…'
-                      : `Ask ${activeAgent.name}`
+                      ? 'Streaming the panel…'
+                      : panelAgents.length === 1
+                        ? `Ask ${panelAgents[0].name}`
+                        : `Ask all ${panelAgents.length} agents in parallel`
               }
             >
-              {composerSubmitting ? '… STREAMING' : '+ ASK'}
+              {composerSubmitting
+                ? '… STREAMING'
+                : panelAgents.length >= 2
+                  ? `+ ASK PANEL (${panelAgents.length})`
+                  : '+ ASK'}
             </button>
           </div>
+          {panelAgents.length > 0 ? (
+            <p className="editorial-po-draft-panel-hint">
+              {panelAgents.map((a) => a.name).join(' · ')}
+              {skippedAgentCount > 0
+                ? ` · ${skippedAgentCount} skipped (auth missing)`
+                : ''}
+            </p>
+          ) : null}
           {composerError ? (
             <p className="editorial-po-draft-panel-error">{composerError}</p>
           ) : null}

--- a/webapp/src/pages/EditorialSetupPage.tsx
+++ b/webapp/src/pages/EditorialSetupPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
 import {
@@ -21,11 +21,13 @@ import {
   type Destination,
   type SetupState,
 } from '../lib/editorial-setup';
+import { PROVIDER_CATALOG, type ProviderEntry } from '../lib/llm-providers';
 import {
-  catalogIdForFixtureProvider,
-  PROVIDER_CATALOG,
-  type ProviderEntry,
-} from '../lib/llm-providers';
+  isAgentAuthed,
+  useProviderAuth,
+  type AdditionalProviderCard,
+  type AdditionalProviderCardMap,
+} from '../lib/llm-provider-auth';
 
 // SetupState mirrors docs/contracts/editorial-room/v0/setup_state.schema.json
 // (also in EDITORIAL_ROOM_CONTRACT.md §2.1). Persisted to localStorage via
@@ -1288,19 +1290,8 @@ function OpenAICodexOAuthCard({ onChange }: { onChange?: () => void } = {}) {
 // ─── Generic API-key auth card ──────────────────────────────────────────────
 // Backs api_key entries in the provider catalog (Gemini, NVIDIA, …) by
 // POSTing to the existing PUT /api/v1/agents/providers/:providerId route.
-// Provider state (hasCredential, credentialHint) comes from GET /api/v1/agents.
-
-type AdditionalProviderCard = {
-  id: string;
-  hasCredential: boolean;
-  credentialHint: string | null;
-  verificationStatus:
-    | 'verified'
-    | 'invalid'
-    | 'unavailable'
-    | 'missing'
-    | 'not_verified';
-};
+// Provider state (hasCredential, credentialHint) comes from GET /api/v1/agents
+// via the shared `useProviderAuth` hook in `lib/llm-provider-auth.ts`.
 
 function ApiKeyAuthCard({
   entry,
@@ -1468,89 +1459,9 @@ function ApiKeyAuthCard({
   );
 }
 
-// ─── Provider auth list + status hook ────────────────────────────────────────
-
-type ProviderAuthMap = Record<string, boolean>;
-
-type AdditionalProviderCardMap = Record<string, AdditionalProviderCard>;
-
-function useProviderAuth(): {
-  authed: ProviderAuthMap;
-  cards: AdditionalProviderCardMap;
-  refresh: () => Promise<void>;
-} {
-  const [authed, setAuthed] = useState<ProviderAuthMap>({});
-  const [cards, setCards] = useState<AdditionalProviderCardMap>({});
-
-  const refresh = useCallback(async (): Promise<void> => {
-    const next: ProviderAuthMap = {};
-    const nextCards: AdditionalProviderCardMap = {};
-
-    const oauthEntries = PROVIDER_CATALOG.filter((p) => p.oauthStatusEndpoint);
-    const apiKeyEntries = PROVIDER_CATALOG.filter(
-      (p) => p.authType === 'api_key',
-    );
-
-    await Promise.all([
-      ...oauthEntries.map(async (p) => {
-        try {
-          const res = await fetch(p.oauthStatusEndpoint!, {
-            credentials: 'include',
-          });
-          const json = (await res.json()) as
-            | { ok: true; data: { connected: boolean } }
-            | { ok: false };
-          next[p.id] = !!(
-            'ok' in json &&
-            json.ok &&
-            (json.data as { connected?: boolean }).connected
-          );
-        } catch {
-          next[p.id] = false;
-        }
-      }),
-      apiKeyEntries.length > 0
-        ? (async () => {
-            try {
-              const res = await fetch('/api/v1/agents', {
-                credentials: 'include',
-              });
-              const json = (await res.json()) as
-                | {
-                    ok: true;
-                    data: {
-                      additionalProviders: AdditionalProviderCard[];
-                    };
-                  }
-                | { ok: false };
-              if ('ok' in json && json.ok) {
-                for (const p of apiKeyEntries) {
-                  const found = json.data.additionalProviders.find(
-                    (ap) => ap.id === p.id,
-                  );
-                  next[p.id] = !!found?.hasCredential;
-                  if (found) nextCards[p.id] = found;
-                }
-              } else {
-                for (const p of apiKeyEntries) next[p.id] = false;
-              }
-            } catch {
-              for (const p of apiKeyEntries) next[p.id] = false;
-            }
-          })()
-        : Promise.resolve(),
-    ]);
-
-    setAuthed(next);
-    setCards(nextCards);
-  }, []);
-
-  useEffect(() => {
-    void refresh();
-  }, [refresh]);
-
-  return { authed, cards, refresh };
-}
+// ─── Provider auth list ─────────────────────────────────────────────────────
+// `useProviderAuth` + `isAgentAuthed` live in `lib/llm-provider-auth.ts` so
+// the Draft right-rail panel composer can reuse them.
 
 function ProviderAuthList({
   cards,
@@ -1579,12 +1490,6 @@ function ProviderAuthList({
       })}
     </>
   );
-}
-
-function isAgentAuthed(a: AgentProfile, authed: ProviderAuthMap): boolean {
-  const catalogId = catalogIdForFixtureProvider(a.provider);
-  if (!catalogId) return false;
-  return !!authed[catalogId];
 }
 
 function LLMRoomSection({

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -8508,6 +8508,17 @@ a.editorial-phase-pill:hover {
   word-break: break-word;
 }
 
+.editorial-po-draft-panel-hint {
+  margin: 0.15rem 0.6rem 0.5rem;
+  padding: 0;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6a6a6a;
+  word-break: break-word;
+}
+
 /* Sources tab content */
 
 .editorial-po-draft-sources-list {


### PR DESCRIPTION
## Summary

- The Draft right-rail composer now fans `+ ASK` out across **every** authed agent in `setup.llm_room_agent_profile_ids`, not just the first one.
- Each agent gets its own placeholder turn that streams independently. One agent's failure doesn't block the others (matches `partial_provider_failures` semantics in `EDITORIAL_ROOM_CONTRACT.md` §4.4).
- Composer button label switches to `+ ASK PANEL (N)` once N ≥ 2; a hint line under the textarea lists the agents who will respond plus any selected agents skipped because their provider lost auth.
- `useProviderAuth` + `isAgentAuthed` extracted from `EditorialSetupPage.tsx` to a shared `lib/llm-provider-auth.ts` so Draft and Setup use the same provider-auth source of truth (no page→page import).

## Why

Design intent (`design/04_draft.md`, kickoff §15 anti-pattern) is *panel = many agents debating*. Single-agent dispatch was a stand-in shipped to validate the SSE plumbing — confirmed working with one Anthropic agent in PRs #291–293. This closes the gap so two or more selected agents actually run in parallel.

## Test plan

- [x] `npm --prefix webapp run typecheck`
- [x] `npm --prefix webapp run build`
- [x] `npm --prefix webapp run test` (214 passed, 1 skipped)
- [x] `npm run typecheck`
- [x] `NANOCLAW_ALLOW_UNSUPPORTED_NODE=1 node scripts/run-vitest.mjs run src/clawrocket/llm/editorial-llm-call.test.ts` (13 passed)
- [x] Prettier on changed files
- [ ] Manual: 2 Anthropic agents (Argus + Voice Critic) selected in Setup → Draft → click into a paragraph → `+ ASK PANEL (2)` → both turns stream independently
- [ ] Manual: confirm one agent failing leaves the other's turn intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)