### PR TITLE
feat: + ASK panel composer in 02 Theme/Topics + 03 Points/Outline

### DIFF
--- a/webapp/src/lib/panel-fanout.ts
+++ b/webapp/src/lib/panel-fanout.ts
@@ -1,0 +1,160 @@
+// Shared dispatch helper for Editorial Room `+ ASK` panel composers.
+//
+// `streamAgentPanelTurn` POSTs one panel turn to /api/v1/editorial/panel-turn
+// and parses the SSE response, invoking callbacks as text deltas arrive,
+// once on completion, and once on error. Pages that fan out across multiple
+// agents call this in parallel under `Promise.allSettled` so one agent's
+// failure can't block the others — that mirrors the contract's
+// `partial_provider_failures` semantics in EDITORIAL_ROOM_CONTRACT.md §4.4.
+//
+// Each page owns its own turn shape, storage key, and JSX; this module just
+// gives them a single source of truth for the network protocol.
+
+export interface PanelFanOutAgent {
+  /** Fixture-provider tag (uppercase) — ANTHROPIC | OPENAI | GOOGLE | GEMINI | NVIDIA. */
+  provider: string;
+  name: string;
+  role: string;
+}
+
+export interface PanelFanOutRequest {
+  agent: PanelFanOutAgent;
+  userMessage: string;
+  segmentContext: string;
+  /** Optional point index for routing context. Pass null when the panel is
+   *  scoped to a Topic (no Point yet) or a Theme. */
+  scopePointIndex: number | null;
+  /** Test seam. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface PanelFanOutCallbacks {
+  /** Fires every time the server emits a token. `accumulated` is the
+   *  running concatenation so far. */
+  onTextDelta?: (delta: string, accumulated: string) => void;
+  /** Fires once when the stream finishes successfully. `finalText` is the
+   *  authoritative server-emitted value (what arrived in the `completed`
+   *  event), falling back to the running accumulator. */
+  onComplete?: (finalText: string) => void;
+  /** Fires once on a transport, HTTP, or stream error. After this fires,
+   *  the function rejects so a `Promise.allSettled` caller can identify
+   *  which agents failed. */
+  onError?: (message: string) => void;
+}
+
+/**
+ * Stream a single agent's panel turn. Throws on hard error after invoking
+ * the optional `onError` callback, so callers can use `Promise.allSettled`
+ * to fan out across N agents and still distinguish per-agent outcomes.
+ */
+export async function streamAgentPanelTurn(
+  request: PanelFanOutRequest,
+  callbacks: PanelFanOutCallbacks = {},
+): Promise<string> {
+  const fetchImpl = request.fetchImpl ?? fetch;
+  let accumulated = '';
+  let streamErrorMessage: string | null = null;
+
+  try {
+    const res = await fetchImpl('/api/v1/editorial/panel-turn', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        fixtureProvider: request.agent.provider,
+        agentName: request.agent.name,
+        agentRole: request.agent.role,
+        userMessage: request.userMessage,
+        segmentContext: request.segmentContext,
+        scopePointIndex: request.scopePointIndex,
+      }),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(
+        `HTTP ${res.status}${text ? ` — ${text.slice(0, 200)}` : ''}`,
+      );
+    }
+    if (!res.body) {
+      throw new Error('Response had no stream body.');
+    }
+
+    const decoder = new TextDecoder('utf-8');
+    const reader = res.body.getReader();
+    let buffer = '';
+
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let idx: number;
+      while ((idx = buffer.indexOf('\n\n')) >= 0) {
+        const raw = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 2);
+        const event = parsePanelTurnSseRecord(raw);
+        if (!event) continue;
+
+        if (event.event === 'text_delta') {
+          try {
+            const data = JSON.parse(event.data) as { text?: string };
+            if (typeof data.text === 'string') {
+              accumulated += data.text;
+              callbacks.onTextDelta?.(data.text, accumulated);
+            }
+          } catch {
+            // ignore malformed SSE record
+          }
+        } else if (event.event === 'completed') {
+          try {
+            const data = JSON.parse(event.data) as { text?: string };
+            if (typeof data.text === 'string' && data.text.length > 0) {
+              accumulated = data.text;
+            }
+          } catch {
+            // ignore
+          }
+        } else if (event.event === 'error') {
+          try {
+            const data = JSON.parse(event.data) as { message?: string };
+            streamErrorMessage = data.message ?? 'Panel turn errored.';
+          } catch {
+            streamErrorMessage = 'Panel turn errored.';
+          }
+        }
+      }
+    }
+
+    if (streamErrorMessage) throw new Error(streamErrorMessage);
+    callbacks.onComplete?.(accumulated);
+    return accumulated;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Panel turn failed.';
+    callbacks.onError?.(msg);
+    throw err;
+  }
+}
+
+/**
+ * Minimal SSE record parser. Mirrors the server-side parser in
+ * `src/clawrocket/llm/editorial-llm-call.ts`; the route emits records of
+ * the form `event: <name>\ndata: <json>\n\n`.
+ */
+export function parsePanelTurnSseRecord(
+  raw: string,
+): { event?: string; data: string } | null {
+  const lines = raw.split(/\r?\n/);
+  let eventName: string | undefined;
+  const dataLines: string[] = [];
+  for (const line of lines) {
+    if (!line || line.startsWith(':')) continue;
+    const colon = line.indexOf(':');
+    const field = colon === -1 ? line : line.slice(0, colon);
+    const valueRaw = colon === -1 ? '' : line.slice(colon + 1);
+    const value = valueRaw.startsWith(' ') ? valueRaw.slice(1) : valueRaw;
+    if (field === 'event') eventName = value;
+    else if (field === 'data') dataLines.push(value);
+  }
+  if (dataLines.length === 0 && !eventName) return null;
+  return { event: eventName, data: dataLines.join('\n') };
+}

