### PR TITLE
purge PR-2: backend bootstrap promotion

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
+    "dev:editorial": "tsx src/server.ts",
+    "start:editorial": "node dist/server.js",
     "check:webapp": "node scripts/ensure-webapp-installed.mjs",
     "install:webapp": "node scripts/install-webapp.mjs",
     "install:all": "npm install && npm run install:webapp",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,57 @@
+// editorialboard standalone bootstrap.
+//
+// PR-2 of the PURGE adds this minimal entry point that boots the Hono web
+// server directly, without going through the NanoClaw `src/index.ts`
+// orchestrator (containers, scheduler, channels, IPC, group queues).
+//
+// During the PURGE window both bootstraps coexist:
+//   - `npm run dev`           → tsx src/index.ts  (legacy NanoClaw)
+//   - `npm run dev:editorial` → tsx src/server.ts (this file)
+//
+// PR-5 deletes src/index.ts and promotes this to the only entry.
+// PR-6 swaps `npm run dev` to point at this file.
+
+import { initDatabase } from './db.js';
+import { logger } from './logger.js';
+import { WEB_HOST, WEB_PORT } from './clawrocket/config.js';
+import { createWebServer } from './clawrocket/web/server.js';
+
+async function main(): Promise<void> {
+  initDatabase();
+  logger.info('Database initialized');
+
+  const server = createWebServer({ host: WEB_HOST, port: WEB_PORT });
+
+  let bound: { host: string; port: number };
+  try {
+    bound = await server.start();
+  } catch (err) {
+    logger.error({ err }, 'Failed to start editorialboard web server');
+    process.exit(1);
+  }
+  logger.info(
+    { host: bound.host, port: bound.port },
+    'editorialboard server ready',
+  );
+
+  let shuttingDown = false;
+  const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    logger.info({ signal }, 'editorialboard shutting down');
+    try {
+      await server.stop();
+    } catch (err) {
+      logger.error({ err }, 'Error during web server shutdown');
+    }
+    process.exit(0);
+  };
+
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+}
+
+main().catch((err) => {
+  logger.error({ err }, 'editorialboard bootstrap failed');
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

PR-2 of 6 in the PURGE plan (\`docs/PURGE_PLAN.md\`). Adds a standalone editorialboard bootstrap (\`src/server.ts\`) that boots the Hono web server directly, bypassing the NanoClaw orchestrator (containers, scheduler, channels, IPC, group queues) in \`src/index.ts\`.

Both bootstraps coexist during the PURGE window:

| Script | Bootstrap |
|---|---|
| \`npm run dev\` | \`tsx src/index.ts\` (legacy NanoClaw) |
| \`npm run dev:editorial\` | \`tsx src/server.ts\` (this PR) |

PR-5 deletes \`src/index.ts\` and promotes \`src/server.ts\` to the only entry. PR-6 swaps \`npm run dev\` to point at it.

## What's added
- \`src/server.ts\` — minimal bootstrap: \`initDatabase()\` → \`createWebServer()\` (no Talk/main/job workers; defaults to noops) → \`server.start()\` → SIGINT/SIGTERM handlers
- \`package.json\` scripts: \`dev:editorial\` and \`start:editorial\`

## Validation
- [x] \`npm run typecheck\` green
- [x] \`npm run dev:editorial\` boots cleanly: "Database initialized" → "editorialboard server ready"
- [x] Health endpoint responds 200 OK on the new bootstrap
- [x] Chrome MCP smoke: sign-in page renders against the new bootstrap (Vite proxies /api/* to localhost:3210)
- [x] Old \`npm run dev\` (NanoClaw) unchanged and still works

## Per

- \`docs/PURGE_PLAN.md\` §5 (backend bootstrap promotion)
- \`docs/CLOUD_TARGET.md\` Phase A2 — minimal new-bootstrap scaffold

🤖 Generated with [Claude Code](https://claude.com/claude-code)