### PR TITLE
fix: pass store=false to Codex Responses endpoint

### DIFF
--- a/src/clawrocket/llm/editorial-llm-call.ts
+++ b/src/clawrocket/llm/editorial-llm-call.ts
@@ -536,6 +536,9 @@ async function* streamOpenAIResponses(
   const body = {
     model: cred.model,
     stream: true,
+    // Codex+ChatGPT rejects the request unless `store` is explicitly false
+    // (server-side response storage isn't allowed on this account type).
+    store: false,
     instructions: input.systemPrompt,
     input: [
       {


### PR DESCRIPTION
## Summary

Codex+ChatGPT rejects \`POST /responses\` without \`store: false\` — the endpoint refuses to persist responses server-side for ChatGPT-subscription accounts. Marisol's panel turns failed with HTTP 400 \`{"detail":"Store must be set to false"}\`. Adds the flag to the request body so the call goes through.

Follow-up to #296 (which fixed the model rejection but exposed this second 400).

## Test plan
- [x] \`npm run typecheck\`
- [x] \`NANOCLAW_ALLOW_UNSUPPORTED_NODE=1 node scripts/run-vitest.mjs run src/clawrocket/llm/editorial-llm-call.test.ts\` (13 passed)
- [ ] Manual: re-run the failing Marisol panel turn — expect a real critique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)