--- a/webapp/src/pages/DraftWorkspacePage.tsx
+++ b/webapp/src/pages/DraftWorkspacePage.tsx
@@ -29,6 +29,7 @@ import {
 import { isAgentAuthed, useProviderAuth } from '../lib/llm-provider-auth';
 import { serializeDocToMarkdown, type JSONNode } from '../lib/markdown-export';
 import { parseMarkdownToDoc } from '../lib/markdown-import';
+import { streamAgentPanelTurn } from '../lib/panel-fanout';
 
 // ───────────────────────────────────────────────────────────────────────────
 // Phase 04 DRAFT — bubble toolbar + link/underline/align/highlight.
@@ -260,28 +261,6 @@ function persistLivePanelTurns(turns: LivePanelTurnMap): void {
   } catch {
     // localStorage full / disabled — non-fatal at v0p.
   }
-}
-
-// Minimal client-side SSE record parser. Mirrors the server-side parser in
-// editorial-llm-call.ts; the route emits {event: text_delta|completed|error,
-// data: <json>} records terminated by blank lines.
-type ClientSseEvent = { event?: string; data: string };
-
-function parseClientSseRecord(raw: string): ClientSseEvent | null {
-  const lines = raw.split(/\r?\n/);
-  let eventName: string | undefined;
-  const dataLines: string[] = [];
-  for (const line of lines) {
-    if (!line || line.startsWith(':')) continue;
-    const colon = line.indexOf(':');
-    const field = colon === -1 ? line : line.slice(0, colon);
-    const valueRaw = colon === -1 ? '' : line.slice(colon + 1);
-    const value = valueRaw.startsWith(' ') ? valueRaw.slice(1) : valueRaw;
-    if (field === 'event') eventName = value;
-    else if (field === 'data') dataLines.push(value);
-  }
-  if (dataLines.length === 0 && !eventName) return null;
-  return { event: eventName, data: dataLines.join('\n') };
 }
 
 const PANEL_TURNS: ReadonlyArray<PanelTurn> = [
@@ -1438,91 +1417,30 @@ export function DraftWorkspacePage(_props: Props) {
       agent,
       turnId,
     }: PlannedTurn): Promise<void> => {
-      try {
-        const res = await fetch('/api/v1/editorial/panel-turn', {
-          method: 'POST',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            fixtureProvider: agent.provider,
-            agentName: agent.name,
-            agentRole: agent.role,
-            userMessage,
-            segmentContext,
-            scopePointIndex: activePoint,
-          }),
-        });
-
-        if (!res.ok) {
-          const text = await res.text().catch(() => '');
-          throw new Error(
-            `HTTP ${res.status}${text ? ` — ${text.slice(0, 200)}` : ''}`,
-          );
-        }
-        if (!res.body) {
-          throw new Error('Response had no stream body.');
-        }
-
-        const decoder = new TextDecoder('utf-8');
-        const reader = res.body.getReader();
-        let buffer = '';
-        let accumulated = '';
-        let streamErrorMessage: string | null = null;
-
-        for (;;) {
-          const { value, done } = await reader.read();
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          let idx: number;
-          while ((idx = buffer.indexOf('\n\n')) >= 0) {
-            const raw = buffer.slice(0, idx);
-            buffer = buffer.slice(idx + 2);
-            const event = parseClientSseRecord(raw);
-            if (!event) continue;
-
-            if (event.event === 'text_delta') {
-              try {
-                const data = JSON.parse(event.data) as { text?: string };
-                if (typeof data.text === 'string') {
-                  accumulated += data.text;
-                  updateTurn(turnId, { body: accumulated });
-                }
-              } catch {
-                // ignore malformed SSE record
-              }
-            } else if (event.event === 'completed') {
-              try {
-                const data = JSON.parse(event.data) as { text?: string };
-                if (typeof data.text === 'string' && data.text.length > 0) {
-                  accumulated = data.text;
-                }
-              } catch {
-                // ignore
-              }
-            } else if (event.event === 'error') {
-              try {
-                const data = JSON.parse(event.data) as { message?: string };
-                streamErrorMessage = data.message ?? 'Panel turn errored.';
-              } catch {
-                streamErrorMessage = 'Panel turn errored.';
-              }
-            }
-          }
-        }
-
-        if (streamErrorMessage) throw new Error(streamErrorMessage);
-        // Drained-from-completed text wins over the accumulator so the
-        // persisted turn matches the server's authoritative final value.
-        updateTurn(turnId, { body: accumulated, streaming: false });
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : 'Panel turn failed.';
-        updateTurn(turnId, {
-          body: msg,
-          streaming: false,
-          errored: true,
-        });
-        throw err;
-      }
+      await streamAgentPanelTurn(
+        {
+          agent: {
+            provider: agent.provider,
+            name: agent.name,
+            role: agent.role,
+          },
+          userMessage,
+          segmentContext,
+          scopePointIndex: activePoint,
+        },
+        {
+          onTextDelta: (_delta, accumulated) =>
+            updateTurn(turnId, { body: accumulated }),
+          onComplete: (finalText) =>
+            updateTurn(turnId, { body: finalText, streaming: false }),
+          onError: (msg) =>
+            updateTurn(turnId, {
+              body: msg,
+              streaming: false,
+              errored: true,
+            }),
+        },
+      );
     };
 
     const results = await Promise.allSettled(planned.map(streamForAgent));

--- a/webapp/src/pages/PointsOutlineWorkspacePage.tsx
+++ b/webapp/src/pages/PointsOutlineWorkspacePage.tsx
@@ -17,6 +17,13 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 
 import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
+import {
+  getAgentProfileById,
+  type AgentProfile,
+} from '../lib/editorial-fixtures';
+import { loadSetupState } from '../lib/editorial-setup';
+import { isAgentAuthed, useProviderAuth } from '../lib/llm-provider-auth';
+import { streamAgentPanelTurn } from '../lib/panel-fanout';
 
 // ───────────────────────────────────────────────────────────────────────────
 // Fixture-shaped data, hardcoded inline for the 0p-a vertical slice. Real
@@ -101,6 +108,51 @@ type RevisionTurn = {
 };
 
 type DiscussionTurn = AgentTurn | RevisionTurn;
+
+// Live panel turns produced by the `+ ASK` composer in this workspace.
+// Persisted to localStorage at LIVE_PANEL_TURNS_STORAGE_KEY so the user's
+// history survives reloads. Fixture turns (PointDetail.discussion) stay
+// behind live turns in the rendered list.
+type LivePanelTurn = {
+  id: string;
+  agentMonogram: string;
+  agentName: string;
+  agentRole: string;
+  body: string;
+  timestamp: string;
+  streaming?: boolean;
+  errored?: boolean;
+};
+
+type LivePanelTurnMap = Record<string, LivePanelTurn[]>;
+
+const LIVE_PANEL_TURNS_STORAGE_KEY =
+  'editorial-room.points-outline.panel-turns-v0';
+
+function loadLivePanelTurns(): LivePanelTurnMap {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(LIVE_PANEL_TURNS_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return {};
+    return parsed as LivePanelTurnMap;
+  } catch {
+    return {};
+  }
+}
+
+function persistLivePanelTurns(turns: LivePanelTurnMap): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(
+      LIVE_PANEL_TURNS_STORAGE_KEY,
+      JSON.stringify(turns),
+    );
+  } catch {
+    // localStorage full / disabled — non-fatal at v0p.
+  }
+}
 
 type PointDetail = {
   slug: string;
@@ -1398,6 +1450,158 @@ export function PointsOutlineWorkspacePage(_props: Props) {
   const stale = state?.stale ?? false;
   const rescoring = rescoringSlug === activePoint.slug;
 
+  // Setup-driven panel agents. Same plumbing as Setup → LLM Room and Draft.
+  const [setup] = useState(loadSetupState);
+  const { authed: providerAuthed } = useProviderAuth();
+  const selectedAgents = useMemo<AgentProfile[]>(
+    () =>
+      setup.llm_room_agent_profile_ids
+        .map((id) => getAgentProfileById(id))
+        .filter((a): a is AgentProfile => a !== null),
+    [setup.llm_room_agent_profile_ids],
+  );
+  const panelAgents = useMemo<AgentProfile[]>(
+    () => selectedAgents.filter((a) => isAgentAuthed(a, providerAuthed)),
+    [selectedAgents, providerAuthed],
+  );
+  const skippedAgentCount = selectedAgents.length - panelAgents.length;
+
+  const [livePanelTurns, setLivePanelTurns] =
+    useState<LivePanelTurnMap>(loadLivePanelTurns);
+
+  const handleSubmitPointPanelTurn = async (
+    point: { slug: string; claim: string; stake: string; notes: Note[] },
+    pointPosition: string | null,
+    userMessage: string,
+  ): Promise<{ allFailed: boolean; errorMessage: string | null }> => {
+    if (panelAgents.length === 0) {
+      return { allFailed: true, errorMessage: 'No connected panel agents.' };
+    }
+
+    // segmentContext = active Point's claim + stake + notes. The LLM gets
+    // enough about the Point to debate it without asking for context.
+    const noteLines = point.notes
+      .map((n) => `[${n.type}] ${n.body}`)
+      .join('\n');
+    const segmentContext = [
+      `CLAIM: ${point.claim}`,
+      `STAKE: ${point.stake}`,
+      noteLines.length > 0 ? `NOTES:\n${noteLines}` : null,
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+
+    const submittedAt = Date.now();
+    const timestamp = new Date(submittedAt).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+
+    type PlannedTurn = { agent: AgentProfile; turnId: string };
+    const planned: PlannedTurn[] = panelAgents.map((agent, idx) => ({
+      agent,
+      turnId: `live-${submittedAt}-${idx}`,
+    }));
+    const placeholders: LivePanelTurn[] = planned.map(({ agent, turnId }) => ({
+      id: turnId,
+      agentMonogram: agent.monogram,
+      agentName: agent.name.toUpperCase(),
+      agentRole: agent.role.toUpperCase(),
+      body: '',
+      timestamp,
+      streaming: true,
+    }));
+
+    setLivePanelTurns((prev) => {
+      const existing = prev[point.slug] ?? [];
+      return { ...prev, [point.slug]: [...placeholders, ...existing] };
+    });
+
+    const updateTurn = (
+      turnId: string,
+      patch: Partial<LivePanelTurn>,
+    ): void => {
+      setLivePanelTurns((prev) => {
+        const arr = prev[point.slug] ?? [];
+        return {
+          ...prev,
+          [point.slug]: arr.map((t) =>
+            t.id === turnId ? { ...t, ...patch } : t,
+          ),
+        };
+      });
+    };
+
+    // Active position is a 1-based string ("1", "2", …). Convert to 0-based
+    // numeric for `scopePointIndex` so the route's prompt builder can echo
+    // "Point N" with the right number.
+    const scopePointIndex = pointPosition
+      ? Math.max(0, Number(pointPosition) - 1)
+      : null;
+
+    const streamForAgent = async ({
+      agent,
+      turnId,
+    }: PlannedTurn): Promise<void> => {
+      await streamAgentPanelTurn(
+        {
+          agent: {
+            provider: agent.provider,
+            name: agent.name,
+            role: agent.role,
+          },
+          userMessage,
+          segmentContext,
+          scopePointIndex,
+        },
+        {
+          onTextDelta: (_delta, accumulated) =>
+            updateTurn(turnId, { body: accumulated }),
+          onComplete: (finalText) =>
+            updateTurn(turnId, { body: finalText, streaming: false }),
+          onError: (msg) =>
+            updateTurn(turnId, {
+              body: msg,
+              streaming: false,
+              errored: true,
+            }),
+        },
+      );
+    };
+
+    const results = await Promise.allSettled(planned.map(streamForAgent));
+
+    setLivePanelTurns((prev) => {
+      persistLivePanelTurns(prev);
+      return prev;
+    });
+
+    const allFailed =
+      results.length > 0 && results.every((r) => r.status === 'rejected');
+    const errorMessage = allFailed
+      ? (() => {
+          const first = results[0] as PromiseRejectedResult;
+          return first.reason instanceof Error
+            ? first.reason.message
+            : 'Panel turn failed.';
+        })()
+      : null;
+    return { allFailed, errorMessage };
+  };
+
+  const handleClearPointPanel = (pointSlug: string): void => {
+    setLivePanelTurns((prev) => {
+      if (!prev[pointSlug]) return prev;
+      const next = { ...prev };
+      delete next[pointSlug];
+      persistLivePanelTurns(next);
+      return next;
+    });
+  };
+
+  const activePointLiveTurns = livePanelTurns[activePoint.slug] ?? [];
+
   function rescorePoint(slug: string) {
     if (rescoringSlug) return;
     const cur = detailStates[slug];
@@ -1652,6 +1856,7 @@ export function PointsOutlineWorkspacePage(_props: Props) {
         <main className="editorial-po-center">
           {detail ? (
             <PointDetailView
+              key={detail.slug}
               detail={detail}
               stale={stale}
               rescoring={rescoring}
@@ -1667,6 +1872,14 @@ export function PointsOutlineWorkspacePage(_props: Props) {
               noteAdd={noteAddProps}
               noteEdit={noteEditProps}
               activePosition={activePosition}
+              liveTurns={activePointLiveTurns}
+              panelAgents={panelAgents}
+              selectedAgents={selectedAgents}
+              skippedAgentCount={skippedAgentCount}
+              onPanelSubmit={(message) =>
+                handleSubmitPointPanelTurn(detail, activePosition, message)
+              }
+              onPanelClear={() => handleClearPointPanel(detail.slug)}
             />
           ) : null}
         </main>
@@ -1889,6 +2102,12 @@ function PointDetailView({
   noteAdd,
   noteEdit,
   activePosition,
+  liveTurns,
+  panelAgents,
+  selectedAgents,
+  skippedAgentCount,
+  onPanelSubmit,
+  onPanelClear,
 }: {
   detail: PointDetail;
   stale: boolean;
@@ -1905,18 +2124,74 @@ function PointDetailView({
   noteAdd: NoteAddProps;
   noteEdit: NoteEditProps;
   activePosition: string | null;
+  liveTurns: LivePanelTurn[];
+  panelAgents: AgentProfile[];
+  selectedAgents: AgentProfile[];
+  skippedAgentCount: number;
+  onPanelSubmit: (
+    message: string,
+  ) => Promise<{ allFailed: boolean; errorMessage: string | null }>;
+  onPanelClear: () => void;
 }) {
   const editingClaim =
     editing?.slug === detail.slug && editing.field === 'claim';
   const editingStake =
     editing?.slug === detail.slug && editing.field === 'stake';
   const lastTurnAt =
-    detail.discussion.length > 0
-      ? detail.discussion[detail.discussion.length - 1].timestamp
-      : '—';
+    liveTurns.length > 0
+      ? liveTurns[0].timestamp
+      : detail.discussion.length > 0
+        ? detail.discussion[detail.discussion.length - 1].timestamp
+        : '—';
   const lastAgentTurn = [...detail.discussion]
     .reverse()
     .find((t): t is AgentTurn => t.kind === 'agent');
+  // Drawer summary prefers the latest LIVE turn (if any), falling back to
+  // the last fixture agent turn.
+  const drawerSummary =
+    liveTurns.length > 0 && liveTurns[0].body.length > 0
+      ? liveTurns[0].body
+      : (lastAgentTurn?.body ?? null);
+
+  const [composerValue, setComposerValue] = useState<string>('');
+  const [composerSubmitting, setComposerSubmitting] = useState<boolean>(false);
+  const [composerError, setComposerError] = useState<string | null>(null);
+
+  const handleSubmitPanel = async (): Promise<void> => {
+    if (panelAgents.length === 0) return;
+    if (composerSubmitting) return;
+    const message = composerValue.trim();
+    if (!message) return;
+
+    setComposerSubmitting(true);
+    setComposerError(null);
+    setComposerValue('');
+    const { allFailed, errorMessage } = await onPanelSubmit(message);
+    if (allFailed && errorMessage) {
+      setComposerError(errorMessage);
+    }
+    setComposerSubmitting(false);
+  };
+
+  const handleClearPanel = (): void => {
+    onPanelClear();
+    setComposerError(null);
+  };
+
+  const composerPlaceholder =
+    panelAgents.length === 0
+      ? selectedAgents.length === 0
+        ? 'Add an agent in Setup → LLM Room to ask the panel…'
+        : 'No connected providers — reconnect in Setup → LLM Room.'
+      : panelAgents.length === 1
+        ? `Ask ${panelAgents[0].name} (${panelAgents[0].role})…`
+        : `Ask the panel (${panelAgents.length} agents)…`;
+
+  const composerButtonLabel = composerSubmitting
+    ? '… STREAMING'
+    : panelAgents.length >= 2
+      ? `+ ASK PANEL (${panelAgents.length}) ⌥↵`
+      : '+ ASK ⌥↵';
 
   // Rewrite the fixture eyebrow's "POINT N" prefix with the live display
   // position so reordering keeps the center detail label honest.
@@ -2104,12 +2379,24 @@ function PointDetailView({
         <section className="editorial-po-discussion">
           <header className="editorial-po-discussion-header">
             <h3 className="editorial-tt-section-label">
-              PANEL DISCUSSION · {detail.discussion.length} TURNS
+              PANEL DISCUSSION · {liveTurns.length + detail.discussion.length}{' '}
+              TURNS
             </h3>
             <div className="editorial-po-discussion-meta">
               <span className="editorial-po-discussion-last">
                 LAST {lastTurnAt}
               </span>
+              {liveTurns.length > 0 ? (
+                <button
+                  type="button"
+                  className="editorial-chip-button editorial-tt-discussion-clear"
+                  onClick={handleClearPanel}
+                  disabled={composerSubmitting}
+                  title="Clear live turns for this Point"
+                >
+                  ✕ CLEAR
+                </button>
+              ) : null}
               <span className="editorial-po-discussion-mentions">
                 {['@ALL', '@A', '@R', '@M'].map((m) => (
                   <span key={m} className="editorial-po-discussion-mention">
@@ -2120,12 +2407,15 @@ function PointDetailView({
             </div>
           </header>
 
-          {detail.discussion.length === 0 ? (
+          {liveTurns.length === 0 && detail.discussion.length === 0 ? (
             <p className="editorial-tt-empty">
               No discussion yet — ask the panel.
             </p>
           ) : (
             <ol className="editorial-po-turn-list">
+              {liveTurns.map((t) => (
+                <LiveTurnView key={t.id} turn={t} />
+              ))}
               {detail.discussion.map((t) =>
                 t.kind === 'agent' ? (
                   <AgentTurnView key={t.id} turn={t} />
@@ -2139,17 +2429,46 @@ function PointDetailView({
           <div className="editorial-po-discussion-input">
             <input
               type="text"
-              placeholder="Ask the panel — or @reference a note…"
-              disabled
+              placeholder={composerPlaceholder}
+              value={composerValue}
+              onChange={(e) => setComposerValue(e.target.value)}
+              disabled={panelAgents.length === 0 || composerSubmitting}
+              onKeyDown={(e) => {
+                if (
+                  (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) ||
+                  (e.key === 'Enter' && !e.shiftKey)
+                ) {
+                  e.preventDefault();
+                  void handleSubmitPanel();
+                }
+              }}
             />
             <button
               type="button"
               className="editorial-chip-button editorial-chip-button-primary"
-              disabled
+              disabled={
+                panelAgents.length === 0 ||
+                composerSubmitting ||
+                !composerValue.trim()
+              }
+              onClick={() => {
+                void handleSubmitPanel();
+              }}
             >
-              SEND ⌥↵
+              {composerButtonLabel}
             </button>
           </div>
+          {panelAgents.length > 0 ? (
+            <p className="editorial-tt-discussion-hint">
+              {panelAgents.map((a) => a.name).join(' · ')}
+              {skippedAgentCount > 0
+                ? ` · ${skippedAgentCount} skipped (auth missing)`
+                : ''}
+            </p>
+          ) : null}
+          {composerError ? (
+            <p className="editorial-tt-discussion-error">{composerError}</p>
+          ) : null}
         </section>
       ) : (
         <>
@@ -2162,7 +2481,7 @@ function PointDetailView({
           </section>
           <DiscussionDrawer
             lastTurnAt={lastTurnAt}
-            lastAgentSummary={lastAgentTurn?.body ?? null}
+            lastAgentSummary={drawerSummary}
             onExpand={onToggleLayout}
           />
         </>
@@ -2200,6 +2519,37 @@ function DiscussionDrawer({
       </span>
       <span className="editorial-po-drawer-hint">⌘O</span>
     </button>
+  );
+}
+
+function LiveTurnView({ turn }: { turn: LivePanelTurn }) {
+  return (
+    <li className="editorial-po-turn editorial-tt-turn-live">
+      <div className="editorial-po-turn-head">
+        <span
+          className="editorial-persona-avatar editorial-persona-avatar-sm"
+          data-persona={turn.agentMonogram}
+        >
+          {turn.agentMonogram}
+        </span>
+        <span className="editorial-po-turn-name">{turn.agentName}</span>
+        <span className="editorial-po-turn-role">{turn.agentRole}</span>
+        <span className="editorial-po-turn-timestamp">{turn.timestamp}</span>
+      </div>
+      <p
+        className={
+          'editorial-po-turn-body' +
+          (turn.errored ? ' editorial-tt-turn-body-errored' : '')
+        }
+      >
+        {turn.body}
+        {turn.streaming ? (
+          <span className="editorial-tt-turn-cursor" aria-hidden="true">
+            ▍
+          </span>
+        ) : null}
+      </p>
+    </li>
   );
 }
 

--- a/webapp/src/pages/ThemeTopicsWorkspacePage.tsx
+++ b/webapp/src/pages/ThemeTopicsWorkspacePage.tsx
@@ -1,6 +1,13 @@
 import { useMemo, useState } from 'react';
 
 import { EditorialPhaseStrip } from '../components/EditorialPhaseStrip';
+import {
+  getAgentProfileById,
+  type AgentProfile,
+} from '../lib/editorial-fixtures';
+import { loadSetupState } from '../lib/editorial-setup';
+import { isAgentAuthed, useProviderAuth } from '../lib/llm-provider-auth';
+import { streamAgentPanelTurn } from '../lib/panel-fanout';
 
 // ───────────────────────────────────────────────────────────────────────────
 // Fixture-shaped data, hardcoded inline for the 0p-a vertical slice. Real
@@ -67,6 +74,51 @@ type SourceCard = {
   cited: boolean;
   disputed?: boolean;
 };
+
+// Live panel turns produced by the `+ ASK` composer for the active topic.
+// Persisted to localStorage at LIVE_PANEL_TURNS_STORAGE_KEY so the user's
+// history survives reloads. Fixture turns (Topic.discussion above) stay as
+// the first-time-UX fallback at the top of the rendered list.
+type LivePanelTurn = {
+  id: string;
+  agentMonogram: string;
+  agentName: string;
+  agentRole: string;
+  body: string;
+  timestamp: string;
+  streaming?: boolean;
+  errored?: boolean;
+};
+
+type LivePanelTurnMap = Record<string, LivePanelTurn[]>;
+
+const LIVE_PANEL_TURNS_STORAGE_KEY =
+  'editorial-room.theme-topics.panel-turns-v0';
+
+function loadLivePanelTurns(): LivePanelTurnMap {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(LIVE_PANEL_TURNS_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return {};
+    return parsed as LivePanelTurnMap;
+  } catch {
+    return {};
+  }
+}
+
+function persistLivePanelTurns(turns: LivePanelTurnMap): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(
+      LIVE_PANEL_TURNS_STORAGE_KEY,
+      JSON.stringify(turns),
+    );
+  } catch {
+    // localStorage full / disabled — non-fatal at v0p.
+  }
+}
 
 const PRIMARY_PERSONAS: ReadonlyArray<Persona> = [
   { slug: 'persona/ankit-indie-dev', letter: 'A', name: 'ANKIT' },
@@ -407,6 +459,149 @@ export function ThemeTopicsWorkspacePage(_props: Props) {
 
   const activeTheme = THEMES.find((t) => t.slug === activeThemeSlug);
 
+  // Setup-driven panel agents. Reuses the same provider-auth and agent
+  // selection plumbing as Setup → LLM Room and the Draft right rail.
+  const [setup] = useState(loadSetupState);
+  const { authed: providerAuthed } = useProviderAuth();
+  const selectedAgents = useMemo<AgentProfile[]>(
+    () =>
+      setup.llm_room_agent_profile_ids
+        .map((id) => getAgentProfileById(id))
+        .filter((a): a is AgentProfile => a !== null),
+    [setup.llm_room_agent_profile_ids],
+  );
+  const panelAgents = useMemo<AgentProfile[]>(
+    () => selectedAgents.filter((a) => isAgentAuthed(a, providerAuthed)),
+    [selectedAgents, providerAuthed],
+  );
+  const skippedAgentCount = selectedAgents.length - panelAgents.length;
+
+  const [livePanelTurns, setLivePanelTurns] =
+    useState<LivePanelTurnMap>(loadLivePanelTurns);
+
+  const handleSubmitTopicPanelTurn = async (
+    topic: Topic,
+    userMessage: string,
+  ): Promise<{ allFailed: boolean; errorMessage: string | null }> => {
+    if (panelAgents.length === 0) {
+      return { allFailed: true, errorMessage: 'No connected panel agents.' };
+    }
+
+    // segmentContext = topic title + thesis + flat note dump. The LLM
+    // gets enough to debate the notes without having to ask for them.
+    const noteLines = topic.notes
+      .map((n) => `[${n.type}] ${n.body}`)
+      .join('\n');
+    const segmentContext = [
+      `TOPIC: ${topic.workingTitle}`,
+      `THESIS: ${topic.thesis}`,
+      noteLines.length > 0 ? `NOTES:\n${noteLines}` : null,
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+
+    const submittedAt = Date.now();
+    const timestamp = new Date(submittedAt).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+
+    type PlannedTurn = { agent: AgentProfile; turnId: string };
+    const planned: PlannedTurn[] = panelAgents.map((agent, idx) => ({
+      agent,
+      turnId: `live-${submittedAt}-${idx}`,
+    }));
+    const placeholders: LivePanelTurn[] = planned.map(({ agent, turnId }) => ({
+      id: turnId,
+      agentMonogram: agent.monogram,
+      agentName: agent.name.toUpperCase(),
+      agentRole: agent.role.toUpperCase(),
+      body: '',
+      timestamp,
+      streaming: true,
+    }));
+
+    setLivePanelTurns((prev) => {
+      const existing = prev[topic.slug] ?? [];
+      return { ...prev, [topic.slug]: [...placeholders, ...existing] };
+    });
+
+    const updateTurn = (
+      turnId: string,
+      patch: Partial<LivePanelTurn>,
+    ): void => {
+      setLivePanelTurns((prev) => {
+        const arr = prev[topic.slug] ?? [];
+        return {
+          ...prev,
+          [topic.slug]: arr.map((t) =>
+            t.id === turnId ? { ...t, ...patch } : t,
+          ),
+        };
+      });
+    };
+
+    const streamForAgent = async ({
+      agent,
+      turnId,
+    }: PlannedTurn): Promise<void> => {
+      await streamAgentPanelTurn(
+        {
+          agent: {
+            provider: agent.provider,
+            name: agent.name,
+            role: agent.role,
+          },
+          userMessage,
+          segmentContext,
+          scopePointIndex: null,
+        },
+        {
+          onTextDelta: (_delta, accumulated) =>
+            updateTurn(turnId, { body: accumulated }),
+          onComplete: (finalText) =>
+            updateTurn(turnId, { body: finalText, streaming: false }),
+          onError: (msg) =>
+            updateTurn(turnId, {
+              body: msg,
+              streaming: false,
+              errored: true,
+            }),
+        },
+      );
+    };
+
+    const results = await Promise.allSettled(planned.map(streamForAgent));
+
+    setLivePanelTurns((prev) => {
+      persistLivePanelTurns(prev);
+      return prev;
+    });
+
+    const allFailed =
+      results.length > 0 && results.every((r) => r.status === 'rejected');
+    const errorMessage = allFailed
+      ? (() => {
+          const first = results[0] as PromiseRejectedResult;
+          return first.reason instanceof Error
+            ? first.reason.message
+            : 'Panel turn failed.';
+        })()
+      : null;
+    return { allFailed, errorMessage };
+  };
+
+  const handleClearTopicPanel = (topicSlug: string): void => {
+    setLivePanelTurns((prev) => {
+      if (!prev[topicSlug]) return prev;
+      const next = { ...prev };
+      delete next[topicSlug];
+      persistLivePanelTurns(next);
+      return next;
+    });
+  };
+
   return (
     <div className="editorial-room">
       <EditorialPhaseStrip activePhase="theme-topics" />
@@ -574,7 +769,18 @@ export function ThemeTopicsWorkspacePage(_props: Props) {
         {/* CENTER: TOPIC DETAIL */}
         <main className="editorial-tt-center">
           {activeTopic ? (
-            <TopicDetail topic={activeTopic} />
+            <TopicDetail
+              key={activeTopic.slug}
+              topic={activeTopic}
+              liveTurns={livePanelTurns[activeTopic.slug] ?? []}
+              panelAgents={panelAgents}
+              selectedAgents={selectedAgents}
+              skippedAgentCount={skippedAgentCount}
+              onSubmit={(message) =>
+                handleSubmitTopicPanelTurn(activeTopic, message)
+              }
+              onClear={() => handleClearTopicPanel(activeTopic.slug)}
+            />
           ) : (
             <div className="editorial-tt-center-empty">
               Pick a Theme with Topics to start.
@@ -632,7 +838,72 @@ export function ThemeTopicsWorkspacePage(_props: Props) {
   );
 }
 
-function TopicDetail({ topic }: { topic: Topic }) {
+function TopicDetail({
+  topic,
+  liveTurns,
+  panelAgents,
+  selectedAgents,
+  skippedAgentCount,
+  onSubmit,
+  onClear,
+}: {
+  topic: Topic;
+  liveTurns: LivePanelTurn[];
+  panelAgents: AgentProfile[];
+  selectedAgents: AgentProfile[];
+  skippedAgentCount: number;
+  onSubmit: (
+    message: string,
+  ) => Promise<{ allFailed: boolean; errorMessage: string | null }>;
+  onClear: () => void;
+}) {
+  const [composerValue, setComposerValue] = useState<string>('');
+  const [composerSubmitting, setComposerSubmitting] = useState<boolean>(false);
+  const [composerError, setComposerError] = useState<string | null>(null);
+
+  const lastTimestamp =
+    liveTurns.length > 0
+      ? liveTurns[0].timestamp
+      : topic.discussion.length > 0
+        ? topic.discussion[topic.discussion.length - 1].timestamp
+        : null;
+
+  const handleSubmit = async (): Promise<void> => {
+    if (panelAgents.length === 0) return;
+    if (composerSubmitting) return;
+    const message = composerValue.trim();
+    if (!message) return;
+
+    setComposerSubmitting(true);
+    setComposerError(null);
+    setComposerValue('');
+    const { allFailed, errorMessage } = await onSubmit(message);
+    if (allFailed && errorMessage) {
+      setComposerError(errorMessage);
+    }
+    setComposerSubmitting(false);
+  };
+
+  const handleClear = (): void => {
+    onClear();
+    setComposerError(null);
+  };
+
+  const composerPlaceholder =
+    panelAgents.length === 0
+      ? selectedAgents.length === 0
+        ? 'Add an agent in Setup → LLM Room to ask the panel…'
+        : 'No connected providers — reconnect in Setup → LLM Room.'
+      : panelAgents.length === 1
+        ? `Ask ${panelAgents[0].name} (${panelAgents[0].role}) — or @reference a note above…`
+        : `Ask the panel (${panelAgents.length} agents) — or @reference a note above…`;
+
+  const composerButtonLabel = composerSubmitting
+    ? '… STREAMING'
+    : panelAgents.length >= 2
+      ? `+ ASK PANEL (${panelAgents.length}) ⌥↵`
+      : '+ ASK ⌥↵';
+
   return (
     <article className="editorial-tt-topic-detail">
       <header className="editorial-tt-topic-header">
@@ -750,21 +1021,71 @@ function TopicDetail({ topic }: { topic: Topic }) {
       <section className="editorial-tt-discussion">
         <header className="editorial-tt-discussion-header">
           <h3 className="editorial-tt-section-label">
-            PANEL DISCUSSION · {topic.discussion.length} TURNS
-            {topic.discussion.length > 0 ? ' DEBATING NOTES ABOVE' : ''}
+            PANEL DISCUSSION · {liveTurns.length + topic.discussion.length}{' '}
+            TURNS
+            {liveTurns.length + topic.discussion.length > 0
+              ? ' DEBATING NOTES ABOVE'
+              : ''}
           </h3>
-          <span className="editorial-tt-discussion-last">
-            {topic.discussion.length > 0
-              ? `LAST ${topic.discussion[topic.discussion.length - 1].timestamp}`
-              : '—'}
-          </span>
+          <div className="editorial-tt-discussion-meta">
+            <span className="editorial-tt-discussion-last">
+              {lastTimestamp ? `LAST ${lastTimestamp}` : '—'}
+            </span>
+            {liveTurns.length > 0 ? (
+              <button
+                type="button"
+                className="editorial-chip-button editorial-tt-discussion-clear"
+                onClick={handleClear}
+                disabled={composerSubmitting}
+                title="Clear live turns for this Topic"
+              >
+                ✕ CLEAR
+              </button>
+            ) : null}
+          </div>
         </header>
-        {topic.discussion.length === 0 ? (
+        {liveTurns.length === 0 && topic.discussion.length === 0 ? (
           <p className="editorial-tt-empty">
             No discussion yet — ask the panel.
           </p>
         ) : (
           <ol className="editorial-tt-turn-list">
+            {liveTurns.map((t) => (
+              <li
+                key={t.id}
+                className="editorial-tt-turn editorial-tt-turn-live"
+              >
+                <div className="editorial-tt-turn-head">
+                  <span
+                    className="editorial-persona-avatar editorial-persona-avatar-sm"
+                    data-persona={t.agentMonogram}
+                  >
+                    {t.agentMonogram}
+                  </span>
+                  <span className="editorial-tt-turn-name">{t.agentName}</span>
+                  <span className="editorial-tt-turn-role">{t.agentRole}</span>
+                  <span className="editorial-tt-turn-timestamp">
+                    {t.timestamp}
+                  </span>
+                </div>
+                <p
+                  className={
+                    'editorial-tt-turn-body' +
+                    (t.errored ? ' editorial-tt-turn-body-errored' : '')
+                  }
+                >
+                  {t.body}
+                  {t.streaming ? (
+                    <span
+                      className="editorial-tt-turn-cursor"
+                      aria-hidden="true"
+                    >
+                      ▍
+                    </span>
+                  ) : null}
+                </p>
+              </li>
+            ))}
             {topic.discussion.map((t) => (
               <li key={t.id} className="editorial-tt-turn">
                 <div className="editorial-tt-turn-head">
@@ -800,24 +1121,46 @@ function TopicDetail({ topic }: { topic: Topic }) {
         <div className="editorial-tt-discussion-input">
           <input
             type="text"
-            placeholder="Ask the panel — or @reference a note above…"
-            disabled
+            placeholder={composerPlaceholder}
+            value={composerValue}
+            onChange={(e) => setComposerValue(e.target.value)}
+            disabled={panelAgents.length === 0 || composerSubmitting}
+            onKeyDown={(e) => {
+              if (
+                (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) ||
+                (e.key === 'Enter' && !e.shiftKey)
+              ) {
+                e.preventDefault();
+                void handleSubmit();
+              }
+            }}
           />
-          <div className="editorial-tt-discussion-mentions">
-            {['@ALL', '@A', '@R', '@M', '#NOTE'].map((m) => (
-              <span key={m} className="editorial-tt-discussion-mention">
-                {m}
-              </span>
-            ))}
-          </div>
           <button
             type="button"
             className="editorial-chip-button editorial-chip-button-primary"
-            disabled
+            disabled={
+              panelAgents.length === 0 ||
+              composerSubmitting ||
+              !composerValue.trim()
+            }
+            onClick={() => {
+              void handleSubmit();
+            }}
           >
-            SEND ⌥↵
+            {composerButtonLabel}
           </button>
         </div>
+        {panelAgents.length > 0 ? (
+          <p className="editorial-tt-discussion-hint">
+            {panelAgents.map((a) => a.name).join(' · ')}
+            {skippedAgentCount > 0
+              ? ` · ${skippedAgentCount} skipped (auth missing)`
+              : ''}
+          </p>
+        ) : null}
+        {composerError ? (
+          <p className="editorial-tt-discussion-error">{composerError}</p>
+        ) : null}
       </section>
     </article>
   );

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -6475,6 +6475,75 @@ a.editorial-phase-pill:hover {
   color: #6c6655;
 }
 
+.editorial-tt-discussion-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.editorial-tt-discussion-clear {
+  font-size: 0.6rem;
+}
+
+.editorial-tt-discussion-hint {
+  margin: 0.3rem 0 0;
+  padding: 0;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6c6655;
+}
+
+.editorial-tt-discussion-error {
+  margin: 0.3rem 0 0;
+  padding: 0.4rem 0.55rem;
+  background: #fff0eb;
+  border: 1px solid #b7372a;
+  border-radius: 4px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.02em;
+  color: #b7372a;
+  word-break: break-word;
+}
+
+.editorial-tt-turn-live {
+  background: #fbf6e8;
+  padding: 0.55rem;
+  border-radius: 4px;
+  border: 1px solid #e6d9b1;
+}
+
+.editorial-tt-turn-role {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.05em;
+  color: #6c6655;
+  text-transform: uppercase;
+}
+
+.editorial-tt-turn-body-errored {
+  color: #b7372a;
+}
+
+.editorial-tt-turn-cursor {
+  display: inline-block;
+  margin-left: 0.15rem;
+  animation: editorial-tt-blink 1.1s steps(2, end) infinite;
+}
+
+@keyframes editorial-tt-blink {
+  0%,
+  60% {
+    opacity: 1;
+  }
+  60.01%,
+  100% {
+    opacity: 0;
+  }
+}
+
 .editorial-tt-sources {
   border-left: 1px solid #ddd6c8;
   padding: 0.85rem 0.85rem;


### PR DESCRIPTION
## Summary

- The disabled discussion inputs in the **Theme + Topics** workspace and the **Points + Outline** workspace (state \`a\`) are now real \`+ ASK\` composers that fan out across every authed agent in \`setup.llm_room_agent_profile_ids\`, mirroring the Draft behavior shipped in #294.
- Live turns prepend the existing fixture turns and stream independently per agent. One agent's failure is isolated to that agent's turn (matches \`partial_provider_failures\` semantics in \`EDITORIAL_ROOM_CONTRACT.md\` §4.4).
- Per-agent SSE/fetch loop extracted to \`webapp/src/lib/panel-fanout.ts\` (\`streamAgentPanelTurn\`) so all three pages share one network-protocol source of truth. Draft's dispatcher is rewritten on top of the helper.
- Composer button label switches to \`+ ASK PANEL (N) ⌥↵\` once N ≥ 2; a hint line lists who'll respond plus any agents skipped because their provider lost auth.
- \`✕ CLEAR\` chip in the discussion header drops live turns for the active scope (per-Topic in 02, per-Point in 03), mirroring Draft's existing affordance.
- 03 state \`b\` drawer summary now reflects the latest live turn (if any), falling back to the last fixture agent turn.

## Persistence

| Page | localStorage key | Scope |
| --- | --- | --- |
| 02 Theme + Topics | \`editorial-room.theme-topics.panel-turns-v0\` | \`topic.slug\` |
| 03 Points + Outline | \`editorial-room.points-outline.panel-turns-v0\` | \`point.slug\` |
| 04 Draft | \`editorial-room.draft.panel-turns-v0\` (unchanged) | \`activePoint\` index |

## Test plan

- [x] \`npm --prefix webapp run typecheck\`
- [x] \`npm --prefix webapp run build\`
- [x] \`npm --prefix webapp run test\` (214 passed, 1 skipped)
- [x] \`npm run typecheck\`
- [x] \`NANOCLAW_ALLOW_UNSUPPORTED_NODE=1 node scripts/run-vitest.mjs run src/clawrocket/llm/editorial-llm-call.test.ts\` (13 passed)
- [x] Prettier on changed files
- [ ] Manual: in 02, pick the Embracer Topic, click \`+ ASK PANEL (N) ⌥↵\`, confirm fan-out streams
- [ ] Manual: in 03, pick a Point in state \`a\`, ask the panel, confirm live turn appears above fixture turns
- [ ] Manual: switch to state \`b\`, confirm drawer summary shows the latest live turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)